### PR TITLE
Remove unused variables and imports causing compiler warnings

### DIFF
--- a/common/src/models/snp_trinuc_model.rs
+++ b/common/src/models/snp_trinuc_model.rs
@@ -303,7 +303,6 @@ impl SnpTrinucModel {
         let mut trinuc_distros: HashMap<TrinucFrame, TransitionMatrix> = HashMap::new();
         let all_contexts = ALL_CONTEXTS.clone();
         debug!("All contexts: {:?}", &all_contexts);
-        let all_frames = ALL_FRAMES.clone();
         for frame in &all_contexts {
             trinuc_distros.insert(frame.clone() ,TransitionMatrix::default()?);
             snp_weights.push(1.0);

--- a/rneat/src/filter_reads/mod.rs
+++ b/rneat/src/filter_reads/mod.rs
@@ -2,7 +2,7 @@ pub mod errors;
 pub mod utils;
 use std::path::PathBuf;
 use log::*;
-use common::{file_tools::bed_reader::{self, BedReaderError}};
+use common::{file_tools::bed_reader::{self}};
 use utils::filter_lib::{filter_fastq, filter_vcf};
 
 use crate::filter_reads::{

--- a/rneat/src/gen_mut_model/errors.rs
+++ b/rneat/src/gen_mut_model/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 use std::num::ParseIntError;
-use common::{file_tools::{bed_reader::BedReaderError, fasta_reader::FastaReaderError, vcf_tools::VcfToolsError}, models::{mutation_model::MutationModelError, snp_trinuc_model::SnpTrinucError}, structs::fasta_map::FastaMapError};
+use common::{file_tools::{bed_reader::BedReaderError, fasta_reader::FastaReaderError, vcf_tools::VcfToolsError}, models::mutation_model::MutationModelError, structs::fasta_map::FastaMapError};
 
 #[derive(Error, Debug)]
 pub enum GenMutationModelError {


### PR DESCRIPTION
- snp_trinuc_model.rs: remove dead ALL_FRAMES clone (loop uses all_contexts)
- filter_reads/mod.rs: remove unused BedReaderError import
- gen_mut_model/errors.rs: remove unused SnpTrinucError import