### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,64 +1,8 @@
-# RustyNeat v1.0.0
-
-9/5/2023
-=========
-- Initialized Cargo package with hello world default script.
-- Added function to select a random integer from a list (for selecting positions)
-
-9/9/2012
-=========
-- Created a first pass program that mutates a hardcoded DNA string at one random non-N position.
-- Added a logging function to print out time-stamped log items both to stdout and to file.
-- Need to improve error handling all around, taking advantage of Rusts error handling system.
-- Design decision: After toying with some options to create a standardized RNG to use throughout the program, it seems the best option is to use an on-the-fly rng per function for now. This eliminates reproducibility between runs, but should enable parallelism of processing.
-- Redesign from the ground up. Trying to use KISS as much as possible, and only introduce complexity as it becomes necessary, or as I learn Rust tricks that may help this endeavor.
-
-## rusty-neat v0.1
-
-Goal: To release a version of NEAT in rust capable of reading an arbitrary fasta file, 
-and outputting a version of that file with 1% of the bases mutated as SNPs.
-
-9/11/2023
-=========
-- Found a sqlite crate for rust. This might be a good way to store the reference information for our genome. We can have one row per chromosome. Name, info, sequence. Read the data in once, store it for long term retrieval. Website: https://docs.rs/sqlite/latest/sqlite/
-
-## rusty-neat v0.1.0
-
-Moved the code from a brach under NEAT (https://github.com/ncsa/neat) to its own repo https://github.com/ncsa/rusty-neat. This project will be considered a separate, related project. We will use the same underlying design ideas as NEAT, but it will essentially be different and won't be guaranteed in any way to be able to reproduce what the original NEAT did (though we aim to get it as close as possible, the differences in Python and Rust would make byte-by-byte compatability very difficult). I have implemented an idea I prototyped in a private repo (https://github.com/joshfactorial/basic_neat), of reading in the file in what I hope is a straightforward way. I was looking for stuff like running out of memory and speed. It can read in the `E. coli` fasta file in about 30 seconds on my laptop, which is pretty fast, compared to Python. What's more is it can store the whole thing in memory, due to the efficient way Rust uses memory. Instead of copying the entire data set every time in memory, quickly eating it up, Rust forces you to decide when to pass a read-only version, copy the dataset, or use up the dataset once and lose it forever (all valid choices depending on context). So I'm feeling hopeful that this will work. I am publishing an Alpha called v0.1.0 for people to test, if they feel so inclined. See the README for more details.
-
-9/9/2025
+5/9/2026
 =========
 
-## rusty-neat v1.0.0
-- It's been a couple years since I had an update to rusty-neat. This new vrison is version 1.0.0! It is not yet fully functional, as it is missing the BAM creation, though it does work on some test data: H1N1.fa and ecoli.fa. It's very fast for H1N1, but that's not too surprising. It's slow right now on fastq creation. I already know what I need to do to fix that part, I put an [issue](https://github.com/ncsa/rusty-neat/issues/65) up here that I am working on in develop. But for now, rusty-neat functions and can be executed on some arbitrary data. Will update the readme as well. Once I get the fastq generation idea to work (will require changes to fastq_tools and runner scripts), next step will be parallelizing the main contig loop in runner. That should give us some speedup. Also, we went from using way too much memory to using almost no memory. I'm not sure which is better. It would be nice to find a balance. I still think that a database could work. I'm wondering, maybe we index on position. Just use like a json-based database: {"contig": "chr1", "sequence": {"1":A, "2": C, etc}} We'd want something that had fast retrieval for writing. Something to investigate, maybe.
-- The code is significantly different now, I read in all the old models from the original NEAT2.0, and stored them as default models. I used a lot of the same algorithms that they used in NEAT 2.0, figuring it was closer to rust than NEAT 3.X. 
-- rusty-neat writes out a ton of files. It should clean them up afterward, but I'm not sure it does yet, may need to investigate if there is an added command required. But it stores them in temp and linux cleans that up. Basically, we are splitting up the input fasta into smaller chunks (tbd on if there is an optimal size) then writing those to file for later retrival. Need to test various chunk sizes. I am basically doing blocked gzip-type things, but with some twists. If someone really understood bgzip format, it could probably be used directly. I'm not there yet.
-- My runtimes running on a WSL2 Ubuntu setup with the latest rust installed: 311 milliseconds for H1N1.fa, 13 minutes for ecoli. It's all the IO during that step. I knew it was ugly as I was writing it but it's a rough draft. Obviously all the repeat code in fastq_tools is not ideal.
-- The output files, so far have looked good. I realized I haven't tested paired-ended yet.
-- I decided to map out the N-regions then overwrite them with random valid bases. The main reason being that it kept dipping into N regions and trying to use them for snp creation and that isn't going to work. NEAT 2.0 had a data structure that kept track of how long N-regions were, then would skip them if they were longer than a read length or overwrite them if they were short. That might work. Potential room for improvement, but it's fast so far.
-- Eliminated bam creation for now. The option is in there, but it warns you that it doesn't work yet. Once fastqs are sorted and maybe after parallelism, it'll be next up.
-
-9/11/2025
-=========
-
-## rusty-neat v1.1.0
-- We have refactored the fastq code. Now a temporary fastq is written to file per block read in by the fasta reader. This should allow us to parallelize the temporary fastqs. Then it's simply a matter of concatenating them together. Works great! I got through single-ended E coli depth 10 in 36 seconds. I got through paired-ended E coli in 78 seconds. 
-- Caveats: the fastqs are sorted by read start. Included in each name is the exact location where the sequence was drawn from. Now, when you run an alignment, the reads will be named in such a way that will have <chromosome name>_start-pos_length in the name, so you can shuffle the reads and run an alignment, and easily check to see if your alignment is in the correct contig and location.
-
-9/13/2025
-=========
-
-## rust-neat v1.1.2
-- I missed an intermediate version. Basically, it was converting to the command `neat gen-reads` instead of `generate-reads`, which will allow us to add subcommands, similar to how python NEAT worked. I also fixed some bugs in the fastq generation and paired-ended creation.
-- In this release, we are adding a bed reader that can limit the fasta regions of interest. Basically, it will take an input bed and only generate reads over the sections in the bed.
-
-9/19/2025
-=========
-
-## rneat v1.2.0
-- Executable name change to `rneat`. In order to differentiate rusty-neat from the main neat, we are changing the binary name to `rneat` and we have expanded subcommands and made them more robust.
-- Added bed filtering functions. Now if you supply a "filter_output" bed file to your gen-reads run, it will produce the original files plus a filtered version showing only reads and variants that overlap with the regions in the bed.
-- It's also possible to run this utility separately with `rneat filter-reads`
+## rneat v1.4.1
+- `gen-reads` new feature: `long_reads` configuration flag (boolean, default `false`). When `true`, fragments sampled from the fragment length model that are shorter than `read_len` are accepted rather than discarded, and the resulting read is truncated to the actual fragment length. This reproduces the realistic read-length distribution seen in real long-read datasets (PacBio HiFi, Oxford Nanopore), where size selection is imperfect and a tail of shorter reads is always present. When `false` (the default, appropriate for Illumina short reads), fragments shorter than `read_len` continue to be rejected — for Illumina, short fragments produce adapter read-through rather than truncated reads, which is outside the scope of this simulator. The flag affects both the uniform-coverage fragment path and the GC-bias-weighted path, as well as the FASTQ and BAM writers, which compute an effective read length of `min(fragment_len, read_len)` per fragment when `long_reads: true`. Added to `template_config/gen_reads_template.yml` with inline documentation.
 
 5/9/2026
 =========
@@ -70,8 +14,6 @@ Moved the code from a brach under NEAT (https://github.com/ncsa/neat) to its own
 - `gen-reads` bug fix: `cover_dataset` accumulated `start` across loop iterations instead of resetting to `temp_end`, causing reads to pile up at the beginning of each region rather than spanning it evenly.
 - `gen-reads` / `mutation_model` bug fix: soft-masked nucleotides (`Maskeda/c/g/t`) were leaking into VCF REF/ALT fields and FASTQ read sequences as lowercase letters (`a/c/g/t`). `generate_mutation` now applies `check_base()` to the extracted `ref_base` and to each base of the deletion reference slice, unmasking all bases before they are written to output.
 - New integration tests in `gen-reads`: `test_paired_ended_bam_flags_correct` (SAM flags on every R1/R2 record), `test_paired_ended_insert_size_matches_model` (TLEN mean within ±20% of configured fragment mean), `test_input_vcf_snp_appears_in_bam_reads` (seeded input-VCF SNP visible in BAM reads at the correct position).
-
-
 - `gen-seq-error-model`: FASTQ input is now streamed one record at a time instead of being fully loaded into memory. Peak memory is bounded by a single record rather than the entire file, which matters for large (multi-GB) FASTQ inputs. The `max_reads` early-exit now also fires without reading the rest of the file.
 - `gen-mut-model`: Trinucleotide probability computation is now O(n) instead of O(n²). Transition counts are pre-grouped by reference frame once before the probability loop, eliminating a redundant linear scan per trinucleotide context.
 - `filter-reads` (`filter_fastq` and `filter_vcf`): Replaced `format!("{}\n", line)` heap allocations on every written line with two `write_all` calls (bytes + newline). Eliminated double HashMap lookups (`contains_key` + index) in favour of a single `get` call. Contig name reconstruction changed from a manual push loop to `join("_")`. The read-name prefix check simplified from `find` + index comparison to `starts_with`.
@@ -104,3 +46,62 @@ Moved the code from a brach under NEAT (https://github.com/ncsa/neat) to its own
 - Added `input_vcf` config key to `gen-reads`. A single-sample VCF (`.vcf` or `.vcf.gz`) can now be supplied to force specific variants into the simulation. Each record must carry a `GT` field; SNPs and indels are applied at the given position before random variant generation runs on the remaining mutable bases. Complex variants (multi-base REF and ALT) are skipped with a warning. Random variants still fire at `mutation_rate` for positions not covered by the input VCF; set `mutation_rate: 0` to suppress them entirely. Caveats: only the first ALT allele of multi-allelic records is used; REF alleles are not verified against the reference sequence.
 - Added `gen-gc-bias-model` subcommand. Reads a reference FASTA and a per-base coverage file (samtools depth, bedtools genomecov -d, or bedtools genomecov -dz), tiles the reference in sliding windows, and accumulates mean coverage per integer GC% bin to produce a `GcBiasModel` (gzipped JSON). Bins with fewer than `min_windows_per_bin` observations receive a neutral weight of 1.0 so sparse GC% values do not distort the model. Designed to scale to large genomes: coverage is indexed once and loaded one contig at a time; the reference is streamed without temp files; both GC counting and coverage summing use O(1)-amortized sliding windows so peak memory is bounded by the longest contig rather than total genome size. Added `template_config/gen_gc_bias_model.yml` documenting all config fields.
 - Added GC bias simulation to `gen-reads`. When a `gc_bias_model` is supplied, fragment start positions are sampled directly from a per-position probability distribution derived from GC content, replacing the previous rejection-sampling approach. The model's `window_size` is embedded in the model file so the application-time window always matches the training-time window. Set `gc_bias_normalize_coverage: true` (default) to inflate fragment count to compensate for low-weight regions; set `false` to preserve the raw requested coverage.
+
+9/19/2025
+=========
+
+## rneat v1.2.0
+- Executable name change to `rneat`. In order to differentiate rusty-neat from the main neat, we are changing the binary name to `rneat` and we have expanded subcommands and made them more robust.
+- Added bed filtering functions. Now if you supply a "filter_output" bed file to your gen-reads run, it will produce the original files plus a filtered version showing only reads and variants that overlap with the regions in the bed.
+- It's also possible to run this utility separately with `rneat filter-reads`
+
+9/13/2025
+=========
+
+## rust-neat v1.1.2
+- I missed an intermediate version. Basically, it was converting to the command `neat gen-reads` instead of `generate-reads`, which will allow us to add subcommands, similar to how python NEAT worked. I also fixed some bugs in the fastq generation and paired-ended creation.
+- In this release, we are adding a bed reader that can limit the fasta regions of interest. Basically, it will take an input bed and only generate reads over the sections in the bed.
+
+9/11/2025
+=========
+
+## rusty-neat v1.1.0
+- We have refactored the fastq code. Now a temporary fastq is written to file per block read in by the fasta reader. This should allow us to parallelize the temporary fastqs. Then it's simply a matter of concatenating them together. Works great! I got through single-ended E coli depth 10 in 36 seconds. I got through paired-ended E coli in 78 seconds.
+- Caveats: the fastqs are sorted by read start. Included in each name is the exact location where the sequence was drawn from. Now, when you run an alignment, the reads will be named in such a way that will have <chromosome name>_start-pos_length in the name, so you can shuffle the reads and run an alignment, and easily check to see if your alignment is in the correct contig and location.
+
+9/9/2025
+=========
+
+## rusty-neat v1.0.0
+- It's been a couple years since I had an update to rusty-neat. This new version is version 1.0.0! It is not yet fully functional, as it is missing the BAM creation, though it does work on some test data: H1N1.fa and ecoli.fa. It's very fast for H1N1, but that's not too surprising. It's slow right now on fastq creation. I already know what I need to do to fix that part, I put an [issue](https://github.com/ncsa/rusty-neat/issues/65) up here that I am working on in develop. But for now, rusty-neat functions and can be executed on some arbitrary data. Will update the readme as well. Once I get the fastq generation idea to work (will require changes to fastq_tools and runner scripts), next step will be parallelizing the main contig loop in runner. That should give us some speedup. Also, we went from using way too much memory to using almost no memory. I'm not sure which is better. It would be nice to find a balance. I still think that a database could work. I'm wondering, maybe we index on position. Just use like a json-based database: {"contig": "chr1", "sequence": {"1":A, "2": C, etc}} We'd want something that had fast retrieval for writing. Something to investigate, maybe.
+- The code is significantly different now, I read in all the old models from the original NEAT2.0, and stored them as default models. I used a lot of the same algorithms that they used in NEAT 2.0, figuring it was closer to rust than NEAT 3.X.
+- rusty-neat writes out a ton of files. It should clean them up afterward, but I'm not sure it does yet, may need to investigate if there is an added command required. But it stores them in temp and linux cleans that up. Basically, we are splitting up the input fasta into smaller chunks (tbd on if there is an optimal size) then writing those to file for later retrival. Need to test various chunk sizes. I am basically doing blocked gzip-type things, but with some twists. If someone really understood bgzip format, it could probably be used directly. I'm not there yet.
+- My runtimes running on a WSL2 Ubuntu setup with the latest rust installed: 311 milliseconds for H1N1.fa, 13 minutes for ecoli. It's all the IO during that step. I knew it was ugly as I was writing it but it's a rough draft. Obviously all the repeat code in fastq_tools is not ideal.
+- The output files, so far have looked good. I realized I haven't tested paired-ended yet.
+- I decided to map out the N-regions then overwrite them with random valid bases. The main reason being that it kept dipping into N regions and trying to use them for snp creation and that isn't going to work. NEAT 2.0 had a data structure that kept track of how long N-regions were, then would skip them if they were longer than a read length or overwrite them if they were short. That might work. Potential room for improvement, but it's fast so far.
+- Eliminated bam creation for now. The option is in there, but it warns you that it doesn't work yet. Once fastqs are sorted and maybe after parallelism, it'll be next up.
+
+9/11/2023
+=========
+
+## rusty-neat v0.1.0
+
+Moved the code from a branch under NEAT (https://github.com/ncsa/neat) to its own repo https://github.com/ncsa/rusty-neat. This project will be considered a separate, related project. We will use the same underlying design ideas as NEAT, but it will essentially be different and won't be guaranteed in any way to be able to reproduce what the original NEAT did (though we aim to get it as close as possible, the differences in Python and Rust would make byte-by-byte compatibility very difficult). I have implemented an idea I prototyped in a private repo (https://github.com/joshfactorial/basic_neat), of reading in the file in what I hope is a straightforward way. I was looking for stuff like running out of memory and speed. It can read in the `E. coli` fasta file in about 30 seconds on my laptop, which is pretty fast, compared to Python. What's more is it can store the whole thing in memory, due to the efficient way Rust uses memory. Instead of copying the entire data set every time in memory, quickly eating it up, Rust forces you to decide when to pass a read-only version, copy the dataset, or use up the dataset once and lose it forever (all valid choices depending on context). So I'm feeling hopeful that this will work. I am publishing an Alpha called v0.1.0 for people to test, if they feel so inclined. See the README for more details.
+
+## rusty-neat v0.1
+
+Goal: To release a version of NEAT in rust capable of reading an arbitrary fasta file,
+and outputting a version of that file with 1% of the bases mutated as SNPs.
+
+9/5/2023
+=========
+- Initialized Cargo package with hello world default script.
+- Added function to select a random integer from a list (for selecting positions)
+
+9/9/2023
+=========
+- Created a first pass program that mutates a hardcoded DNA string at one random non-N position.
+- Added a logging function to print out time-stamped log items both to stdout and to file.
+- Need to improve error handling all around, taking advantage of Rusts error handling system.
+- Design decision: After toying with some options to create a standardized RNG to use throughout the program, it seems the best option is to use an on-the-fly rng per function for now. This eliminates reproducibility between runs, but should enable parallelism of processing.
+- Redesign from the ground up. Trying to use KISS as much as possible, and only introduce complexity as it becomes necessary, or as I learn Rust tricks that may help this endeavor.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bincode",
  "bstr",
@@ -891,7 +891,7 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 
 [[package]]
 name = "rneat"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.4.0'
+version = '1.4.1'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/README.md
+++ b/README.md
@@ -560,3 +560,7 @@ Only reads that satisfy all of the following are used:
 
 **Outlier filtering:**  
 Fragment lengths that exceed `median + 10 × MAD` (median absolute deviation) are removed before fitting. This mirrors the filtering in Python NEAT's fragment length modeler. If no lengths survive the filter, lower `min_reads` or set it to `0`.
+
+**Zenodo release**
+
+[![DOI](https://zenodo.org/badge/765847780.svg)](https://doi.org/10.5281/zenodo.20100558)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # The rusty-neat project
-Weclome to `rneat`, a Rust port of NEAT (https://github.com/ncsa/neat), a genetic simulation program that creates next-gen-looking fastq files along with an accompanying golden vcf file showing all of the variants inserted by NEAT. It also generates "noise" in the form of sequencing errors as it is writing out files. These features can help you hone in your alignment software to your data. 
+Welcome to `rneat`, a Rust port of NEAT (https://github.com/ncsa/neat), a genetic simulation program that creates next-gen-looking fastq files along with an accompanying golden VCF and BAM files showing all of the variants inserted by `rneat` and the ideal alignments. It also generates "noise" in the form of sequencing errors as it is writing out files. These features can help you hone in your alignment and variant calling software to your data. Training models on your data will allow `rneat` to faithfully reproduce the statistical properties of your dataset.
 
-As of now, `rneat` is still under development. We are working toward the goal of the original NEAT of being able to read user data and construct a model based on that data. We do however, have functional reads being generated, with variants tracked in a vcf file. This is our 1.2.0 version.
+The most recent version of `rneat` includes adding in the utilities to allow users to generate their own models for running `rneat`. It also now outputs a golden BAM file with ideal alignments, accepts a BED file for filtering the genome down to target regions for read creation, a more accurate coverage tool, and the ability to read in custom variants from a VCF file and insert them into the code. We swapped out the temp file writing method for a file streaming method that seems to work even faster and does not take up as much space on disk, avoiding expensive disk I/O of previous versions. We've done numerous benchmarks and tests on the data, but we look forward to user feedback on how well the output reproduces their data on a statistical level,
 
 # How to use `rneat`
 
 ## Prerequisites
-One of the packages requires cmake to use. For Debian/Ubuntu this should be a simple `sudo apt install cmake` and for RHEL/Rocky type distros this should be `sudo dnf install cmake`
+You will need to install the rust toolchain to compile `rneat`, including `cargo`. Check the cargo documentation for instructions (https://doc.rust-lang.org/cargo/getting-started/installation.html). Alternatively, you can try one of the binaries on the release page. Select the one that matches your system and let us know if you run into errors. During compilation, you may run into errors, such as cmake not found. Some of the packages `rneat` uses have these dependencies. For Debian/Ubuntu this should be a simple `sudo apt install cmake` and for RHEL/Rocky type distros this should be `sudo dnf install cmake`. There may be some other requirements. Drop a comment if you need specific help.
 
-Download the executable in the release (current version 1.4.0).
+Download the executable in the release (current version 1.4.1).
 
 ```bash
 $ rneat --help
@@ -70,7 +70,7 @@ Options:
 
 Use the help menu to see the available options and leave an issue if you find something bad happening.
 
-To compile and run `rneat` yourself, you will need the Rust environment (https://www.rust-lang.org/tools/install), with cargo. You will also need git installed for your operating system. You will then need to git clone and cd into the repo directory. From your home directory in Linux the process might look something like:
+To compile and run `rneat` yourself, besides the rust toolchain, you will need `git` installed for your operating system. You will then need to git clone and cd into the repo directory. From your home directory in Linux the process might look something like:
 
 ```bash
 ~/$ git clone git@github.com:ncsa/rusty-neat.git
@@ -78,7 +78,7 @@ To compile and run `rneat` yourself, you will need the Rust environment (https:/
 ~/rusty-neat/$
 ```
 
-For Windows users, you're probably going to want to use WSL, but go ahead and test it if there's a Rust for windows. (Post help requests in the Issues tab if you need assistance or have suggestions).
+For Windows and Mac users, try the binary packaged with the latest version of `rneat`.
 
 Once in the repo, you can build the program either in debug (default) or release mode. The main difference is how much info it gives you if there is an error. Release mode also has some optimizations to run it faster.
 
@@ -88,7 +88,7 @@ Once in the repo, you can build the program either in debug (default) or release
 
 If you prefer to run the package directly without using the binary, you can also use
 ```bash
-~/rusty-neat/$ cargo run
+~/rusty-neat/$ cargo run -- gen-reads -c my_config.yml
 ```
 
 Rust will download any required packages. Compiling Rust code is the slowest part of the process. The final binary will be built and the program run immediately after in the second case. To run the program manually, from the repo main dir, run
@@ -97,29 +97,29 @@ Rust will download any required packages. Compiling Rust code is the slowest par
 ~/rusty-neat/$ ./target/release/rneat -h
 ```
 
-`rneat` uses a configuration file to read values it needs for the run. Most of these features should be active, but there is currently no way to generate your own data, so stick with default models for now. A command line execution might look like this:
+`rneat` uses a configuration file to read values it needs for the run. A command line execution might look like this:
 
 ```bash
-~/rusty-neat/$ ./target/release/rneat -C /path/to/filled/in/config.yml
+~/rusty-neat/$ ./target/release/rneat -c /path/to/filled/in/config.yml
 ```
-If you record the output in the logs of Seed string to regenerate these exact results: XXXXXXX, you should be able to use that string as input with rng_seed and reproduce your results (untested as of yet).
+If you record the output in the logs of Seed string to regenerate these exact results: XXXXXXX, you should be able to use that string as input with rng_seed and reproduce your results.
 
 Fastq Output
 ============
-the fastq output will have a key name that identifies the block where teh read was drawn from. This should allow you to asseses how well the aligner funcution. The name will have the format `<contig short name>_<fragment_start>_<fragment_end>`
+The fastq output will have a key name that identifies the block where the read was drawn from, for quick comparisons in alignments. The output BAM file will contain the original sequence and cigar string. The name will have the format `RNEAT_generated_<contig short name>_<fragment_start>_<fragment_end>/1` (or `/2` for the second read in a pair), where start and end are zero-padded to 10 digits.
 
 ```bash
-@neat_generated_Chromosome_0000000000_0000353_1:1
+@RNEAT_generated_Chromosome_0000000000_0000000353/1
 CTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGCTTCTTAACTGGTTACCTGCCGTGAGTAAATTAAAATTTTATTGACTTAGGTCACTAAATACTTTAACCAATATAGGCATAGC
 +
 >AC7<GDEGGGGEFGA<GFCGG;GGGGGF>GEGGEGGGFGFEFGCEGGGGGGCG:AEFGFFGG>FG;GDGA9$GGAGF=GFG=EFFCGGGFGGGGGC$BFGEFFAGGG9F7E@>?GFGGGG>EBFGFDG)DGC6DEDFA2EG:EGG%FFB
 ```
-For example, comes from the chromosome in the reference (which was simply named "Chromosome") between 0 and 353, which is the size 
+The above example comes from the chromosome in the reference (which was simply named "Chromosome") between 0 and 353, which is the size
 of a fragment in the simulated DNA. If there is a pair with this read, it will have the same coordinates, though it started at index 352 instead.
 
 BAM Output
 ==========
-`rneat` can write a golden BAM file alongside the FASTQ output. The BAM contains the same reads as the FASTQ — same sequences, same quality scores, same variants and sequencing errors applied — with alignment information included. To enable it, set `produce_bam: true` in your `gen-reads` config. The output path is derived automatically from `output_filename` (e.g. `output_filename: my_run` → `my_run.bam`).
+`rneat` can write a golden BAM file alongside the FASTQ output. The BAM contains the same reads as the FASTQ — same sequences, same quality scores, same variants and sequencing errors applied — with alignment information included. To enable it, set `produce_bam: true` in your `gen-reads` config. The output path is derived automatically from `output_filename` (e.g. `output_filename: my_run` → `my_run.bam`). Please note that the BAM has a higher overhead than the fastq, and may take longer to produce.
 
 ```yaml
 produce_bam: true
@@ -145,9 +145,9 @@ For exome, targeted-panel, or any run where you only want reads over specific re
 target_bed: /path/to/targets.bed
 ```
 
-When `target_bed` is set, `gen-reads` skips contigs absent from the BED entirely — no blocks are read, no variants are placed, and no temp files are written for those contigs. Within covered contigs, reads and variants are generated only over the intersecting non-N regions. This is the recommended approach for targeted runs on large genomes; it is far more efficient than generating genome-wide reads and post-filtering with `filter-reads`.
+When `target_bed` is set, `gen-reads` skips contigs absent from the BED entirely — no blocks are read, no variants are placed, and no reads are generated for those contigs. Within covered contigs, reads and variants are generated only over the intersecting non-N regions. This is the recommended approach for targeted runs on large genomes; it is far more efficient than generating genome-wide reads and post-filtering with `filter-reads`.
 
-The BED contig names must match the short names derived from the reference FASTA (the text after `>` up to the first space or `|`). Both `.bed` and `.bed.gz` inputs are accepted.
+The BED contig names must match the short names derived from the reference FASTA (the text after `>` up to the first whitespace character). Both `.bed` and `.bed.gz` inputs are accepted.
 
 Input Variants VCF
 ==================
@@ -163,7 +163,7 @@ input_vcf: /path/to/variants.vcf.gz
 
 - The VCF must be single-sample (one sample column).
 - Every record must include `GT` in the FORMAT field. `rneat` uses the genotype to determine whether to apply the variant to all reads covering the position (homozygous, e.g. `1/1`) or only a probabilistic subset (heterozygous, e.g. `0/1`). Records without `GT` are rejected.
-- Contig names must match the short names derived from the reference FASTA (text after `>` up to the first space or `|`). Variants on unrecognised contigs are skipped with a warning.
+- Contig names must match the short names derived from the reference FASTA (text after `>` up to the first whitespace character). Variants on unrecognised contigs are skipped with a warning.
 - Both `.vcf` and `.vcf.gz` files are accepted.
 
 **Supported variant types**
@@ -209,16 +209,18 @@ By default `rneat` uses all available logical cores. You can cap the thread coun
 ```yaml
 # use 4 threads instead of all available cores
 num_threads: 4
-
+```
+or disable parallelism entirely (useful for debugging or reproducibility testing)
+```yaml
 # disable parallelism entirely (useful for debugging or reproducibility testing)
 num_threads: 1
 ```
 
 Omit `num_threads` (or set it to `.`) to restore the default all-cores behaviour.
 
-**BAM output is now fully parallel:**
+**BAM output is fully parallel:**
 
-`rneat` uses a per-contig temp-file strategy: each contig worker writes its alignment records to a private temporary BAM body file, then a single concatenation pass assembles them in reference order into the final coordinate-sorted BAM. This means `produce_bam: true` no longer disables parallelism — all contigs are processed concurrently regardless of whether BAM output is requested.
+`rneat` uses a per-contig temp-file strategy: each contig worker writes its alignment records to a private temporary BAM body file, then a single concatenation pass assembles them in reference order into the final coordinate-sorted BAM.
 
 **Reproducibility:**
 
@@ -226,7 +228,7 @@ Each contig's random number generator is derived deterministically from the pare
 
 Reading Bed Data
 ================
-`rneat` can now read bed data and filter the reads based on regions specified. This comes with some caveats. First is that rust can't handle any header lines or non-header rows in the bed file. Second, the names must match what is in the fasta. Third, `rneat` can only filter, and does not use the rest of the bed. If this is an issue please raise an issue and we will see about adding more features.
+`rneat` can now read bed data and filter the reads based on regions specified. This comes with some caveats. First is that rust can't handle any header lines or non-header rows in the bed file, because of potential range of possibilities. Second, the names must match what is in the fasta. Third, `rneat` can only filter, and does not use the rest of the bed information. It treats each record as a region of interest only.
 
 Bed data will have some challenges. For example, if the contig names in the bed file don't match the assumed contig name from the fasta file, how will rust be able to know which is what? To make things work, we are going to assume, for now, that the bed file contig names match the names as derived by `rneat`. To determine this:
 
@@ -239,7 +241,7 @@ $ grep "^>" input.fasta
 >NC_001135.5 Saccharomyces cerevisiae S288C chromosome III, complete sequence
 >etc
 ```
-This will give you the fill fasta name. `rneat` determines the short name of the input fasta by skipping the initial '>' character, then taking the string up to the first delimiter (space or '|'). In the above example, the short names are "NC_001133.9", "NC_001134.8", etc. 
+This will give you the full fasta name. `rneat` determines the short name of the input fasta by skipping the initial '>' character, then taking the string up to the first whitespace delimiter. In the above example, the short names are "NC_001133.9", "NC_001134.8", etc. 
 
 Next, we check the bed. This example awk command will look for unique values in the first column of your bed file and print out what it finds. 
 
@@ -250,20 +252,20 @@ $ awk '!seen[$1]++ {print $1}' file.bed
 3
 etc
 ```
-In this case, the bed file uses a simple numbering scheme to number the chromosomes. We can see a mapping with the roman numeral chromosomes in the name, but it's tricky to program. So, the following command will allow you, the user, to map these chromosomes and thus instruct NEAT. Yours will vary based on the inputs.
+In this case, the bed file uses a simple numbering scheme to number the chromosomes. We can see a mapping with the roman numeral chromosomes in the name, but it's tricky to handle consistently. So, the following command will allow you, the user, to map these chromosomes and thus instruct `rneat`. Yours will vary based on the inputs.
 
 ```bash
 awk -F'\t' '{$1=($1=="1"?"NC_001133.9":$1); $1=($1=="2"?"NC_001134.8":$1); print}' OFS='\t' file.bed > file_renamed.bed
 ```
-You will have to tailor this command to your dataset, but this will allow you to map the names from the bed to the fasta in a way `rneat` will understand.
+You will have to tailor this command to your dataset, but this is one way to map the names from the bed to the fasta in a way `rneat` will understand.
 
 Filtering Your Data
 ====================
 
-To run filter-reads, you must first copy the filter_reads_template.yml file from rusty-neat/template_config/ to a directory of your choosing. Then you can edit the  file in your favorite editor. The configuration only has three fields:
+To run filter-reads, you must first copy the filter_reads_template.yml file from rusty-neat/template_config/ to a directory of your choosing. Then you can edit the file in your favorite editor. The configuration has four fields:
 
 ```bash
-bed-file: /path/to/my.bed # required
+bed_file: /path/to/my.bed # required
 ```
 A filename (full path is best) for a bed file with regions to target for filtering. It should be tab-separated in standard bed format.
 
@@ -287,7 +289,12 @@ Note the full extension is important, but filter-reads should be able to handle 
 ```bash
 filter_key: .
 ```
-This is the key appended to the filename, before extensions. For example, if your filename is "miscanthus_r1.fast.gz", and you set the key as "_only_genes", the output file would be "miscanthus_r1_only_genes.fastq.gz. The default is "_filtered".
+This is the key appended to the filename, before extensions. For example, if your filename is "miscanthus_r1.fastq.gz", and you set the key as "_only_genes", the output file would be "miscanthus_r1_only_genes.fastq.gz". The default is "_filter".
+
+```bash
+overwrite_output: false # optional, default false
+```
+Set to `true` to allow filter-reads to overwrite existing output files. When `false`, the run will error if the output file already exists.
 
 Once your files are entered and your config is saved, you can run rneat:
 
@@ -306,7 +313,7 @@ Generating a Mutation Model
 $ rneat gen-mut-model -c gen_mut_model_config.yml
 ```
 
-The inputs are a single-sample VCF and the reference FASTA the VCF was called against. `rneat` computes statistics for indels and SNPs and builds the trinucleotide model of SNP generation, as in the original NEAT. The output is a gzipped JSON model file that can be passed directly to `gen-reads` via its `mutation_model` config key.
+The inputs are a single-sample VCF and the reference FASTA the VCF was called against. `rneat` computes statistics for indels and SNPs and builds the trinucleotide model of SNP generation, as in the original `rneat`. The output is a gzipped JSON model file that can be passed directly to `gen-reads` via its `mutation_model` config key.
 
 Copy `template_config/gen_mut_model_template.yml` to a directory of your choosing and fill in the fields:
 
@@ -340,7 +347,7 @@ transition_matrix_file: /path/to/matrix.tsv
 - Each variant record must have `GT` in the `FORMAT` column; `rneat` hard-errors if GT is missing
 - `QUAL=.` is accepted and treated as quality score 0
 
-Caveats: Only one sample can be read at this point. Currently, high-mutation regions and common variants features from NEAT are not yet implemented. Please submit or comment on a feature request if you desire this feature.
+Caveats: Only one sample can be read at this point. Currently, high-mutation regions and common variants features from Python NEAT are not yet implemented.
 
 Try it out and let us know if you run into any issues!
 
@@ -389,7 +396,7 @@ transition_matrix_file: /path/to/matrix.tsv
 **SNP transition matrix priority:**
 1. `transition_matrix_file` (explicit TSV) — highest priority
 2. `bam_file` (inferred from MD-tagged BAM mismatches)
-3. Default matrix from Python NEAT — used when neither is provided
+3. Default matrix from Python `rneat` — used when neither is provided
 
 **BAM MD tag requirement:**
 The BAM path requires MD tags to identify reference bases at mismatch positions. Most aligners (BWA-MEM, STAR with `--outSAMattributes MD`) add them automatically. If yours does not, generate them with:
@@ -399,7 +406,7 @@ samtools index aligned_with_md.bam
 ```
 
 **TSV format:**
-The transition matrix TSV has 4 data rows (one per reference base: A, C, G, T) and 4 whitespace-separated columns (one per read base: A, C, G, T). An optional header row (non-numeric first token) is skipped. Diagonal values are zeroed automatically. Rows are re-normalized to sum to 1.
+The transition matrix TSV has 4 data rows (one per reference base: A, C, G, T) and 4 whitespace-separated columns (one per read base: A, C, G, T). The first row is skipped if it is non-numeric (treated as a header). Diagonal values are zeroed automatically. Rows are re-normalized to sum to 1.
 
 ```
 A    C    G    T
@@ -408,8 +415,6 @@ A    C    G    T
 0.4  0.3  0.0  0.3
 0.3  0.3  0.4  0.0
 ```
-
-That's it so far! Test out the features and let us know what you think!
 
 Generating a GC Bias Model
 ====================

--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -82,6 +82,7 @@ pub fn write_block_fastq<T: Write, W: Write> (
     buffer1: &mut GzEncoder<T>,
     buffer2: &mut GzEncoder<W>,
     read_length: usize,
+    long_reads: bool,
     read_name_prefix: &str,
     quality_score_model: &QualityScoreModel,
     sequencing_error_model: &SequencingErrorModel,
@@ -91,18 +92,25 @@ pub fn write_block_fastq<T: Write, W: Write> (
     debug!("writing reads for {}", sequence_block.contig);
     for (start, end) in block_fragments {
         let fragment = sequence_block.get_subseq(start, end)?;
+        // In long-read mode a fragment may be shorter than read_length; truncate the read
+        // to the actual fragment length rather than discarding it.
+        let effective_read_len = if long_reads {
+            fragment.len().min(read_length)
+        } else {
+            read_length
+        };
         let mut read1_variants: HashMap<usize, &Variant> = HashMap::new();
         let mut reads1_flagged: Vec<usize> = Vec::new();
         let mut read2_variants: HashMap<usize, &Variant> = HashMap::new();
         let mut reads2_flagged: Vec<usize> = Vec::new();
         for (pos, variant) in &block_map.variant_map {
-            if (start..(start+read_length)).contains(&pos) {
+            if (start..(start+effective_read_len)).contains(&pos) {
                 let var_pos = pos - start;
                 read1_variants.insert(var_pos, variant);
                 reads1_flagged.push(var_pos);
             }
-            if end > read_length {
-                if paired_ended == true && ((end-read_length)..end).contains(&pos) {
+            if end > effective_read_len {
+                if paired_ended && ((end-effective_read_len)..end).contains(&pos) {
                     let var_pos = (end - 1) - pos;
                     read2_variants.insert(var_pos, variant);
                     reads2_flagged.push(var_pos);
@@ -115,19 +123,19 @@ pub fn write_block_fastq<T: Write, W: Write> (
         let abs_end = end + ref_start;
         let base_name = format!("{}_{:010}_{:010}", read_name_prefix, abs_start, abs_end);
 
-        let r2_start = if paired_ended && abs_end >= read_length {
-            abs_end - read_length
+        let r2_start = if paired_ended && abs_end >= effective_read_len {
+            abs_end - effective_read_len
         } else {
             0
         };
         let tlen = if paired_ended { (abs_end - abs_start) as i32 } else { 0 };
 
-        let quality_scores_1 = quality_score_model.generate_quality_scores(read_length, rng)?;
+        let quality_scores_1 = quality_score_model.generate_quality_scores(effective_read_len, rng)?;
         let r1_record = match generate_read(
             &fragment,
             &reads1_flagged,
             &read1_variants,
-            read_length,
+            effective_read_len,
             format!("{}/1", base_name),
             Strand::Forward,
             quality_scores_1,
@@ -152,15 +160,15 @@ pub fn write_block_fastq<T: Write, W: Write> (
         }
 
         if paired_ended {
-            let quality_scores_2 = quality_score_model.generate_quality_scores(read_length, rng)?;
-            let r2_pos = if abs_end >= read_length { abs_end - read_length } else { 0 };
+            let quality_scores_2 = quality_score_model.generate_quality_scores(effective_read_len, rng)?;
+            let r2_pos = if abs_end >= effective_read_len { abs_end - effective_read_len } else { 0 };
             let tlen_r2 = -((abs_end - abs_start) as i32);
 
             let r2_record = match generate_read(
                 &reverse_complement(fragment),
                 &reads2_flagged,
                 &read2_variants,
-                read_length,
+                effective_read_len,
                 format!("{}/2", base_name),
                 Strand::Reverse,
                 quality_scores_2,
@@ -562,7 +570,7 @@ mod tests {
         write_block_fastq(
             fragments, &mutated_map, &block, false,
             &mut buf1, &mut buf2,
-            10, "chr1",
+            10, false, "chr1",
             &quality_model, &seq_err_model, &mut rng,
             None,
         ).unwrap();

--- a/rneat/src/gen_reads/mod.rs
+++ b/rneat/src/gen_reads/mod.rs
@@ -192,12 +192,12 @@ mod tests {
         assert_eq!(count, 0, "Expected no reads when BED references only unknown contigs, got {count}");
     }
 
-    /// When produce_fastq=false and produce_bam=true, read staging only happens inside
-    /// the produce_fastq block. The BAM is therefore header-only (0 records) but must
-    /// still be a valid, readable file. This test locks in that behavior so any future
-    /// change to stage reads regardless of produce_fastq will be caught.
+    /// When produce_fastq=false and produce_bam=true, reads must still be generated and
+    /// staged into the BAM body writer. The output BAM must be a valid, non-empty,
+    /// coordinate-sorted file — identical in record count to a paired FASTQ run with the
+    /// same seed and coverage.
     #[test]
-    fn test_bam_only_no_fastq_produces_readable_empty_bam() {
+    fn test_bam_only_no_fastq_produces_records() {
         let out = tempdir().unwrap();
 
         let mut yaml = NamedTempFile::new().unwrap();
@@ -211,8 +211,6 @@ mod tests {
         ).unwrap();
         let config = RunConfiguration::from_yaml_file(&yaml.path().to_path_buf()).unwrap();
         let bam_path = config.output_bam.clone().unwrap();
-        // The config builder sets output_fastq_1 for single-ended runs unconditionally;
-        // what matters is that the FASTQ file is never written to disk.
         let fastq_path = config.output_fastq_1.clone();
 
         run(config);
@@ -222,19 +220,24 @@ mod tests {
                 "FASTQ file must not be created when produce_fastq=false");
         }
 
-        assert!(bam_path.exists(), "BAM file must exist even with produce_fastq=false");
+        assert!(bam_path.exists(), "BAM file must exist with produce_bam=true");
 
-        // Verify the file is a structurally valid BAM (readable header + alignment section).
-        // Record count is 0 because staging happens inside the produce_fastq block.
         let mut reader = bam::io::Reader::new(std::fs::File::open(&bam_path).unwrap());
         let header = reader.read_header().unwrap();
         let n_ref_seqs = header.reference_sequences().len();
         assert_eq!(n_ref_seqs, 8,
             "H1N1 BAM header should list 8 reference sequences, got {n_ref_seqs}");
 
-        let record_count = reader.records().count();
-        assert_eq!(record_count, 0,
-            "expected 0 BAM records when produce_fastq=false (staging skipped), got {record_count}");
+        let positions = bam_positions(&bam_path);
+        assert!(!positions.is_empty(),
+            "BAM must contain records when produce_bam=true even if produce_fastq=false");
+
+        // Records must be in coordinate-sorted order.
+        for window in positions.windows(2) {
+            assert!(window[0] <= window[1],
+                "BAM not coordinate-sorted in BAM-only mode: {:?} followed by {:?}",
+                window[0], window[1]);
+        }
     }
 
     /// Running with an explicit num_threads exercises the ThreadPoolBuilder path in

--- a/rneat/src/gen_reads/utils/config.rs
+++ b/rneat/src/gen_reads/utils/config.rs
@@ -75,6 +75,9 @@ pub struct RunConfiguration {
     pub(crate) gc_bias_normalize_coverage: bool,
     // maximum threads for parallel contig processing (None = rayon default = all cores)
     pub num_threads: Option<usize>,
+    // when true, fragments shorter than read_len are kept and produce truncated reads
+    // (long-read platforms); when false, such fragments are discarded (short-read default)
+    pub long_reads: bool,
 }
 
 // The config builder allows us to construct a config in multiple different ways, depending
@@ -133,6 +136,7 @@ impl ConfigBuilder {
                     gc_bias_model: None,
                     gc_bias_normalize_coverage: true,
                     num_threads: None,
+                    long_reads: false,
                 }
             },
             None => {
@@ -503,6 +507,16 @@ impl RunConfiguration {
                             }
                         }
                     },
+                    "long_reads" => {
+                        match value.as_bool() {
+                            Some(lr) => configuration.long_reads = lr,
+                            None => {
+                                return Err(GenerateReadsError::ConfigReadError(
+                                    "long_reads".to_string(), "boolean".to_string()
+                                ))
+                            }
+                        }
+                    },
                     _ => continue,
                 },
             }
@@ -531,6 +545,9 @@ impl RunConfiguration {
         }
         info!("  >ploidy: {}", &self.ploidy);
         info!("  >paired ended: {}", &self.paired_ended);
+        if self.long_reads {
+            info!("  >long reads mode: enabled (short fragments produce truncated reads)");
+        }
         if self.overwrite_output {
             warn!("Overwriting any existing files.")
         }
@@ -690,6 +707,7 @@ mod tests {
             gc_bias_model: None,
             gc_bias_normalize_coverage: true,
             num_threads: None,
+            long_reads: false,
         };
 
         println!("{:?}", test_configuration);

--- a/rneat/src/gen_reads/utils/generate_fragments.rs
+++ b/rneat/src/gen_reads/utils/generate_fragments.rs
@@ -284,8 +284,10 @@ fn cover_dataset(
     rng.shuffle_in_place(&mut fragment_pool)?;
     let mut cover_fragment_pool = VecDeque::from(fragment_pool);
 
+    let pool_size = cover_fragment_pool.len();
     let mut fragment_set: Vec<(usize, usize)> = Vec::with_capacity(target_count);
     let mut start = (rng.rand_int()? as usize) % (read_length / 4).max(1);
+    let mut non_placing_streak = 0usize;
 
     while fragment_set.len() < target_count {
         let fragment_length = cover_fragment_pool.pop_front().unwrap();
@@ -295,8 +297,25 @@ fn cover_dataset(
         if temp_end > span_length {
             // Restart from the beginning of the contig for the next sweep.
             start = 0;
+            // Only count fragments that can NEVER fit (length > span), not fragments
+            // that merely overshot from a high start position and will fit after restart.
+            if fragment_length > span_length {
+                non_placing_streak += 1;
+                // If we've seen pool_size consecutive fragments that are each individually
+                // larger than the span, every fragment in the pool is too large — break.
+                if non_placing_streak >= pool_size {
+                    debug!(
+                        "All fragments exceed span of {} bp; stopping early with {} fragments placed.",
+                        span_length, fragment_set.len()
+                    );
+                    break;
+                }
+            } else {
+                non_placing_streak = 0;
+            }
             continue;
         }
+        non_placing_streak = 0;
 
         fragment_set.push((start + read_start, temp_end + read_start));
         let wildcard = (rng.rand_u32()? % (read_length as u32 / 4).max(1)) as usize;
@@ -684,5 +703,23 @@ mod tests {
             "Expected {num_frags_expected} fragments despite high rejection rate, got {}",
             result.len()
         );
+    }
+
+    #[test]
+    fn test_cover_dataset_fragment_larger_than_span_terminates() {
+        // Regression test: when every fragment in the pool is larger than the contig,
+        // cover_dataset must terminate rather than loop forever.
+        // Mirrors the yeast long-read scenario: fragment_mean=30000, small scaffold.
+        let span_length = 5_000;
+        let read_length = 1_000;
+        let coverage = 5;
+        // Pool of fragments all larger than the span.
+        let fragment_pool = vec![30_000_usize; 10];
+        let mut rng = NeatRng::new_from_seed(&vec!["termination-test".to_string()]).unwrap();
+
+        let result = cover_dataset(span_length, read_length, 0, fragment_pool, coverage, &mut rng).unwrap();
+
+        // No fragments should be placed (none can fit), but the call must return.
+        assert!(result.is_empty(), "No fragments should be placed when all exceed span");
     }
 }

--- a/rneat/src/gen_reads/utils/generate_fragments.rs
+++ b/rneat/src/gen_reads/utils/generate_fragments.rs
@@ -50,13 +50,20 @@ pub fn generate_fragments(
         return Ok(Vec::new())
     }
 
-    let num_frags = sequence_length.saturating_mul(coverage) / read_length;
+    // Each paired-end fragment produces two reads (R1 + R2), so halve the fragment count
+    // so that mean per-base read depth matches the requested coverage value.
+    let num_frags = if paired_ended {
+        sequence_length.saturating_mul(coverage) / (2 * read_length).max(1)
+    } else {
+        sequence_length.saturating_mul(coverage) / read_length
+    };
     if paired_ended {
         // For paired-end reads the physical fragment length (insert size) determines spacing.
         // Keep sampling until num_frags valid fragments are collected so that the pool has
         // full size diversity even when the model's distribution overlaps with read_length.
         let max_attempts = num_frags.saturating_mul(10);
         let mut attempts = 0;
+        fragment_pool.reserve(num_frags);
         while fragment_pool.len() < num_frags && attempts < max_attempts {
             let frag = fragment_model.generate_fragment(rng.random()?)?;
             // In long-read mode accept all fragments; in short-read mode discard those
@@ -88,9 +95,9 @@ pub fn generate_fragments(
     let fragments: Vec<(usize, usize)> = cover_dataset(
         sequence_length,
         read_length,
+        num_frags,
         start,
         fragment_pool,
-        coverage,
         rng
     )?;
 
@@ -202,6 +209,7 @@ pub fn generate_weighted_fragments(
     gc_bias_model: &GcBiasModel,
     fragment_model: &FragmentLengthModel,
     normalize: bool,
+    paired_ended: bool,
     long_reads: bool,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
@@ -228,7 +236,13 @@ pub fn generate_weighted_fragments(
     let n_valid_positions = prefix_sum.len() - 1;
     let mean_weight = total_weight / n_valid_positions as f64;
 
-    let num_frags_base = region_len.saturating_mul(coverage) / read_length;
+    // Same paired-end correction as generate_fragments: each fragment yields two reads,
+    // so halve the count so that mean per-base read depth matches requested coverage.
+    let num_frags_base = if paired_ended {
+        region_len.saturating_mul(coverage) / (2 * read_length).max(1)
+    } else {
+        region_len.saturating_mul(coverage) / read_length
+    };
     let num_frags = if normalize {
         let inflated = (num_frags_base as f64 / mean_weight).round() as usize;
         let cap = num_frags_base.saturating_mul(MAX_COVERAGE_MULTIPLIER);
@@ -285,16 +299,14 @@ pub fn generate_weighted_fragments(
 fn cover_dataset(
     span_length: usize,
     read_length: usize,
+    target_count: usize,
     read_start: usize,
     mut fragment_pool: Vec<usize>,
-    coverage: usize,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
-    // Place exactly (span_length * coverage / read_length) fragments so that mean depth
-    // equals the target regardless of inter-fragment jitter size.  Stopping on fragment
-    // count rather than sweep count means the wildcard gap can be proportional to
-    // read_length without reducing mean coverage.
-    let target_count = span_length.saturating_mul(coverage) / read_length;
+    // Places exactly target_count fragments so that mean depth equals the requested
+    // coverage. Stopping on fragment count rather than sweep count means the wildcard
+    // gap can be proportional to read_length without reducing mean coverage.
 
     rng.shuffle_in_place(&mut fragment_pool)?;
     let mut cover_fragment_pool = VecDeque::from(fragment_pool);
@@ -385,12 +397,13 @@ mod tests {
             "Cruel".to_string(),
             "World".to_string(),
         ]).unwrap();
+        let target_count = span_length * coverage / read_length;
         let cover = cover_dataset(
             span_length,
             read_length,
+            target_count,
             0,
             fragment_pool,
-            coverage,
             &mut rng
         ).unwrap();
         assert_eq!(cover[0], (0, 10))
@@ -407,16 +420,16 @@ mod tests {
             "Cruel".to_string(),
             "World".to_string(),
         ]).unwrap();
+        let target_count = span_length / read_length * coverage;
         let cover = cover_dataset(
             span_length,
             read_length,
+            target_count,
             0,
             fragment_pool,
-            coverage,
             &mut rng
         ).unwrap();
-        // target_count = span / read_length * coverage = 1000 fragments.
-        assert_eq!(cover.len(), span_length / read_length * coverage);
+        assert_eq!(cover.len(), target_count);
         // After a wrap the cursor resets to 0, so the sorted first fragment starts there.
         assert_eq!(cover[0], (0, 300));
         // All fragments must fit within the span and have the pool fragment length.
@@ -518,7 +531,9 @@ mod tests {
             &fragment_model,
             &mut rng,
         ).unwrap();
-        let expected = seq_len * coverage / read_length;
+        // Paired-end produces 2 reads per fragment, so fragment count is halved to keep
+        // per-base read depth equal to the requested coverage.
+        let expected = seq_len * coverage / (2 * read_length);
         assert!(!reads.is_empty());
         assert_eq!(reads.len(), expected, "Paired reads: expected {expected} fragments, got {}", reads.len());
         assert!(reads.iter().all(|&(s, e)| e <= seq_len && e > s),
@@ -532,7 +547,7 @@ mod tests {
         let seq_len = 50_000_usize;
         let read_length = 100;
         let coverage = 2;
-        let num_frags = seq_len * coverage / read_length;
+        let num_frags = seq_len * coverage / (2 * read_length);
         let mut rng = NeatRng::new_from_seed(&vec!["pool-fill-test".to_string()]).unwrap();
         let fragment_model = FragmentLengthModel::new_normal(600.0, 30.0).unwrap();
         let reads = generate_fragments(
@@ -556,7 +571,7 @@ mod tests {
 
         let result = generate_weighted_fragments(
             &sequence_block, 0, 50, 30, 10, 5,
-            &GcBiasModel::default(), &fragment_model, false, false, &mut rng,
+            &GcBiasModel::default(), &fragment_model, false, false, false, &mut rng,
         ).unwrap();
 
         assert!(result.is_empty(), "Region too short should return no fragments");
@@ -573,7 +588,7 @@ mod tests {
         let mut rng = make_rng();
 
         let result = generate_weighted_fragments(
-            &sequence_block, 0, 500, 10, 0, 5, &model, &fragment_model, false, false, &mut rng,
+            &sequence_block, 0, 500, 10, 0, 5, &model, &fragment_model, false, false, false, &mut rng,
         ).unwrap();
 
         assert!(result.is_empty(), "All-zero-weight region should produce no fragments");
@@ -589,7 +604,7 @@ mod tests {
 
         let fragments = generate_weighted_fragments(
             &sequence_block, 0, 2000, 100, 0, 10,
-            &GcBiasModel::default(), &fragment_model, false, false, &mut rng,
+            &GcBiasModel::default(), &fragment_model, false, false, false, &mut rng,
         ).unwrap();
 
         assert!(!fragments.is_empty(), "Valid region with uniform model should produce fragments");
@@ -606,7 +621,7 @@ mod tests {
 
         let fragments = generate_weighted_fragments(
             &sequence_block, region_start, region_end, 100, 0, 5,
-            &GcBiasModel::default(), &fragment_model, false, false, &mut rng,
+            &GcBiasModel::default(), &fragment_model, false, false, false, &mut rng,
         ).unwrap();
 
         for (start, end) in &fragments {
@@ -625,13 +640,13 @@ mod tests {
         let mut rng1 = make_rng();
         let run1 = generate_weighted_fragments(
             &sequence_block, 0, 2000, 100, 0, 5,
-            &GcBiasModel::default(), &fragment_model, false, false, &mut rng1,
+            &GcBiasModel::default(), &fragment_model, false, false, false, &mut rng1,
         ).unwrap();
 
         let mut rng2 = make_rng();
         let run2 = generate_weighted_fragments(
             &sequence_block, 0, 2000, 100, 0, 5,
-            &GcBiasModel::default(), &fragment_model, false, false, &mut rng2,
+            &GcBiasModel::default(), &fragment_model, false, false, false, &mut rng2,
         ).unwrap();
 
         assert_eq!(run1, run2, "Same seed must produce identical fragment sets");
@@ -651,12 +666,12 @@ mod tests {
 
         let mut rng = make_rng();
         let unnormalized = generate_weighted_fragments(
-            &sequence_block, 0, 10000, 100, 0, 10, &model, &fragment_model, false, false, &mut rng,
+            &sequence_block, 0, 10000, 100, 0, 10, &model, &fragment_model, false, false, false, &mut rng,
         ).unwrap();
 
         let mut rng = make_rng();
         let normalized = generate_weighted_fragments(
-            &sequence_block, 0, 10000, 100, 0, 10, &model, &fragment_model, true, false, &mut rng,
+            &sequence_block, 0, 10000, 100, 0, 10, &model, &fragment_model, true, false, false, &mut rng,
         ).unwrap();
 
         assert!(
@@ -684,7 +699,7 @@ mod tests {
         let mut rng = make_rng();
         let result = generate_weighted_fragments(
             &sequence_block, 0, sequence_block.sequence.len(),
-            read_len, 0, target_coverage, &model, &fragment_model, true, false, &mut rng,
+            read_len, 0, target_coverage, &model, &fragment_model, true, false, false, &mut rng,
         ).unwrap();
 
         let base_frags = (sequence_block.sequence.len() / read_len) * target_coverage;
@@ -714,7 +729,7 @@ mod tests {
 
         let result = generate_weighted_fragments(
             &sequence_block, region_start, region_end, read_length, 0, coverage,
-            &GcBiasModel::default(), &fragment_model, false, false, &mut rng,
+            &GcBiasModel::default(), &fragment_model, false, false, false, &mut rng,
         ).unwrap();
 
         assert_eq!(
@@ -736,7 +751,8 @@ mod tests {
         let fragment_pool = vec![30_000_usize; 10];
         let mut rng = NeatRng::new_from_seed(&vec!["termination-test".to_string()]).unwrap();
 
-        let result = cover_dataset(span_length, read_length, 0, fragment_pool, coverage, &mut rng).unwrap();
+        let target_count = span_length * coverage / read_length;
+        let result = cover_dataset(span_length, read_length, target_count, 0, fragment_pool, &mut rng).unwrap();
 
         // No fragments should be placed (none can fit), but the call must return.
         assert!(result.is_empty(), "No fragments should be placed when all exceed span");

--- a/rneat/src/gen_reads/utils/generate_fragments.rs
+++ b/rneat/src/gen_reads/utils/generate_fragments.rs
@@ -22,6 +22,7 @@ pub fn generate_fragments(
     start: usize,
     coverage: usize,
     paired_ended: bool,
+    long_reads: bool,
     fragment_model: &FragmentLengthModel,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
@@ -31,13 +32,20 @@ pub fn generate_fragments(
     // coverage: the average depth of coverage for this run
     // paired_ended: when false, read_length is used as the fragment length so that
     //   coverage is computed in read-length steps rather than insert-size steps.
+    // long_reads: when true, fragments shorter than read_length are accepted and produce
+    //   truncated reads (appropriate for PacBio HiFi / ONT paired-end simulation).
     // rng: the random number generator for the run
     // Returns:
     // A vector of (start, end) pairs representing fragment coordinates.
     let mut fragment_pool: Vec<usize> = Vec::new();
-    // First thing we'll do is throw out regions where we can't get a full read.
-    // Adding the 2 * max_del_len should ensure we are sufficiently padded.
-    if sequence_length <= (read_length + (max_del_len * 2)) {
+    // For long-read paired-end mode the region only needs deletion padding; for all other
+    // modes the full read_length must fit.
+    let min_region = if long_reads && paired_ended {
+        max_del_len * 2
+    } else {
+        read_length + max_del_len * 2
+    };
+    if sequence_length <= min_region {
         debug!("Sequence length was too short, maybe because of a small bed region.");
         return Ok(Vec::new())
     }
@@ -51,7 +59,9 @@ pub fn generate_fragments(
         let mut attempts = 0;
         while fragment_pool.len() < num_frags && attempts < max_attempts {
             let frag = fragment_model.generate_fragment(rng.random()?)?;
-            if frag >= read_length {
+            // In long-read mode accept all fragments; in short-read mode discard those
+            // shorter than read_length (adapter read-through is out of scope here).
+            if long_reads || frag >= read_length {
                 fragment_pool.push(frag);
             }
             attempts += 1;
@@ -192,12 +202,14 @@ pub fn generate_weighted_fragments(
     gc_bias_model: &GcBiasModel,
     fragment_model: &FragmentLengthModel,
     normalize: bool,
+    long_reads: bool,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
     const MAX_COVERAGE_MULTIPLIER: usize = 100;
 
     let region_len = region_end.saturating_sub(region_start);
-    if region_len <= read_length + max_del_len * 2 {
+    let min_region = if long_reads { max_del_len * 2 } else { read_length + max_del_len * 2 };
+    if region_len <= min_region {
         debug!("Region too short for weighted fragment generation.");
         return Ok(Vec::new());
     }
@@ -237,7 +249,7 @@ pub fn generate_weighted_fragments(
     }
 
     // Keep sampling until num_frags fragments are placed so that fragment model
-    // rejection (frag_len < read_length) and edge clamping don't silently reduce coverage.
+    // rejection and edge clamping don't silently reduce coverage.
     let max_attempts = num_frags.saturating_mul(10);
     let mut attempts = 0;
     let mut fragments = Vec::with_capacity(num_frags);
@@ -246,11 +258,14 @@ pub fn generate_weighted_fragments(
         let start = region_start + offset;
         let frag_len = fragment_model.generate_fragment(rng.random()?)?;
         attempts += 1;
-        if frag_len < read_length {
+        if !long_reads && frag_len < read_length {
             continue;
         }
         let end = (start + frag_len).min(region_end);
-        if end - start < read_length {
+        if end == start {
+            continue;
+        }
+        if !long_reads && end - start < read_length {
             continue;
         }
         fragments.push((start, end));
@@ -425,6 +440,7 @@ mod tests {
             0,
             coverage,
             false,
+            false,
             &fragment_model,
             &mut rng,
         ).unwrap();
@@ -453,6 +469,7 @@ mod tests {
             0,
             coverage,
             false,
+            false,
             &fragment_model,
             &mut rng,
         ).unwrap();
@@ -470,6 +487,7 @@ mod tests {
             0,
             0,
             coverage,
+            false,
             false,
             &fragment_model,
             &mut rng2,
@@ -496,6 +514,7 @@ mod tests {
             0,
             coverage,
             true,
+            false,
             &fragment_model,
             &mut rng,
         ).unwrap();
@@ -517,7 +536,7 @@ mod tests {
         let mut rng = NeatRng::new_from_seed(&vec!["pool-fill-test".to_string()]).unwrap();
         let fragment_model = FragmentLengthModel::new_normal(600.0, 30.0).unwrap();
         let reads = generate_fragments(
-            seq_len, read_length, 0, 0, coverage, true, &fragment_model, &mut rng,
+            seq_len, read_length, 0, 0, coverage, true, false, &fragment_model, &mut rng,
         ).unwrap();
         // When rejection is near-zero the pool is full, so coverage should match exactly.
         assert_eq!(reads.len(), num_frags,
@@ -537,7 +556,7 @@ mod tests {
 
         let result = generate_weighted_fragments(
             &sequence_block, 0, 50, 30, 10, 5,
-            &GcBiasModel::default(), &fragment_model, false, &mut rng,
+            &GcBiasModel::default(), &fragment_model, false, false, &mut rng,
         ).unwrap();
 
         assert!(result.is_empty(), "Region too short should return no fragments");
@@ -554,7 +573,7 @@ mod tests {
         let mut rng = make_rng();
 
         let result = generate_weighted_fragments(
-            &sequence_block, 0, 500, 10, 0, 5, &model, &fragment_model, false, &mut rng,
+            &sequence_block, 0, 500, 10, 0, 5, &model, &fragment_model, false, false, &mut rng,
         ).unwrap();
 
         assert!(result.is_empty(), "All-zero-weight region should produce no fragments");
@@ -570,7 +589,7 @@ mod tests {
 
         let fragments = generate_weighted_fragments(
             &sequence_block, 0, 2000, 100, 0, 10,
-            &GcBiasModel::default(), &fragment_model, false, &mut rng,
+            &GcBiasModel::default(), &fragment_model, false, false, &mut rng,
         ).unwrap();
 
         assert!(!fragments.is_empty(), "Valid region with uniform model should produce fragments");
@@ -587,7 +606,7 @@ mod tests {
 
         let fragments = generate_weighted_fragments(
             &sequence_block, region_start, region_end, 100, 0, 5,
-            &GcBiasModel::default(), &fragment_model, false, &mut rng,
+            &GcBiasModel::default(), &fragment_model, false, false, &mut rng,
         ).unwrap();
 
         for (start, end) in &fragments {
@@ -606,13 +625,13 @@ mod tests {
         let mut rng1 = make_rng();
         let run1 = generate_weighted_fragments(
             &sequence_block, 0, 2000, 100, 0, 5,
-            &GcBiasModel::default(), &fragment_model, false, &mut rng1,
+            &GcBiasModel::default(), &fragment_model, false, false, &mut rng1,
         ).unwrap();
 
         let mut rng2 = make_rng();
         let run2 = generate_weighted_fragments(
             &sequence_block, 0, 2000, 100, 0, 5,
-            &GcBiasModel::default(), &fragment_model, false, &mut rng2,
+            &GcBiasModel::default(), &fragment_model, false, false, &mut rng2,
         ).unwrap();
 
         assert_eq!(run1, run2, "Same seed must produce identical fragment sets");
@@ -632,12 +651,12 @@ mod tests {
 
         let mut rng = make_rng();
         let unnormalized = generate_weighted_fragments(
-            &sequence_block, 0, 10000, 100, 0, 10, &model, &fragment_model, false, &mut rng,
+            &sequence_block, 0, 10000, 100, 0, 10, &model, &fragment_model, false, false, &mut rng,
         ).unwrap();
 
         let mut rng = make_rng();
         let normalized = generate_weighted_fragments(
-            &sequence_block, 0, 10000, 100, 0, 10, &model, &fragment_model, true, &mut rng,
+            &sequence_block, 0, 10000, 100, 0, 10, &model, &fragment_model, true, false, &mut rng,
         ).unwrap();
 
         assert!(
@@ -665,7 +684,7 @@ mod tests {
         let mut rng = make_rng();
         let result = generate_weighted_fragments(
             &sequence_block, 0, sequence_block.sequence.len(),
-            read_len, 0, target_coverage, &model, &fragment_model, true, &mut rng,
+            read_len, 0, target_coverage, &model, &fragment_model, true, false, &mut rng,
         ).unwrap();
 
         let base_frags = (sequence_block.sequence.len() / read_len) * target_coverage;
@@ -695,7 +714,7 @@ mod tests {
 
         let result = generate_weighted_fragments(
             &sequence_block, region_start, region_end, read_length, 0, coverage,
-            &GcBiasModel::default(), &fragment_model, false, &mut rng,
+            &GcBiasModel::default(), &fragment_model, false, false, &mut rng,
         ).unwrap();
 
         assert_eq!(

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -453,6 +453,7 @@ fn process_contig(
                     frag_start,
                     ctx.config.coverage,
                     ctx.config.paired_ended,
+                    ctx.config.long_reads,
                     ctx.fragment_length_model,
                     &mut rng,
                 )?
@@ -467,6 +468,7 @@ fn process_contig(
                     ctx.gc_bias_model,
                     ctx.fragment_length_model,
                     ctx.config.gc_bias_normalize_coverage,
+                    ctx.config.long_reads,
                     &mut rng,
                 )?
             };
@@ -526,6 +528,7 @@ fn process_contig(
                 &mut buffer1,
                 &mut buffer2,
                 ctx.config.read_len,
+                ctx.config.long_reads,
                 &read_name_prefix,
                 ctx.quality_score_model,
                 ctx.seq_error_model,
@@ -546,6 +549,7 @@ fn process_contig(
                 &mut buffer1,
                 &mut buffer2,
                 ctx.config.read_len,
+                ctx.config.long_reads,
                 &read_name_prefix,
                 ctx.quality_score_model,
                 ctx.seq_error_model,

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -468,6 +468,7 @@ fn process_contig(
                     ctx.gc_bias_model,
                     ctx.fragment_length_model,
                     ctx.config.gc_bias_normalize_coverage,
+                    ctx.config.paired_ended,
                     ctx.config.long_reads,
                     &mut rng,
                 )?

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -494,6 +494,8 @@ fn process_contig(
         None
     };
 
+    let read_name_prefix = format!("RNEAT_generated_{}", current_block.contig);
+
     if ctx.config.produce_fastq {
         let mut file_to_write_1 = PathBuf::from(ctx.working_dir);
         file_to_write_1.push(format!(
@@ -505,7 +507,6 @@ fn process_contig(
         let file1 = append_to_file(&file_to_write_1)?;
         let writer1 = BufWriter::new(&file1);
         let mut buffer1 = GzEncoder::new(writer1, Compression::default());
-        let read_name_prefix = format!("RNEAT_generated_{}", current_block.contig);
         let bam_stager: Option<&mut dyn BamRecordStager> =
             bam_body_writer.as_mut().map(|w| w as &mut dyn BamRecordStager);
         if ctx.config.paired_ended {
@@ -558,6 +559,31 @@ fn process_contig(
             )?;
             contig_files_r1.push(file_to_write_1);
         }
+    } else if ctx.config.produce_bam {
+        // BAM-only: generate reads and stage them into the BAM body writer.
+        // The FASTQ buffers drain into null sinks and are discarded.
+        let bam_stager: Option<&mut dyn BamRecordStager> =
+            bam_body_writer.as_mut().map(|w| w as &mut dyn BamRecordStager);
+        let null1: VectorBuffer = VectorBuffer::new();
+        let null2: VectorBuffer = VectorBuffer::new();
+        let mut buf1 = GzEncoder::new(null1, Compression::default());
+        let mut buf2 = GzEncoder::new(null2, Compression::default());
+        debug!("BAM-only: generating reads for {}", contig_name);
+        write_block_fastq(
+            block_fragments,
+            &mutated_map,
+            &current_block,
+            ctx.config.paired_ended,
+            &mut buf1,
+            &mut buf2,
+            ctx.config.read_len,
+            ctx.config.long_reads,
+            &read_name_prefix,
+            ctx.quality_score_model,
+            ctx.seq_error_model,
+            &mut rng,
+            bam_stager,
+        )?;
     }
 
     // Flush and finalize the BAM body file; the bgzf EOF is written on drop.

--- a/template_config/filter_reads_template.yml
+++ b/template_config/filter_reads_template.yml
@@ -1,12 +1,14 @@
-# You must input a bed file with valid regions 
+# You must input a bed file with valid regions
 # for the fastq and/or vcf files to be filtered
 bed_file: # required
-# You must input a list of files to filter. 
+# You must input a list of files to filter.
 # The list can be one file.
 files_to_filter: [
   # required, in list form
 ]
 # This is the filter key that will be appended to the end of the filename
-# before the extensions. The default is "_filtered" i.e., 
-# "output_file.vcf.gz" becomes "output_file_filtered.vcf.gz"
+# before the extensions. The default is "_filter" i.e.,
+# "output_file.vcf.gz" becomes "output_file_filter.vcf.gz"
 filter_key: .
+# Set to true to overwrite existing output files. false will error on collision. (default: false)
+overwrite_output: false

--- a/template_config/gen_reads_template.yml
+++ b/template_config/gen_reads_template.yml
@@ -137,6 +137,24 @@ gc_bias_model: .
 # correct this undersampling. If you prefer to accept lower coverage, then set this to false
 gc_bias_normalize_coverage: true
 
+# --------------- long reads ---------------
+
+# Set to true when simulating long-read platforms (PacBio HiFi, Oxford Nanopore).
+# When true, fragments sampled from the fragment model that are shorter than read_len are
+# kept rather than discarded, and the resulting read is truncated to the actual fragment
+# length. This reproduces the realistic read-length distribution seen in real long-read
+# datasets, where size selection is imperfect and a tail of shorter reads is always present.
+#
+# When false (the default, appropriate for Illumina short reads), fragments shorter than
+# read_len are rejected. For Illumina, the correct physical behavior for short fragments
+# is adapter read-through (full-length reads padded with adapter sequence), which is a
+# separate concern outside the scope of this simulator; discarding them is the standard
+# approach used by short-read simulators.
+#
+# long_reads requires paired_ended: true and a configured fragment_mean / fragment_model.
+# (default: false)
+long_reads: false
+
 # --------------- performance ---------------
 
 # Maximum number of threads to use for parallel contig processing.

--- a/template_config/gen_reads_template.yml
+++ b/template_config/gen_reads_template.yml
@@ -58,8 +58,8 @@ produce_vcf: false
 
 # Produce a BAM file whose reads match the FASTQ exactly (same sequence, quality scores,
 # variants, and sequencing errors applied). CIGAR strings reflect both genomic variants
-# and sequencing error indels. Run `samtools sort` + `samtools index` before use with
-# most downstream tools. (default: false)
+# and sequencing error indels. The output is written in coordinate-sorted order, so
+# `samtools index` is all that is needed before use with downstream tools. (default: false)
 produce_bam: false
 
 # --------------- output location ---------------
@@ -158,7 +158,8 @@ long_reads: false
 # --------------- performance ---------------
 
 # Maximum number of threads to use for parallel contig processing.
-# Only applies when produce_bam is false — BAM output requires sequential processing.
+# Applies to all output modes including BAM — each contig writes to a private temp file
+# and a final pass assembles them in coordinate order.
 # Set to 1 to disable parallelism entirely. Omit (or set to .) to use all available cores.
 # (default: auto)
 num_threads: .


### PR DESCRIPTION
Tested the codebase with long read runs, to see if rneat could handle them. It did better than expected, but there are some slight peculiarities to the output. This was addressed via a separate process for handling long reads that allows smaller reads to be present in the dataset. We also updated the fastq section so that you can produce a BAM without a fastq. Temp fastq files are still written, but only used for bam creation.