### PR TITLE
Phase 3 test coverage: 3 proptest properties for DiscreteDistribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,8 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bstr"
@@ -248,6 +263,7 @@ dependencies = [
  "lazy_static",
  "log",
  "noodles",
+ "proptest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -361,6 +377,12 @@ dependencies = [
  "libz-rs-sys",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -614,7 +636,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "simba",
  "typenum",
@@ -673,7 +695,7 @@ version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9c846d8128bd80b18d891b13cb9e0bc1d364429d6ab3ec3c83939f3d32ba105"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
  "bstr",
  "indexmap",
  "noodles-bgzf",
@@ -803,6 +825,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec 0.8.0",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,8 +871,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -835,7 +892,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -848,13 +915,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -888,6 +973,12 @@ name = "regex-automata"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
@@ -927,6 +1018,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1040,7 +1143,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1142,6 +1245,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1288,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,12 +409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +416,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -1065,12 +1065,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regex-syntax"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,3 +27,6 @@ statrs = "0.18.0"
 vectorize = "0.2.0"
 lazy_static = "1.5.0"
 bstr = "1"
+
+[dev-dependencies]
+proptest = "1"

--- a/common/src/structs/distributions.rs
+++ b/common/src/structs/distributions.rs
@@ -236,6 +236,104 @@ mod test {
         }
     }
 
+    // ── Property tests ──────────────────────────────────────────────────────
+    //
+    // These exercise invariants of DiscreteDistribution that hold across the space of
+    // possible inputs, not just the hand-rolled fixtures above. The CDF binary search
+    // in sample() is hot-path code shared by every model, so blanketing it with
+    // randomized inputs is cheap insurance against off-by-one bugs.
+
+    use proptest::prelude::*;
+    use proptest::collection::vec as prop_vec;
+
+    /// Strategy: a (weights, values) pair with positive, well-formed weights. Length
+    /// 2..=10 (small enough to keep tests fast but large enough to exercise the
+    /// bisect tree depth). Weights drawn from (0.0, 10.0) — strictly positive to
+    /// ensure sum > 0 and the normalization branch is exercised. Values are indices.
+    fn positive_weights_strategy() -> impl Strategy<Value = (Vec<f64>, Vec<usize>)> {
+        prop_vec(0.001f64..10.0, 2..=10).prop_map(|weights| {
+            let values: Vec<usize> = (0..weights.len()).collect();
+            (weights, values)
+        })
+    }
+
+    proptest! {
+        /// Whatever weights and `rand` value are thrown at it, `sample` must return one of
+        /// the values from the input set — never panic, never return a value not in `values`.
+        /// `rand` covers the inclusive endpoints 0.0 and 1.0 explicitly (proptest does include
+        /// boundary values in its shrink space).
+        #[test]
+        fn proptest_sample_returns_value_from_input_set(
+            (weights, values) in positive_weights_strategy(),
+            rand in 0.0f64..=1.0,
+        ) {
+            let d = DiscreteDistribution::new(&weights, &values).unwrap();
+            let sampled = d.sample(rand).unwrap();
+            prop_assert!(
+                values.contains(&sampled),
+                "sample({rand}) returned {sampled}, which is not in input values {values:?}",
+            );
+        }
+
+        /// With many samples drawn from a deterministic RNG, the empirical frequency of
+        /// each value must approach its normalized weight. This stresses the bisect-left
+        /// implementation in `sample()` more thoroughly than the hand-rolled fixture tests
+        /// — any off-by-one in the CDF construction would show up as a systematic skew.
+        #[test]
+        fn proptest_empirical_frequency_approaches_weights(
+            (weights, values) in positive_weights_strategy(),
+        ) {
+            let d = DiscreteDistribution::new(&weights, &values).unwrap();
+            let total_weight: f64 = weights.iter().sum();
+            let mut counts = vec![0usize; values.len()];
+
+            // Use a deterministic seed so the property is reproducible.
+            let mut rng = NeatRng::new_from_seed(&vec!["proptest empirical seed".to_string()])
+                .unwrap();
+            let n_samples = 20_000usize;
+            for _ in 0..n_samples {
+                let s = d.sample(rng.random().unwrap()).unwrap();
+                counts[s] += 1;
+            }
+
+            // Tolerance: with N=20k draws and worst-case probability ~0.5, the standard
+            // deviation of a count is sqrt(N*p*(1-p)) ≈ 70 (~0.35% of N). A 3% slack on
+            // *N* (equivalent to ~9σ) is comfortable for any individual bin without being
+            // so loose that systematic bias slips through.
+            let tolerance_count = (0.03 * n_samples as f64) as usize;
+            for i in 0..values.len() {
+                let expected = (weights[i] / total_weight) * n_samples as f64;
+                let actual = counts[i] as f64;
+                prop_assert!(
+                    (actual - expected).abs() < tolerance_count as f64,
+                    "bin {i}: expected ~{expected:.1} samples, got {actual} \
+                     (weights={weights:?}, tolerance={tolerance_count})",
+                );
+            }
+        }
+
+        /// All-zero weights are treated as a degenerate case in `new()`: instead of
+        /// dividing by zero, the CDF is set to `[1.0; n]`. Locking in the resulting
+        /// behavior — bisect-left lands at index 0, so every sample returns `values[0]`.
+        /// This is *not* a uniform fallback (the uniform fallback for quality models
+        /// lives at the QualityScoreModel layer). Renaming this contract would be a
+        /// deliberate change, not a silent regression.
+        #[test]
+        fn proptest_all_zero_weights_always_returns_first_value(
+            values in prop_vec(any::<u32>(), 2..=10),
+            rand in 0.0f64..=1.0,
+        ) {
+            let weights = vec![0.0f64; values.len()];
+            let d = DiscreteDistribution::new(&weights, &values).unwrap();
+            let s = d.sample(rand).unwrap();
+            prop_assert_eq!(
+                s, values[0],
+                "all-zero weights must return values[0] regardless of rand={}",
+                rand,
+            );
+        }
+    }
+
     #[test]
     fn test_normal_distribution_inverse_cdf_symmetry() {
         // inverse_cdf(p) and inverse_cdf(1-p) should be symmetric around the mean


### PR DESCRIPTION
DiscreteDistribution::sample is hot-path code shared by every model (quality scores, fragment lengths, indel lengths, nucleotide selection). Blanketing its CDF binary search with randomized inputs is cheap insurance against off-by-one bugs that the 7 hand-rolled fixtures here can't surface.

Adds `proptest = "1"` as a common dev-dep and three properties on DiscreteDistribution:

- `proptest_sample_returns_value_from_input_set`: for any positive weight vector of length 2..=10 and any rand ∈ [0, 1], the sample output is in the input value set. Catches any future bisect bug that returns an out-of-range index. proptest's shrink space naturally exercises the rand=0.0 and rand=1.0 boundaries.

- `proptest_empirical_frequency_approaches_weights`: 20,000 samples drawn through a deterministic NeatRng must produce a histogram within 3% of N per bin (well above the worst-case binomial standard deviation, comfortably below the threshold a systematic CDF bug would induce). Catches any off-by-one in cumulative_sum or the bisect predicate that would show up as a measurable skew.

- `proptest_all_zero_weights_always_returns_first_value`: documents the actual (non-uniform!) behavior when all weights are zero. The `new()` constructor sets the CDF to `[1.0; n]`, which makes bisect-left return index 0 on every sample. Note that this is *not* a uniform fallback — the uniform fallback for quality models lives one layer up in QualityScoreModel::from_counts. Renaming this contract would now be a deliberate change, not a silent regression.

cargo test --workspace: 200 common tests (was 197), 158 rneat tests, all passing.

Closes #104 