### PR TITLE
Fixed a bug in filenames for single ended

### DIFF
--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -403,6 +403,11 @@ pub fn run_neat(config: &Box<RunConfiguration>, rng: &mut NeatRng) -> Result<Vec
                 files_written.push(filename2.clone());
             }
         }
+    } else {
+        if let Some(filename1) = &config.output_fastq_1 {
+            info!("Successfully wrote fastq file: {:?}", &filename1);
+            files_written.push(filename1.clone());
+        }
     }
 
     if let Some(filename) = &config.output_vcf {

--- a/rneat/src/main.rs
+++ b/rneat/src/main.rs
@@ -193,7 +193,7 @@ fn main() -> Result<(), NeatErrors> {
                     let result = gen_reads::main(&file);
                     match result {
                         Err(error) => return Err(NeatErrors::GenerateReadsError(error)),
-                        Ok(()) => info!("rneat gen-reads completed succesfully"),
+                        Ok(()) => info!("rneat gen-reads completed successfully"),
                     }
                 } 
             }

--- a/template_config/gen_reads_template.yml
+++ b/template_config/gen_reads_template.yml
@@ -27,12 +27,6 @@ output_dir: .
 # the common name given to all output files (e.g., "TEST" => TEST_r1.fastq, TEST.vcf, TEST.bam)
 output_filename: .
 
-# If you desire to output only filtered fastqs and cfs, then supplying a bed file
-# to the filter_output option will enable this feature. Note that data not overlapping 
-# a bed region will be lost. If you wish to output full fastqs and then filter, use the
-# neat filter-reads package.
-filter_output: .
-
 # input files (full paths to files)
 # Note that these are not yet active
 # mutation_model: .


### PR DESCRIPTION
Fixed a bug where filenames were not showing up in the output array when in single-ended mode. 