### PR TITLE
Add binned quality scores support for modern Illumina platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,12 @@ max_reads: 0
 # optional: quality score ASCII offset; 33 for Illumina 1.8+/Sanger, 64 for older Illumina (default: 33)
 qual_offset: 33
 
+# optional: list of Q-score bins to quantize the learned model to (e.g. NovaSeq 6000 uses
+# [2, 12, 23, 37]). When set, each observed Q-score is snapped to its nearest bin before
+# the model is built, and gen-reads will emit only these values. Omit for a continuous model.
+# Bins must be < 94 and cannot include 31 (encodes to '@' under Phred+33).
+# binned_quality_bins: [2, 12, 23, 37]
+
 # optional: aligned BAM file to infer the SNP transition matrix from read-vs-reference mismatches.
 # The BAM must have MD tags. If your aligner did not add them, run:
 #   samtools calmd -b aligned.bam reference.fa > aligned_with_md.bam
@@ -428,6 +434,28 @@ A    C    G    T
 0.4  0.3  0.0  0.3
 0.3  0.3  0.4  0.0
 ```
+
+**Binned quality scores:**
+Modern Illumina platforms (NovaSeq 6000, NextSeq 1000/2000, the simplified MiSeq reporting modes) no longer emit the full continuous Q0–Q40 range. Instead, they quantize each per-base quality into a small set of discrete bins — for example, NovaSeq 6000 emits only `{2, 12, 23, 37}`. Set `binned_quality_bins` in the config to mimic this behaviour:
+
+```yaml
+binned_quality_bins: [2, 12, 23, 37]
+```
+
+When this field is set, `gen-seq-error-model` snaps each observed Q-score from the input FASTQ to its nearest bin (ties round down) before learning seed, transition, and global-frequency counts. The resulting model file is flagged `binned_scores: true` and lists the bin values as its `quality_score_options`. `gen-reads` then samples only those bin values when emitting reads — no extra flag needed on the read-generation side.
+
+Validation rules:
+- Bins must be non-empty integers in `[0, 94)` (entries are sorted and deduped automatically).
+- Value `31` is rejected — under Phred+33 it encodes to `@`, which would corrupt FASTQ output. If you need a bin near Q31, pick 30 or 32.
+- Bins with no observed counts in the training FASTQ are still kept in `quality_score_options`; their transition rows fall back to a uniform distribution, and a warning is logged listing the empty bins.
+
+Some common platform bin sets (consult your sequencer's documentation for the authoritative list):
+
+| Platform                       | Suggested bins     |
+|--------------------------------|--------------------|
+| NovaSeq 6000 (4-bin)           | `[2, 12, 23, 37]`  |
+| NextSeq 1000/2000 (3-bin)      | `[2, 15, 35]`      |
+| NextSeq 1000/2000 (4-bin)      | `[2, 12, 23, 37]`  |
 
 Generating a GC Bias Model
 ====================

--- a/common/src/models/quality_scores.rs
+++ b/common/src/models/quality_scores.rs
@@ -44,6 +44,8 @@ pub enum QualityModelError {
     IoError(#[from] io::Error),
     #[error("Serde error building default model: {0}")]
     SerdeError(#[from] serde_json::Error),
+    #[error("Invalid quality model configuration: {0}")]
+    InvalidConfiguration(String),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -242,7 +244,17 @@ impl QualityScoreModel {
         read_length: usize,
         seed_weights: Vec<f64>,
         trans_weights: Vec<Vec<Vec<f64>>>,
+        is_binned: bool,
     ) -> Result<Self, QualityModelError> {
+        // Phred+33 maps score 31 to '@', which the FASTQ writer treats specially as a seed
+        // (see generate_quality_scores). A binned model that included 31 would silently break
+        // the binning invariant when the seed-`@` workaround fires, so reject it here. Config
+        // validation in gen_seq_error_model also catches this earlier with a friendlier message.
+        if is_binned && quality_score_options.iter().any(|&q| q == 31) {
+            return Err(QualityModelError::InvalidConfiguration(
+                "binned quality model cannot include score 31 ('@' under Phred+33)".to_string(),
+            ));
+        }
         // seed_dist values are actual quality scores (generate_quality_scores pushes the sampled
         // value directly); distros_from_one values are indices into quality_score_options
         // (generate_quality_scores indexes quality_score_options[sampled_index]).
@@ -267,7 +279,7 @@ impl QualityScoreModel {
         }
         Ok(QualityScoreModel {
             quality_score_options,
-            binned_scores: false,
+            binned_scores: is_binned,
             assumed_read_length: read_length,
             seed_dist,
             distros_from_one,
@@ -393,10 +405,11 @@ mod tests {
             vec![vec![1.0, 1.0], vec![1.0, 0.0]],
         ];
         let model = QualityScoreModel::from_counts(
-            options.clone(), 3, seed_weights, trans_weights,
+            options.clone(), 3, seed_weights, trans_weights, false,
         ).unwrap();
         assert_eq!(model.quality_score_options, options);
         assert_eq!(model.assumed_read_length, 3);
+        assert!(!model.binned_scores);
         assert_eq!(model.distros_from_one.len(), 2);
         assert_eq!(model.distros_from_one[0].len(), 2);
         // seed samples actual quality scores
@@ -423,7 +436,7 @@ mod tests {
             vec![vec![2.0, 1.0], vec![0.0, 0.0]],
         ];
         let model = QualityScoreModel::from_counts(
-            options.clone(), 2, seed_weights, trans_weights,
+            options.clone(), 2, seed_weights, trans_weights, false,
         ).unwrap();
         // distros_from_one[pos=0][prev_idx=1] is the formerly-zero row for Q40
         let zero_row = &model.distros_from_one[0][1];
@@ -438,6 +451,53 @@ mod tests {
     }
 
     #[test]
+    fn test_binned_model_generates_only_bins() {
+        // Build a binned model with NovaSeq-style bins and verify that every sampled score
+        // falls within the bin set across many draws and across read-length remapping.
+        let bins = vec![2usize, 12, 23, 37];
+        let n = bins.len();
+        let seed_weights = vec![1.0; n];
+        let uniform_row = vec![1.0; n];
+        let trans_weights = vec![
+            vec![uniform_row.clone(); n],
+            vec![uniform_row.clone(); n],
+            vec![uniform_row.clone(); n],
+        ];
+        let model = QualityScoreModel::from_counts(
+            bins.clone(), 4, seed_weights, trans_weights, true,
+        ).unwrap();
+        assert!(model.binned_scores);
+        assert_eq!(model.quality_score_options, bins);
+        let mut rng = NeatRng::new_from_seed(&vec!["binned".to_string()]).unwrap();
+        for _ in 0..250 {
+            let scores = model.generate_quality_scores(4, &mut rng).unwrap();
+            for &s in &scores {
+                assert!(bins.contains(&s), "binned model emitted non-bin score {s}");
+            }
+        }
+        // Also check the read-length-remap path emits only bins.
+        for _ in 0..250 {
+            let scores = model.generate_quality_scores(11, &mut rng).unwrap();
+            for &s in &scores {
+                assert!(bins.contains(&s), "binned model emitted non-bin score {s} under remap");
+            }
+        }
+    }
+
+    #[test]
+    fn test_from_counts_rejects_binned_with_thirty_one() {
+        let options = vec![2usize, 12, 31, 37];
+        let n = options.len();
+        let seed_weights = vec![1.0; n];
+        let uniform_row = vec![1.0; n];
+        let trans_weights = vec![vec![uniform_row.clone(); n]];
+        let result = QualityScoreModel::from_counts(
+            options, 2, seed_weights, trans_weights, true,
+        );
+        assert!(matches!(result, Err(QualityModelError::InvalidConfiguration(_))));
+    }
+
+    #[test]
     fn test_from_counts_generates_only_observed_scores() {
         // All scores produced by generate_quality_scores must be in quality_score_options.
         let options = vec![20usize, 30usize, 40usize];
@@ -449,7 +509,7 @@ mod tests {
             vec![uniform_row.clone(), uniform_row.clone(), uniform_row.clone()],
         ];
         let model = QualityScoreModel::from_counts(
-            options.clone(), 3, seed_weights, trans_weights,
+            options.clone(), 3, seed_weights, trans_weights, false,
         ).unwrap();
         let mut rng = NeatRng::new_from_seed(&vec!["t".to_string()]).unwrap();
         for _ in 0..50 {

--- a/common/src/models/sequencing_error_model.rs
+++ b/common/src/models/sequencing_error_model.rs
@@ -182,11 +182,17 @@ impl SequencingErrorModel {
     }
 
     pub fn generate_quality_scores(
-        &self, 
-        read_length: usize, 
+        &self,
+        read_length: usize,
         rng: &mut NeatRng
     ) -> Result<Vec<usize>, SeqModelError> {
         self.quality_score_model.generate_quality_scores(read_length, rng)
+    }
+
+    /// Borrow the inner quality-score model. Useful for tests and for callers that need
+    /// to inspect model metadata (e.g., `binned_scores`, `quality_score_options`).
+    pub fn quality_score_model(&self) -> &QualityScoreModel {
+        &self.quality_score_model
     }
 }
 

--- a/rneat/src/gen_seq_error_model/utils/config.rs
+++ b/rneat/src/gen_seq_error_model/utils/config.rs
@@ -11,6 +11,11 @@ pub struct RunConfiguration {
     pub overwrite_output: bool,
     pub max_reads: usize,
     pub qual_offset: usize,
+    /// Optional list of Q-score bins (e.g. `[2, 12, 23, 37]` for NovaSeq). When set,
+    /// learned scores are snapped to the nearest bin and the resulting model only
+    /// emits these values. Sorted/deduped at parse time. Value 31 is rejected
+    /// because it encodes to `@` under Phred+33.
+    pub binned_quality_bins: Option<Vec<usize>>,
     /// Optional aligned BAM file to infer the SNP transition matrix from read-vs-reference
     /// mismatches. Requires MD tags. Ignored if transition_matrix_file is also set.
     pub bam_file: Option<PathBuf>,
@@ -81,6 +86,45 @@ impl RunConfiguration {
             .and_then(|v| v.as_u64())
             .unwrap_or(33) as usize;
 
+        let binned_quality_bins = match scrape_config.get("binned_quality_bins") {
+            None => None,
+            Some(v) => {
+                let seq = v.as_sequence().ok_or_else(|| {
+                    GenSeqErrorModelError::ConfigurationError(
+                        "binned_quality_bins must be a YAML list of integers".to_string(),
+                    )
+                })?;
+                let mut bins: Vec<usize> = Vec::with_capacity(seq.len());
+                for elem in seq {
+                    let n = elem.as_u64().ok_or_else(|| {
+                        GenSeqErrorModelError::ConfigurationError(
+                            "binned_quality_bins entries must be non-negative integers".to_string(),
+                        )
+                    })?;
+                    bins.push(n as usize);
+                }
+                if bins.is_empty() {
+                    return Err(GenSeqErrorModelError::ConfigurationError(
+                        "binned_quality_bins must contain at least one value".to_string(),
+                    ));
+                }
+                if bins.iter().any(|&b| b >= 94) {
+                    return Err(GenSeqErrorModelError::ConfigurationError(
+                        "binned_quality_bins entries must be < 94".to_string(),
+                    ));
+                }
+                if bins.iter().any(|&b| b == 31) {
+                    return Err(GenSeqErrorModelError::ConfigurationError(
+                        "binned_quality_bins cannot include 31 (encodes to '@' under \
+                         Phred+33 and would corrupt FASTQ output)".to_string(),
+                    ));
+                }
+                bins.sort_unstable();
+                bins.dedup();
+                Some(bins)
+            }
+        };
+
         let bam_file = scrape_config
             .get("bam_file")
             .and_then(|v| v.as_str())
@@ -119,6 +163,7 @@ impl RunConfiguration {
             overwrite_output,
             max_reads,
             qual_offset,
+            binned_quality_bins,
             bam_file,
             transition_matrix_file,
         })
@@ -243,6 +288,86 @@ mod tests {
 
         let tmp = write_config(&format!(
             "fastq_file: {}\noutput_file: {}\noverwrite_output: true\nbam_file: /nonexistent/reads.bam\n",
+            fastq.display(), output.display()
+        ));
+        assert!(RunConfiguration::from(&tmp.path().to_path_buf()).is_err());
+    }
+
+    #[test]
+    fn test_binned_quality_bins_parsed_sorted_deduped() {
+        let dir = tempfile::tempdir().unwrap();
+        let fastq = make_fastq(&dir);
+        let output = dir.path().join("model.json.gz");
+
+        let tmp = write_config(&format!(
+            "fastq_file: {}\noutput_file: {}\noverwrite_output: true\nbinned_quality_bins: [37, 2, 23, 12, 12]\n",
+            fastq.display(), output.display()
+        ));
+        let config = RunConfiguration::from(&tmp.path().to_path_buf()).unwrap();
+        assert_eq!(config.binned_quality_bins, Some(vec![2, 12, 23, 37]));
+    }
+
+    #[test]
+    fn test_binned_quality_bins_absent_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let fastq = make_fastq(&dir);
+        let output = dir.path().join("model.json.gz");
+
+        let tmp = write_config(&format!(
+            "fastq_file: {}\noutput_file: {}\noverwrite_output: true\n",
+            fastq.display(), output.display()
+        ));
+        let config = RunConfiguration::from(&tmp.path().to_path_buf()).unwrap();
+        assert!(config.binned_quality_bins.is_none());
+    }
+
+    #[test]
+    fn test_binned_quality_bins_empty_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let fastq = make_fastq(&dir);
+        let output = dir.path().join("model.json.gz");
+
+        let tmp = write_config(&format!(
+            "fastq_file: {}\noutput_file: {}\noverwrite_output: true\nbinned_quality_bins: []\n",
+            fastq.display(), output.display()
+        ));
+        assert!(RunConfiguration::from(&tmp.path().to_path_buf()).is_err());
+    }
+
+    #[test]
+    fn test_binned_quality_bins_out_of_range_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let fastq = make_fastq(&dir);
+        let output = dir.path().join("model.json.gz");
+
+        let tmp = write_config(&format!(
+            "fastq_file: {}\noutput_file: {}\noverwrite_output: true\nbinned_quality_bins: [2, 12, 94]\n",
+            fastq.display(), output.display()
+        ));
+        assert!(RunConfiguration::from(&tmp.path().to_path_buf()).is_err());
+    }
+
+    #[test]
+    fn test_binned_quality_bins_thirty_one_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let fastq = make_fastq(&dir);
+        let output = dir.path().join("model.json.gz");
+
+        let tmp = write_config(&format!(
+            "fastq_file: {}\noutput_file: {}\noverwrite_output: true\nbinned_quality_bins: [2, 12, 31, 37]\n",
+            fastq.display(), output.display()
+        ));
+        assert!(RunConfiguration::from(&tmp.path().to_path_buf()).is_err());
+    }
+
+    #[test]
+    fn test_binned_quality_bins_non_list_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let fastq = make_fastq(&dir);
+        let output = dir.path().join("model.json.gz");
+
+        let tmp = write_config(&format!(
+            "fastq_file: {}\noutput_file: {}\noverwrite_output: true\nbinned_quality_bins: \"2,12,23,37\"\n",
             fastq.display(), output.display()
         ));
         assert!(RunConfiguration::from(&tmp.path().to_path_buf()).is_err());

--- a/rneat/src/gen_seq_error_model/utils/runner.rs
+++ b/rneat/src/gen_seq_error_model/utils/runner.rs
@@ -20,6 +20,24 @@ use crate::gen_seq_error_model::{
 
 const MAX_SCORE: usize = 94;
 
+/// Snap a raw quality score to the nearest value in a sorted bin list.
+/// Ties round toward the lower bin (deterministic; matches Illumina behavior on some platforms).
+/// `bins` must be non-empty and sorted ascending.
+fn snap_to_bin(score: usize, bins: &[usize]) -> usize {
+    debug_assert!(!bins.is_empty(), "snap_to_bin called with empty bin list");
+    // Find the first bin >= score. The nearest bin is either that one or the previous one.
+    match bins.iter().position(|&b| b >= score) {
+        None => *bins.last().unwrap(),
+        Some(0) => bins[0],
+        Some(i) => {
+            let hi = bins[i];
+            let lo = bins[i - 1];
+            // Tie → lower bin.
+            if hi - score < score - lo { hi } else { lo }
+        }
+    }
+}
+
 
 /// Normalizes a raw 4×4 mismatch count matrix into a `TransitionMatrix`.
 ///
@@ -91,6 +109,7 @@ pub fn runner(config: &RunConfiguration) -> Result<(), GenSeqErrorModelError> {
         qual_line: &str,
         qual_offset: usize,
         read_length: usize,
+        bins: Option<&[usize]>,
         seed_counts: &mut [usize],
         transition_counts: &mut [Vec<Vec<usize>>],
         global_counts: &mut [usize],
@@ -98,7 +117,13 @@ pub fn runner(config: &RunConfiguration) -> Result<(), GenSeqErrorModelError> {
     ) -> bool {
         let scores: Vec<usize> = qual_line
             .bytes()
-            .map(|b| (b as usize).saturating_sub(qual_offset).min(MAX_SCORE - 1))
+            .map(|b| {
+                let raw = (b as usize).saturating_sub(qual_offset).min(MAX_SCORE - 1);
+                match bins {
+                    Some(bins) => snap_to_bin(raw, bins),
+                    None => raw,
+                }
+            })
             .collect();
         if scores.is_empty() {
             return false;
@@ -114,8 +139,10 @@ pub fn runner(config: &RunConfiguration) -> Result<(), GenSeqErrorModelError> {
         true
     }
 
+    let bins_slice: Option<&[usize]> = config.binned_quality_bins.as_deref();
+
     if accumulate_qual(
-        &first_qual, qual_offset, read_length,
+        &first_qual, qual_offset, read_length, bins_slice,
         &mut seed_counts, &mut transition_counts, &mut global_counts, &mut total_bases,
     ) {
         reads_processed += 1;
@@ -138,7 +165,7 @@ pub fn runner(config: &RunConfiguration) -> Result<(), GenSeqErrorModelError> {
             Some(Err(e)) => return Err(e.into()),
         };
         if accumulate_qual(
-            &qual, qual_offset, read_length,
+            &qual, qual_offset, read_length, bins_slice,
             &mut seed_counts, &mut transition_counts, &mut global_counts, &mut total_bases,
         ) {
             reads_processed += 1;
@@ -161,10 +188,27 @@ pub fn runner(config: &RunConfiguration) -> Result<(), GenSeqErrorModelError> {
 
     info!("Computed error_rate: {:.6}", error_rate);
 
-    // Collect observed quality scores
-    let quality_score_options: Vec<usize> = (0..MAX_SCORE)
-        .filter(|&q| global_counts[q] > 0)
-        .collect();
+    // Collect quality_score_options. When binning is enabled, use the configured bin list
+    // verbatim — even bins that received zero observed counts stay in the option set so
+    // that from_counts' uniform fallback can produce a sane transition row for them.
+    let (quality_score_options, is_binned): (Vec<usize>, bool) = match &config.binned_quality_bins {
+        Some(bins) => {
+            let zero_count_bins: Vec<usize> =
+                bins.iter().copied().filter(|&b| global_counts[b] == 0).collect();
+            if !zero_count_bins.is_empty() {
+                warn!(
+                    "Binned quality model has {} bin(s) with no observed counts: {:?}; \
+                     transition rows for these will use a uniform fallback",
+                    zero_count_bins.len(), zero_count_bins,
+                );
+            }
+            (bins.clone(), true)
+        }
+        None => {
+            let opts: Vec<usize> = (0..MAX_SCORE).filter(|&q| global_counts[q] > 0).collect();
+            (opts, false)
+        }
+    };
 
     let n_scores = quality_score_options.len();
 
@@ -196,6 +240,7 @@ pub fn runner(config: &RunConfiguration) -> Result<(), GenSeqErrorModelError> {
         read_length,
         seed_weights,
         trans_weights,
+        is_binned,
     )?;
 
     // Determine transition matrix: TSV > BAM inference > defaults from original Python NEAT
@@ -317,6 +362,7 @@ mod tests {
             overwrite_output: true,
             max_reads: 0,
             qual_offset: 33,
+            binned_quality_bins: None,
             bam_file: None,
             transition_matrix_file: None,
         }
@@ -531,6 +577,7 @@ mod tests {
             overwrite_output: true,
             max_reads: 0,
             qual_offset: 33,
+            binned_quality_bins: None,
             bam_file: None,
             transition_matrix_file: Some(tsv_path),
         };
@@ -555,6 +602,7 @@ mod tests {
             overwrite_output: true,
             max_reads: 0,
             qual_offset: 33,
+            binned_quality_bins: None,
             bam_file: Some(bam_path),
             transition_matrix_file: None,
         };
@@ -579,6 +627,7 @@ mod tests {
             overwrite_output: true,
             max_reads: 0,
             qual_offset: 33,
+            binned_quality_bins: None,
             bam_file: Some(bam_path),
             transition_matrix_file: None,
         };
@@ -615,6 +664,7 @@ mod tests {
             overwrite_output: true,
             max_reads: 0,
             qual_offset: 33,
+            binned_quality_bins: None,
             bam_file: Some(bam_path),
             transition_matrix_file: Some(tsv_path),
         };
@@ -645,5 +695,82 @@ mod tests {
             seen.insert(result as usize);
         }
         assert_eq!(seen.len(), 3, "all three off-diagonal bases should be reachable");
+    }
+
+    #[test]
+    fn test_snap_to_bin_basic() {
+        let bins = [2usize, 12, 23, 37];
+        // Below smallest bin
+        assert_eq!(snap_to_bin(0, &bins), 2);
+        assert_eq!(snap_to_bin(2, &bins), 2);
+        // Above largest bin
+        assert_eq!(snap_to_bin(40, &bins), 37);
+        assert_eq!(snap_to_bin(93, &bins), 37);
+        // Interior — nearest bin
+        assert_eq!(snap_to_bin(11, &bins), 12);
+        assert_eq!(snap_to_bin(13, &bins), 12);
+        assert_eq!(snap_to_bin(20, &bins), 23);
+        // Tie: midpoint between 2 and 12 is 7 — rounds to lower (2).
+        assert_eq!(snap_to_bin(7, &bins), 2);
+        // Midpoint between 23 and 37 is 30 — rounds to lower (23).
+        assert_eq!(snap_to_bin(30, &bins), 23);
+    }
+
+    #[test]
+    fn test_snap_to_bin_singleton() {
+        let bins = [12usize];
+        assert_eq!(snap_to_bin(0, &bins), 12);
+        assert_eq!(snap_to_bin(12, &bins), 12);
+        assert_eq!(snap_to_bin(50, &bins), 12);
+    }
+
+    #[test]
+    fn test_runner_binned_quality_scores() {
+        // Synthetic FASTQ has scores in range 33..=42 (see make_test_fastq). With bins
+        // [2, 12, 23, 37], every observed score should snap to 37, so the only quality
+        // option used is 37 — but the model must keep all four bins in
+        // quality_score_options and flag binned_scores = true.
+        let temp = tempfile::tempdir().unwrap();
+        let fastq_path = temp.path().join("test.fastq");
+        make_test_fastq(&fastq_path, 30, 50);
+        let output_path = temp.path().join("model.json.gz");
+
+        let mut config = make_config(fastq_path, output_path.clone());
+        config.binned_quality_bins = Some(vec![2, 12, 23, 37]);
+
+        runner(&config).unwrap();
+        assert!(output_path.exists());
+
+        let model = SequencingErrorModel::from_file(&output_path).unwrap();
+        let qsm = model.quality_score_model();
+        assert!(qsm.binned_scores, "model should be marked binned");
+        assert_eq!(qsm.quality_score_options, vec![2, 12, 23, 37]);
+    }
+
+    #[test]
+    fn test_runner_binned_emits_only_bin_values() {
+        // End-to-end: train a binned model, sample many quality vectors, and verify
+        // every emitted score is in the bin set.
+        use common::rng::NeatRng;
+        let temp = tempfile::tempdir().unwrap();
+        let fastq_path = temp.path().join("test.fastq");
+        make_test_fastq(&fastq_path, 30, 50);
+        let output_path = temp.path().join("model.json.gz");
+
+        let mut config = make_config(fastq_path, output_path.clone());
+        config.binned_quality_bins = Some(vec![2, 12, 23, 37]);
+        runner(&config).unwrap();
+
+        let model = SequencingErrorModel::from_file(&output_path).unwrap();
+        let qsm = model.quality_score_model();
+        let bins: std::collections::HashSet<usize> = qsm.quality_score_options.iter().copied().collect();
+
+        let mut rng = NeatRng::new_from_seed(&vec!["binned-runner".to_string()]).unwrap();
+        for _ in 0..200 {
+            let scores = qsm.generate_quality_scores(50, &mut rng).unwrap();
+            for &s in &scores {
+                assert!(bins.contains(&s), "sampled non-bin score {s}");
+            }
+        }
     }
 }

--- a/template_config/gen_seq_error_model_template.yml
+++ b/template_config/gen_seq_error_model_template.yml
@@ -11,6 +11,11 @@ overwrite_output: false
 max_reads: 0
 # quality score ASCII offset [optional] - 33 for Illumina 1.8+/Sanger, 64 for older Illumina (default: 33)
 qual_offset: 33
+# binned quality bins [optional] - quantize the learned quality scores to a small bin set.
+# When set, each observed Q-score is snapped to the nearest bin and gen-reads will emit only
+# these values. Example presets: NovaSeq 6000 [2, 12, 23, 37], NextSeq 3-bin [2, 15, 35].
+# Bins must be < 94 and cannot include 31 ('@' under Phred+33). Omit for a continuous model.
+# binned_quality_bins: [2, 12, 23, 37]
 # path to an aligned BAM file [optional] - used to infer the SNP transition matrix from
 # read-vs-reference mismatches. The BAM must have MD tags (run 'samtools calmd' if absent).
 # Ignored if transition_matrix_file is also set.


### PR DESCRIPTION
Modern sequencers (NovaSeq 6000, NextSeq 1000/2000) quantize per-base quality into a small set of discrete bins instead of emitting the continuous Q0-Q40 range. This adds a `binned_quality_bins` option to gen-seq-error-model so users can train a model that snaps observed quality scores to a configurable bin set; gen-reads then emits only those bin values when sampling from the model.

- New optional `binned_quality_bins: [..]` YAML field on the gen-seq-error-model config. Validated for non-empty, < 94, and excludes 31 (encodes to '@' under Phred+33 and would corrupt FASTQ output). Sorted and deduped at parse time.
- accumulate_qual now snaps each decoded Q-score to the nearest bin during count accumulation (ties round down), so seed, transition, and global counts are all in bin space; error_rate naturally reflects what reads will look like.
- QualityScoreModel::from_counts gains an is_binned parameter and now sets the previously-hardcoded binned_scores field accordingly. Adds a new InvalidConfiguration error variant.
- Public accessor SequencingErrorModel::quality_score_model() for tests and consumers that need model metadata.
- Zero-count bins are kept in quality_score_options and fall back to the existing uniform-row behavior, with a warn! listing them.
- README and template_config updated with the new field, validation rules, and suggested bin sets per platform.

No gen-reads changes needed: generate_quality_scores already restricts output to quality_score_options, which is now constrained to the bin set when the model is binned.