### PR TITLE
Issue 22: Expanded docs for simple_rng

### DIFF
--- a/simple_rng/src/lib.rs
+++ b/simple_rng/src/lib.rs
@@ -94,10 +94,11 @@ impl Rng {
         }
     }
 
+    /// Generates a random value from the range [0, 1].
     pub fn random(&mut self) -> f64 {
         // Not sure where 2091639 comes from, but let's roll with it
         // The other factor is the reciprocal of the max of u32
-        let t = (2091639_f64 * self.s0) + (self.c as f64 * (1.0/(u32::MAX as f64)));
+        let t = (2091639_f64 * self.s0) + (self.c as f64 * (1.0 / (u32::MAX as f64)));
         self.s0 = self.s1;
         self.s1 = self.s2;
         self.c = t.floor() as u32;
@@ -118,7 +119,7 @@ impl Rng {
         // custom RNG
         if !(0.0..1.0).contains(&frac) {
             if frac == 1.0 {
-                return true
+                return true;
             }
             panic!("Invalid frac for gen_bool {} (must be in [0.0, 1.0)", frac)
         }
@@ -165,7 +166,7 @@ impl Rng {
         for i in (0..=(a.len() - 1)).rev() {
             let j = (self.random() * i as f64).floor() as usize;
             if j == 0 {
-                return a[i].clone()
+                return a[i].clone();
             }
         }
         a[0].clone()
@@ -186,7 +187,7 @@ impl NormalDistribution {
     /// If `mean` or `std_dev` are `NaN` or `std_dev <= 0`.
     pub fn new(mean: f64, std_dev: f64) -> Self {
         NormalDistribution {
-            distribution: Normal::new(mean, std_dev).unwrap()
+            distribution: Normal::new(mean, std_dev).unwrap(),
         }
     }
 
@@ -273,13 +274,14 @@ impl DiscreteDistribution {
     }
 }
 
-fn cumulative_sum(a: &mut Vec<f64>) -> Vec<f64> {
+// Calculates cumulative sum.
+fn cumulative_sum(a: &[f64]) -> Vec<f64> {
     let mut acc = 0.0;
     let mut cumvec = Vec::with_capacity(a.len());
     for x in a {
         acc += *x;
         cumvec.push(acc);
-    };
+    }
     cumvec
 }
 

--- a/simple_rng/src/lib.rs
+++ b/simple_rng/src/lib.rs
@@ -29,7 +29,7 @@ use statrs::distribution::{ContinuousCDF, Normal};
 ///
 /// // Shuffle a sequence of numbers in place.
 /// let mut nums: Vec<u64> = (1..10).collect();
-/// rng.shuffle_in_place(&mut nums);
+/// rng.shuffle(&mut nums);
 /// ```
 
 // Because of overflow, the numbers are kept within the range of u32, even though they are u64 and
@@ -132,7 +132,7 @@ impl Rng {
     }
 
     /// Shuffles elements in a sequence in place.
-    pub fn shuffle_in_place<T: Clone>(&mut self, a: &mut Vec<T>) {
+    pub fn shuffle<T: Clone>(&mut self, a: &mut Vec<T>) {
         for i in (0..a.len()).rev() {
             let j = (self.random() * i as f64).floor() as usize;
             let temp = a[i].clone();
@@ -337,16 +337,16 @@ mod tests {
     }
 
     #[test]
-    fn test_shuffle_in_place() {
+    fn test_shuffle() {
         let mut my_vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
         let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),
         ]);
-        rng.shuffle_in_place(&mut my_vec);
+        rng.shuffle(&mut my_vec);
         assert_eq!(my_vec, vec![5, 7, 6, 3, 2, 1, 9, 4, 8]);
-        rng.shuffle_in_place(&mut my_vec);
+        rng.shuffle(&mut my_vec);
         assert_eq!(my_vec, vec![4, 9, 1, 8, 3, 7, 2, 6, 5]);
     }
 

--- a/simple_rng/src/lib.rs
+++ b/simple_rng/src/lib.rs
@@ -19,7 +19,7 @@ use statrs::distribution::{ContinuousCDF, Normal};
 /// ```
 /// use simple_rng::Rng;
 ///
-/// let mut rng = Rng::new_from_seed(vec!["Hello".to_string(), "word".to_string()]);
+/// let mut rng = Rng::from_seed(vec!["Hello".to_string(), "word".to_string()]);
 ///
 /// // Generate a float between 0 and 1.
 /// let x = rng.random();
@@ -53,7 +53,7 @@ pub struct Rng {
 
 impl Rng {
     /// Creates a new PRNG from the given seed.
-    pub fn new_from_seed(seed_list: Vec<String>) -> Rng {
+    pub fn from_seed(seed_list: Vec<String>) -> Rng {
         // The seed list is assumed to be a vector of strings. We'll have
         // to figure out a clever way to construct seed strings from random seeds
         // For the default string, we present the abstract of the initial paper up to the first
@@ -293,7 +293,7 @@ mod tests {
     fn test_discrete_distribution() {
         let weights: Vec<f64> = vec![1.1, 2.0, 1.0, 8.0, 0.2, 2.0];
         let d = DiscreteDistribution::new(&weights, false);
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_gen_bool() {
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn test_random() {
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),
@@ -339,7 +339,7 @@ mod tests {
     #[test]
     fn test_shuffle_in_place() {
         let mut my_vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),
@@ -354,7 +354,7 @@ mod tests {
     fn test_range() {
         let min = 0;
         let max = 10;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_rand_u64() {
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),

--- a/simple_rng/src/lib.rs
+++ b/simple_rng/src/lib.rs
@@ -64,8 +64,9 @@ impl Rng {
         let mut s1 = masher.mash(&vec![' ']);
         let mut s2 = masher.mash(&vec![' ']);
         let c = 1;
-        let mut seed_vec: Vec::<Vec<char>> = Vec::new();
-        // update seeds
+
+        // Update seeds.
+        let mut seed_vec: Vec<Vec<char>> = Vec::new();
         for seed in seed_list {
             // vectorize the seed and add it to the master list
             let vector_seed = seed.chars().collect::<Vec<char>>();
@@ -132,8 +133,7 @@ impl Rng {
 
     /// Shuffles elements in a sequence in place.
     pub fn shuffle_in_place<T: Clone>(&mut self, a: &mut Vec<T>) {
-        // reverse iterator
-        for i in (0..=(a.len() - 1)).rev() {
+        for i in (0..a.len()).rev() {
             let j = (self.random() * i as f64).floor() as usize;
             let temp = a[i].clone();
             a[i] = a[j].clone();

--- a/simple_rng/src/lib.rs
+++ b/simple_rng/src/lib.rs
@@ -127,7 +127,7 @@ impl Rng {
         // This is just `2.0.powi(64)`, but written this way because it is not available
         // in `no_std` mode. (from rand 0.8.5 docs). We used u64 max + 1, the equivalent
         let p_int = (frac * (u64::MAX as f64 + 1.0)) as u64;
-        let x = self.rand_int();
+        let x = self.rand_u64();
         x < p_int
     }
 
@@ -146,7 +146,8 @@ impl Rng {
         ((min.clone() as f64) + (self.random() * ((max - min) as f64))) as i64
     }
 
-    pub fn rand_int(&mut self) -> u64 {
+    /// Returns a random `u64`.
+    pub fn rand_u64(&mut self) -> u64 {
         let temp = self.random();
         // Keeping it within range of u32 to prevent overflow
         let ret_num: f64 = temp * (u64::MAX as f64);
@@ -155,7 +156,7 @@ impl Rng {
 
     /// Returns a random `u32`.
     pub fn rand_u32(&mut self) -> u32 {
-        let ret_num = self.rand_int();
+        let ret_num = self.rand_u64();
         (ret_num % (u32::MAX as u64)) as u32
     }
 
@@ -366,14 +367,14 @@ mod tests {
     }
 
     #[test]
-    fn test_rand_int() {
+    fn test_rand_u64() {
         let mut rng = Rng::new_from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),
         ]);
-        assert_eq!(rng.rand_int(), 16228467489086898176);
-        assert_eq!(rng.rand_int(), 9226227395537666048);
-        assert_eq!(rng.rand_int(), 11428961760531447808);
+        assert_eq!(rng.rand_u64(), 16228467489086898176);
+        assert_eq!(rng.rand_u64(), 9226227395537666048);
+        assert_eq!(rng.rand_u64(), 11428961760531447808);
     }
 }

--- a/simple_rng/src/mash.rs
+++ b/simple_rng/src/mash.rs
@@ -63,7 +63,7 @@ impl Mash {
         }
         // now update n
         self.n = n_copy.clone() as u64;
-        self.n as f64 * (1.0/(u32::MAX as f64 + 1.0))
+        self.n as f64 * (1.0 / (u32::MAX as f64 + 1.0))
     }
 }
 

--- a/simple_rng/src/mash.rs
+++ b/simple_rng/src/mash.rs
@@ -74,8 +74,8 @@ mod tests {
     #[test]
     fn test_mash() {
         let mut masher = Mash::new();
-        let test = masher.mash(&"hello".chars().collect());
-        assert_eq!(test, 0.7957609200384468);
+        let test1 = masher.mash(&"hello".chars().collect());
+        assert_eq!(test1, 0.7957609200384468);
 
         let test2 = masher.mash(&"cruel".chars().collect());
         assert_eq!(test2, 0.8173183863982558);

--- a/simple_rng/src/mash.rs
+++ b/simple_rng/src/mash.rs
@@ -1,35 +1,47 @@
-// Here is the original javascript this comes from (typescript actually, which is helpful):
-// const Mash = (): ((data: string) => number) => {
-//   var n = 0xefc8249d;
-//
-//   return ((data: string): number => {
-//     for (var i = 0; i < data.length; i++) {
-//       n += data.charCodeAt(i);
-//       var h = 0.02519603282416938 * n;
-//       n = h >>> 0;
-//       h -= n;
-//       h *= n;
-//       n = h >>> 0;
-//       h -= n;
-//       n += h * 0x100000000; // 2^32
-//     }
-//     return (n >>> 0) * 2.3283064365386963e-10; // 2^-32
-//   });
-// };
-//
-// Unclear how all this will translate to rust
-// Note that this was located here: https://rampantmonkey.com/writing/ts-prng/ as of 11/9/2024
+//! A masher for generating a seed for Alea pseudo-random number generator.
+//!
+//! A masher is a hash function with an initialized internal state that is used to hash
+//! the PRNG's seed (strings). Each element of the internal state is altered by a hash of each
+//! argument.
+//!
+//! Current implementation was adapted from a TypeScript version found [here].
+//!
+//! [here]: https://rampantmonkey.com/writing/ts-prng/
 
 pub struct Mash {
     n: u64,
 }
 
 impl Mash {
+    /// Construct a new masher.
     pub fn new() -> Mash {
-        // Unclear where this number comes from
+        // Unclear where this number comes from.
         Mash { n: 0xefc8249d }
     }
 
+    /// Create a seed for a PRNG.
+
+    // In case the site we're referring to will go offline, here's a verbatim copy from the source:
+    //
+    // ```typescript
+    // const Mash = (): ((data: string) => number) => {
+    //   var n = 0xefc8249d;
+    //
+    //   return ((data: string): number => {
+    //     for (var i = 0; i < data.length; i++) {
+    //       n += data.charCodeAt(i);
+    //       var h = 0.02519603282416938 * n;
+    //       n = h >>> 0;
+    //       h -= n;
+    //       h *= n;
+    //       n = h >>> 0;
+    //       h -= n;
+    //       n += h * 0x100000000; // 2^32
+    //     }
+    //     return (n >>> 0) * 2.3283064365386963e-10; // 2^-32
+    //  });
+    // };
+    // ```
     pub fn mash(&mut self, input_data: &Vec<char>) -> f64 {
         // It seemed like n was doing all the heavy lifting, so I created n_copy to bear the weight,
         // so we aren't touching the object as much. No idea if this is a good thought.
@@ -55,14 +67,9 @@ impl Mash {
     }
 }
 
-
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // To test this function I plugged the above code into a javascript
 
     #[test]
     fn test_mash() {
@@ -77,84 +84,3 @@ mod tests {
         assert_eq!(test3, 0.2441756660118699);
     }
 }
-
-// The entire script, for reference:
-// export type Rng = {
-//   seed: Array<string>;
-//   random: () => number;
-// };
-//
-// export const Rng = (seed: string, ...extraSeed: Array<string>): Rng => {
-//   const args = [seed, ...extraSeed];
-//
-//   let mash = Mash();
-//   let s0 = mash(' ');
-//   let s1 = mash(' ');
-//   let s2 = mash(' ');
-//   let c = 1;
-//
-//   for (let i = 0; i < args.length; ++i) {
-//     s0 -= mash(args[i]);
-//     if (s0 < 0) { s0 += 1; }
-//     s1 -= mash(args[i]);
-//     if (s1 < 0) { s1 += 1; }
-//     s2 -= mash(args[i]);
-//     if (s2 < 0) { s2 += 1; }
-//   }
-//
-//   return <Rng>{
-//     seed: args,
-//     random: () => {
-//       let t = 2091639 * s0 + c * 2.3283064365386963e-10; // 2^-32
-//       s0 = s1;
-//       s1 = s2;
-//       return s2 = t - (c = t | 0);
-//     },
-//   }
-// };
-//
-// export const shuffleInPlace = <T>(r: Rng, a: Array<T>): void => {
-//   for (let i = a.length - 1; i > 0; --i) {
-//     const j = Math.floor(r.random() * i);
-//     const tmp = a[i];
-//     a[i] = a[j];
-//     a[j] = tmp;
-//   }
-// };
-//
-// export const select = <T>(r: Rng, a: Array<T>): T => a[uint32(r) % a.length];
-// export const selectIndex = <_>(r: Rng, a: Array<T>): number => uint32(r) % a.length;
-//
-// export const str = (() => {
-//   const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz ';
-//   return (r: Rng, min: number, max: number): string => {
-//     let result = '';
-//     let l = range(r, min, max);
-//     for(let i = 0; i < l; ++i) {
-//       result += charset.charAt(Math.floor(r.random() * charset.length));
-//     }
-//     return result;
-//   }
-// })();
-//
-// export const range = (r: Rng, min: number, max: number): number => min + r.random() * (max - min);
-// export const uint32 = (r: Rng): number => r.random() * 0x100000000; // 2^32
-// export const fract53 = (r: Rng): number => r.random() + (r.random() * 0x200000 | 0) * 1.1102230246251565e-16; // 2^-53
-//
-// const Mash = (): ((data: string) => number) => {
-//   var n = 0xefc8249d;
-//
-//   return ((data: string): number => {
-//     for (var i = 0; i < data.length; i++) {
-//       n += data.charCodeAt(i);
-//       var h = 0.02519603282416938 * n;
-//       n = h >>> 0;
-//       h -= n;
-//       h *= n;
-//       n = h >>> 0;
-//       h -= n;
-//       n += h * 0x100000000; // 2^32
-//     }
-//     return (n >>> 0) * 2.3283064365386963e-10; // 2^-32
-//   });
-// };

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ fn main() {
         }
         info!("Seed string to regenerate these exact results: {}", timestamp);
     }
-    let mut rng: Rng = Rng::new_from_seed(seed_vec);
+    let mut rng: Rng = Rng::from_seed(seed_vec);
     // run the generate reads main script
     run_neat(config, &mut rng).unwrap_or_else(|error| {
         panic!("Neat encountered a problem: {:?}", error)

--- a/src/utils/fastq_tools.rs
+++ b/src/utils/fastq_tools.rs
@@ -142,8 +142,8 @@ mod tests {
         let overwrite_output = true;
         let paired_ended = false;
         let seq1 = vec![0, 0, 0, 0, 1, 1, 1, 1];
-        let seq2 = vec![2, 2, 2, 2, 3, 3, 3, 3,];
-        let mut rng = Rng::new_from_seed(vec![
+        let seq2 = vec![2, 2, 2, 2, 3, 3, 3, 3];
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -174,8 +174,8 @@ mod tests {
         let overwrite_output = false;
         let paired_ended = true;
         let seq1 = vec![0, 0, 0, 0, 1, 1, 1, 1];
-        let seq2 = vec![2, 2, 2, 2, 3, 3, 3, 3,];
-        let mut rng = Rng::new_from_seed(vec![
+        let seq2 = vec![2, 2, 2, 2, 3, 3, 3, 3];
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),

--- a/src/utils/make_reads.rs
+++ b/src/utils/make_reads.rs
@@ -39,7 +39,7 @@ fn cover_dataset(
         cover_fragment_pool = VecDeque::from([read_length]);
     } else {
         // shuffle the fragment pool
-        rng.shuffle_in_place(&mut fragment_pool);
+        rng.shuffle(&mut fragment_pool);
         cover_fragment_pool = VecDeque::from(fragment_pool)
     }
     // Gap size to keep track of how many uncovered bases we have per layer, to help decide if we

--- a/src/utils/make_reads.rs
+++ b/src/utils/make_reads.rs
@@ -159,7 +159,7 @@ mod tests {
         let read_length = 10;
         let fragment_pool = vec![10];
         let coverage = 1;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -181,7 +181,7 @@ mod tests {
         let read_length = 100;
         let fragment_pool = vec![300];
         let coverage = 1;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -205,7 +205,7 @@ mod tests {
         let paired_ended = false;
         let mean = None;
         let st_dev = None;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -231,7 +231,7 @@ mod tests {
         let paired_ended = false;
         let mean = None;
         let st_dev = None;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -267,7 +267,7 @@ mod tests {
         let paired_ended = true;
         let mean = Some(200.0);
         let st_dev = Some(1.0);
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),

--- a/src/utils/mutate.rs
+++ b/src/utils/mutate.rs
@@ -155,7 +155,7 @@ mod tests {
     fn test_mutate_sequence() {
         let seq1: Vec<u8> = vec![4, 4, 0, 0, 0, 1, 1, 2, 0, 3, 1, 1, 1];
         let num_positions = 2;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -170,10 +170,9 @@ mod tests {
     #[test]
     fn test_mutate_fasta() {
         let seq = vec![4, 4, 0, 0, 0, 1, 1, 2, 0, 3, 1, 1, 1];
-        let file_struct: HashMap<String, Vec<u8>> = HashMap::from([
-                ("chr1".to_string(), seq.clone())
-            ]);
-        let mut rng = Rng::new_from_seed(vec![
+        let file_struct: HashMap<String, Vec<u8>> =
+            HashMap::from([("chr1".to_string(), seq.clone())]);
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -199,7 +198,7 @@ mod tests {
             ("chr1".to_string(), seq.clone())
         ]);
         // if a random mutation suddenly pops up in a build, it's probably the seed for this.
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),

--- a/src/utils/nucleotides.rs
+++ b/src/utils/nucleotides.rs
@@ -133,7 +133,7 @@ mod tests {
         let c_weights = vec![20, 0, 1, 1];
         let g_weights = vec![1, 1, 0, 20];
         let t_weights = vec![20, 1, 20, 0];
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),

--- a/src/utils/quality_scores.rs
+++ b/src/utils/quality_scores.rs
@@ -317,7 +317,7 @@ mod tests {
     #[test]
     fn test_quality_scores_short() {
         let run_read_length = 100;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn test_quality_scores_same() {
         let run_read_length = 150;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn test_quality_scores_long() {
         let run_read_length = 200;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),
@@ -362,7 +362,7 @@ mod tests {
     #[test]
     fn test_quality_scores_vast_difference() {
         let run_read_length = 2000;
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "hello".to_string(),
             "cruel".to_string(),
             "world".to_string(),

--- a/src/utils/runner.rs
+++ b/src/utils/runner.rs
@@ -109,7 +109,7 @@ mod tests {
         config.output_dir = PathBuf::from("test");
         fs::create_dir("test").unwrap();
         let config = config.build();
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),
@@ -131,7 +131,7 @@ mod tests {
         config.output_dir = PathBuf::from("output");
         fs::create_dir("output").unwrap();
         let config = config.build();
-        let mut rng = Rng::new_from_seed(vec![
+        let mut rng = Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),

--- a/src/utils/runner.rs
+++ b/src/utils/runner.rs
@@ -77,7 +77,7 @@ pub fn run_neat(config: Box<RunConfiguration>, mut rng: &mut Rng) -> Result<(), 
         info!("Shuffling output fastq data");
         let outsets: Box<Vec<&Vec<u8>>> = Box::new(read_sets.iter().collect());
         let mut outsets_order: Vec<usize> = (0..outsets.len()).collect();
-        rng.shuffle_in_place(&mut outsets_order);
+        rng.shuffle(&mut outsets_order);
 
         info!("Writing fastq");
         write_fastq(

--- a/src/utils/vcf_tools.rs
+++ b/src/utils/vcf_tools.rs
@@ -79,7 +79,7 @@ pub fn write_vcf(
                 // Mod a random int by ploidy and add to 1 (since we are modifying at least one
                 // copy). For example, with a ploidy of 2 the right term will produce either
                 // 0 or 1, so we modify either 1 or 2 copies.
-                num_ploids = 1 + rng.rand_int() as usize % ploidy;
+                num_ploids = 1 + rng.rand_u64() as usize % ploidy;
             }
             for _ in 0..num_ploids {
                 // for each ploid that has the mutation, change one random

--- a/src/utils/vcf_tools.rs
+++ b/src/utils/vcf_tools.rs
@@ -124,7 +124,7 @@ mod tests {
         let reference_path = "/fake/path/to/H1N1.fa";
         let overwrite_output = false;
         let output_file_prefix = "test";
-        let mut rng = simple_rng::Rng::new_from_seed(vec![
+        let mut rng = simple_rng::Rng::from_seed(vec![
             "Hello".to_string(),
             "Cruel".to_string(),
             "World".to_string(),


### PR DESCRIPTION
Edited/modified  comments in `simple_rng` so we can automatically generate module's documentation with `rustdoc`.  I also made some minor changes to `Rng`'s API and propagated them to the main app.

Resolves #22 