### PR TITLE
refactor(gen-gc-bias-model): accept BAM input via CoverageObserver

### DIFF
--- a/rneat/src/gen_gc_bias_model/errors.rs
+++ b/rneat/src/gen_gc_bias_model/errors.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use common::file_tools::bam_reader::BamReaderError;
 use common::file_tools::bed_reader::BedReaderError;
 use common::file_tools::fasta_stream::FastaStreamError;
 use common::models::gc_bias_model::GcBiasModelError;
@@ -19,4 +20,6 @@ pub enum GenGcBiasModelError {
     CoverageParseError(String),
     #[error("Error reading FASTA: {0}")]
     FastaStreamError(#[from] FastaStreamError),
+    #[error("Error reading BAM: {0}")]
+    BamReaderError(#[from] BamReaderError),
 }

--- a/rneat/src/gen_gc_bias_model/utils/config.rs
+++ b/rneat/src/gen_gc_bias_model/utils/config.rs
@@ -38,10 +38,18 @@ impl CoverageFormat {
 #[derive(Debug, Clone)]
 pub struct RunConfiguration {
     // This struct holds all the parameters for running GC Bias modeling.
-    // It is built from user-supplied input in the form of a configuration yaml file
+    // It is built from user-supplied input in the form of a configuration yaml file.
+    //
+    // Coverage source: exactly one of `bam_file` or `coverage_file` must be set.
+    // `bam_file` is the preferred path; `coverage_file` is retained for users with
+    // pre-computed samtools-depth / bedtools-genomecov output.
     pub reference: PathBuf,
-    pub coverage_file: PathBuf,
-    pub coverage_format: CoverageFormat,
+    pub bam_file: Option<PathBuf>,
+    pub coverage_file: Option<PathBuf>,
+    pub coverage_format: Option<CoverageFormat>,
+    /// Minimum mapping quality for in-process coverage accumulation from `bam_file`.
+    /// Ignored on the `coverage_file` path. Default 0 matches `samtools depth`.
+    pub min_mapq: u8,
     pub bed_table: HashMap<String, Vec<BedRecord>>,
     pub output_file: PathBuf,
     pub overwrite_output: bool,
@@ -66,23 +74,67 @@ impl RunConfiguration {
             ));
         }
 
-        let coverage_file = PathBuf::from(
-            scrape_config["coverage_file"]
-                .as_str()
-                .ok_or_else(|| GenGcBiasModelError::ConfigError("Missing coverage_file".to_string()))?
-        );
-        if !coverage_file.is_file() {
-            return Err(GenGcBiasModelError::ConfigError(
-                format!("Invalid coverage file {:?}", coverage_file)
-            ));
+        let bam_file = scrape_config
+            .get("bam_file")
+            .and_then(|v| v.as_str())
+            .map(PathBuf::from);
+        if let Some(p) = &bam_file {
+            if !p.is_file() {
+                return Err(GenGcBiasModelError::ConfigError(
+                    format!("Invalid bam_file {:?}", p)
+                ));
+            }
         }
 
-        let coverage_format = CoverageFormat::from_str(
-            scrape_config
-                .get("coverage_format")
-                .and_then(|v| v.as_str())
-                .unwrap_or("samtools-depth")
-        )?;
+        let coverage_file = scrape_config
+            .get("coverage_file")
+            .and_then(|v| v.as_str())
+            .map(PathBuf::from);
+        if let Some(p) = &coverage_file {
+            if !p.is_file() {
+                return Err(GenGcBiasModelError::ConfigError(
+                    format!("Invalid coverage file {:?}", p)
+                ));
+            }
+        }
+
+        match (&bam_file, &coverage_file) {
+            (Some(_), Some(_)) => {
+                return Err(GenGcBiasModelError::ConfigError(
+                    "Specify either bam_file or coverage_file, not both".to_string()
+                ));
+            }
+            (None, None) => {
+                return Err(GenGcBiasModelError::ConfigError(
+                    "Must specify exactly one of bam_file or coverage_file".to_string()
+                ));
+            }
+            _ => {}
+        }
+
+        // coverage_format only applies to the coverage_file path. It is required (with
+        // a default) when coverage_file is set, and disallowed when bam_file is set so
+        // a misplaced field doesn't silently mislead the user.
+        let coverage_format = if coverage_file.is_some() {
+            Some(CoverageFormat::from_str(
+                scrape_config
+                    .get("coverage_format")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("samtools-depth")
+            )?)
+        } else {
+            if scrape_config.contains_key("coverage_format") {
+                return Err(GenGcBiasModelError::ConfigError(
+                    "coverage_format only applies to coverage_file input".to_string()
+                ));
+            }
+            None
+        };
+
+        let min_mapq = scrape_config
+            .get("min_mapq")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u8;
 
         let bed_file_raw = scrape_config
             .get("bed_file")
@@ -155,8 +207,10 @@ impl RunConfiguration {
 
         Ok(RunConfiguration {
             reference,
+            bam_file,
             coverage_file,
             coverage_format,
+            min_mapq,
             bed_table,
             output_file,
             overwrite_output,
@@ -257,8 +311,9 @@ min_windows_per_bin: 10
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
 
         assert_eq!(config.reference, reference.path());
-        assert_eq!(config.coverage_file, coverage.path());
-        assert_eq!(config.coverage_format, CoverageFormat::SamtoolsDepth);
+        assert_eq!(config.coverage_file.as_deref(), Some(coverage.path()));
+        assert_eq!(config.coverage_format, Some(CoverageFormat::SamtoolsDepth));
+        assert!(config.bam_file.is_none());
         assert!(config.bed_table.is_empty());
         assert_eq!(config.output_file, output_path);
         assert!(config.overwrite_output);
@@ -290,7 +345,7 @@ overwrite_output: true
 
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
 
-        assert_eq!(config.coverage_format, CoverageFormat::SamtoolsDepth);
+        assert_eq!(config.coverage_format, Some(CoverageFormat::SamtoolsDepth));
         assert!(config.bed_table.is_empty());
         assert_eq!(config.window_size, 100);
         assert_eq!(config.window_stride, 100);
@@ -325,8 +380,8 @@ min_windows_per_bin: 5
 
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
 
-        assert_eq!(config.coverage_format, CoverageFormat::BedtoolsGenomecovD);
-        assert!(!config.coverage_format.is_zero_based());
+        assert_eq!(config.coverage_format, Some(CoverageFormat::BedtoolsGenomecovD));
+        assert!(!config.coverage_format.unwrap().is_zero_based());
         assert_eq!(config.window_size, 50);
         assert_eq!(config.window_stride, 25);
         assert_eq!(config.min_windows_per_bin, 5);
@@ -357,8 +412,8 @@ overwrite_output: true
 
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
 
-        assert_eq!(config.coverage_format, CoverageFormat::BedtoolsGenomecovDz);
-        assert!(config.coverage_format.is_zero_based());
+        assert_eq!(config.coverage_format, Some(CoverageFormat::BedtoolsGenomecovDz));
+        assert!(config.coverage_format.unwrap().is_zero_based());
     }
 
     #[test]
@@ -707,5 +762,141 @@ window_stride: 100
 
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
         assert_eq!(config.window_stride, 100);
+    }
+
+    #[test]
+    fn test_run_configuration_rejects_both_bam_and_coverage_file() {
+        let reference = write_temp_file(">chr1\nACGTACGT\n");
+        let bam = write_temp_file("dummy"); // contents don't matter, only is_file
+        let coverage = write_temp_file("chr1\t1\t10\n");
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let output_path = output.path().to_path_buf();
+        drop(output);
+
+        let yaml = format!(
+            "\
+reference: {}
+bam_file: {}
+coverage_file: {}
+output_file: {}
+overwrite_output: true
+",
+            reference.path().display(),
+            bam.path().display(),
+            coverage.path().display(),
+            output_path.display(),
+        );
+        let config_file = write_config(&yaml);
+        let result = RunConfiguration::from(&config_file.path().to_path_buf());
+        assert!(
+            result.is_err(),
+            "Expected setting both bam_file and coverage_file to be rejected"
+        );
+    }
+
+    #[test]
+    fn test_run_configuration_rejects_neither_input_specified() {
+        let reference = write_temp_file(">chr1\nACGTACGT\n");
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let output_path = output.path().to_path_buf();
+        drop(output);
+
+        let yaml = format!(
+            "\
+reference: {}
+output_file: {}
+overwrite_output: true
+",
+            reference.path().display(),
+            output_path.display(),
+        );
+        let config_file = write_config(&yaml);
+        let result = RunConfiguration::from(&config_file.path().to_path_buf());
+        assert!(
+            result.is_err(),
+            "Expected missing both bam_file and coverage_file to be rejected"
+        );
+    }
+
+    #[test]
+    fn test_run_configuration_rejects_coverage_format_with_bam_file() {
+        // coverage_format applies only to coverage_file; surfacing it on the BAM path
+        // would silently mislead the user about how their BAM is processed.
+        let reference = write_temp_file(">chr1\nACGTACGT\n");
+        let bam = write_temp_file("dummy");
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let output_path = output.path().to_path_buf();
+        drop(output);
+
+        let yaml = format!(
+            "\
+reference: {}
+bam_file: {}
+coverage_format: samtools-depth
+output_file: {}
+overwrite_output: true
+",
+            reference.path().display(),
+            bam.path().display(),
+            output_path.display(),
+        );
+        let config_file = write_config(&yaml);
+        let result = RunConfiguration::from(&config_file.path().to_path_buf());
+        assert!(
+            result.is_err(),
+            "Expected coverage_format with bam_file to be rejected"
+        );
+    }
+
+    #[test]
+    fn test_run_configuration_parses_bam_file_path() {
+        let reference = write_temp_file(">chr1\nACGTACGT\n");
+        let bam = write_temp_file("dummy");
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let output_path = output.path().to_path_buf();
+        drop(output);
+
+        let yaml = format!(
+            "\
+reference: {}
+bam_file: {}
+output_file: {}
+overwrite_output: true
+min_mapq: 20
+",
+            reference.path().display(),
+            bam.path().display(),
+            output_path.display(),
+        );
+        let config_file = write_config(&yaml);
+        let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
+        assert_eq!(config.bam_file.as_deref(), Some(bam.path()));
+        assert!(config.coverage_file.is_none());
+        assert!(config.coverage_format.is_none());
+        assert_eq!(config.min_mapq, 20);
+    }
+
+    #[test]
+    fn test_run_configuration_min_mapq_defaults_to_zero() {
+        let reference = write_temp_file(">chr1\nACGTACGT\n");
+        let bam = write_temp_file("dummy");
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let output_path = output.path().to_path_buf();
+        drop(output);
+
+        let yaml = format!(
+            "\
+reference: {}
+bam_file: {}
+output_file: {}
+overwrite_output: true
+",
+            reference.path().display(),
+            bam.path().display(),
+            output_path.display(),
+        );
+        let config_file = write_config(&yaml);
+        let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
+        assert_eq!(config.min_mapq, 0);
     }
 }

--- a/rneat/src/gen_gc_bias_model/utils/coverage_reader.rs
+++ b/rneat/src/gen_gc_bias_model/utils/coverage_reader.rs
@@ -95,6 +95,14 @@ impl CoverageData {
         Ok(Some(CoverageData { depths }))
     }
 
+    /// Builds a CoverageData directly from a pre-computed per-base depth array.
+    /// Used by the BAM input path, where coverage is accumulated in process via
+    /// `common::file_tools::bam_reader::CoverageObserver` rather than parsed from
+    /// a samtools-depth / bedtools-genomecov file.
+    pub fn from_depths(depths: Vec<u32>) -> Self {
+        Self { depths }
+    }
+
     /// Depth at a 0-based position. Returns 0 for positions beyond the stored range.
     #[inline]
     pub fn depth_at(&self, pos: usize) -> u32 {

--- a/rneat/src/gen_gc_bias_model/utils/runner.rs
+++ b/rneat/src/gen_gc_bias_model/utils/runner.rs
@@ -1,8 +1,11 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 use log::*;
 
 use common::{
-    file_tools::fasta_stream::{FastaStream, non_n_regions},
+    file_tools::{
+        bam_reader::{walk_bam, BamWalkFilter, CoverageObserver},
+        fasta_stream::{FastaStream, non_n_regions},
+    },
     models::gc_bias_model::GcBiasModel,
     structs::nucleotides::Nucleotide,
 };
@@ -14,11 +17,47 @@ use crate::gen_gc_bias_model::{
     },
 };
 
+/// Abstracts over the two coverage input modes so the window-sweep loop
+/// below doesn't have to know where the depths came from.
+enum CoverageSource {
+    /// Per-contig depth arrays accumulated from a BAM in process via
+    /// `CoverageObserver`. Contigs are consumed (removed from the map)
+    /// as the runner walks the reference, so peak memory drops as
+    /// processing advances.
+    BamObserved(HashMap<String, Vec<u32>>),
+    /// Legacy path: depths streamed from a samtools-depth /
+    /// bedtools-genomecov file via `CoverageReader`.
+    FromFile(CoverageReader),
+}
+
+impl CoverageSource {
+    fn get(&mut self, contig: &str) -> Result<Option<CoverageData>, GenGcBiasModelError> {
+        match self {
+            CoverageSource::BamObserved(map) => {
+                Ok(map.remove(contig).map(CoverageData::from_depths))
+            }
+            CoverageSource::FromFile(reader) => reader.get(contig),
+        }
+    }
+}
+
 pub fn runner(path: &PathBuf) -> Result<(), GenGcBiasModelError> {
     let config = RunConfiguration::from(path)?;
 
-    info!("Building coverage index from {:?}", config.coverage_file);
-    let mut cov_reader = CoverageReader::open(&config.coverage_file, config.coverage_format)?;
+    let mut cov_source = if let Some(bam_path) = &config.bam_file {
+        info!("Accumulating coverage from BAM {:?}", bam_path);
+        let mut obs = CoverageObserver::default();
+        let mut filter = BamWalkFilter::for_coverage();
+        filter.min_mapq = config.min_mapq;
+        walk_bam(bam_path, &filter, &mut [&mut obs])?;
+        CoverageSource::BamObserved(obs.into_by_contig())
+    } else {
+        // Config validation guarantees this branch has coverage_file + coverage_format set.
+        let coverage_file = config.coverage_file.as_ref().expect("config validated");
+        let coverage_format = config.coverage_format.expect("config validated");
+        info!("Building coverage index from {:?}", coverage_file);
+        CoverageSource::FromFile(CoverageReader::open(coverage_file, coverage_format)?)
+    };
 
     let mut gc_weight_sum = [0.0f64; 101];
     let mut gc_window_count = [0usize; 101];
@@ -41,7 +80,7 @@ pub fn runner(path: &PathBuf) -> Result<(), GenGcBiasModelError> {
             continue;
         }
 
-        let cov = match cov_reader.get(&contig_name)? {
+        let cov = match cov_source.get(&contig_name)? {
             Some(c) => c,
             None => {
                 debug!("No coverage data for {}, skipping", contig_name);
@@ -434,6 +473,210 @@ min_windows_per_bin: {}
         // High-GC bin (100%) is sparse → neutral weight 1.0
         let w_high = model.weight_for_gc_fraction(1.0);
         assert_eq!(w_high, 1.0, "Expected sparse high-GC bin to have neutral weight 1.0");
+    }
+
+    /// Writes a BAM where `depth` reads of length `read_len` are stacked at
+    /// position 1 on a single contig, producing uniform depth `depth` over
+    /// positions [0, read_len) and 0 elsewhere.
+    fn write_uniform_coverage_bam(
+        path: &std::path::PathBuf,
+        contig: &[u8],
+        contig_len: usize,
+        depth: usize,
+        read_len: usize,
+    ) {
+        use noodles::bam;
+        use noodles::core::Position;
+        use noodles::sam::{
+            self as sam,
+            alignment::{
+                RecordBuf,
+                io::Write as _,
+                record::{cigar::{op::Kind, Op}, Flags, MappingQuality},
+                record_buf::{Cigar, Sequence},
+            },
+            header::record::value::{Map, map::ReferenceSequence},
+        };
+
+        let header = sam::Header::builder()
+            .add_reference_sequence(
+                contig.to_vec(),
+                Map::<ReferenceSequence>::new(
+                    std::num::NonZero::<usize>::new(contig_len).unwrap(),
+                ),
+            )
+            .build();
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = bam::io::Writer::new(file);
+        writer.write_header(&header).unwrap();
+
+        let cigar: Cigar = [Op::new(Kind::Match, read_len)].into_iter().collect();
+        let seq = vec![b'A'; read_len];
+        for _ in 0..depth {
+            let mut record = RecordBuf::default();
+            *record.flags_mut() = Flags::empty();
+            *record.cigar_mut() = cigar.clone();
+            *record.reference_sequence_id_mut() = Some(0);
+            *record.alignment_start_mut() = Position::new(1);
+            *record.sequence_mut() = Sequence::from(seq.as_slice());
+            *record.mapping_quality_mut() = Some(MappingQuality::try_from(30u8).unwrap());
+            writer.write_alignment_record(&header, &record).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_bam_input_uniform_coverage_matches_file_input() {
+        // 300 bp reference, 50% GC throughout. Stack 10 reads of length 300
+        // → uniform depth 10 → relative weights ~1.0 everywhere.
+        // Mirrors `test_uniform_coverage_produces_neutral_weights` but through
+        // the bam_file input path instead of coverage_file.
+        let seq: String = "ACGT".repeat(75);
+        let fasta_content = format!(">chr1\n{}\n", seq);
+        let ref_file = write_temp(&fasta_content);
+
+        let temp = tempfile::tempdir().unwrap();
+        let bam_path = temp.path().join("uniform.bam");
+        write_uniform_coverage_bam(&bam_path, b"chr1", 300, 10, 300);
+
+        let out = NamedTempFile::new().unwrap();
+        let out_path = out.path().to_path_buf();
+        drop(out);
+
+        let yaml = format!(
+            "reference: {}\nbam_file: {}\noutput_file: {}\noverwrite_output: true\n\
+             window_size: 100\nwindow_stride: 100\nmin_windows_per_bin: 1\n",
+            ref_file.path().display(),
+            bam_path.display(),
+            out_path.display(),
+        );
+        let config_file = write_temp(&yaml);
+
+        runner(&config_file.path().to_path_buf()).unwrap();
+
+        let model = GcBiasModel::from_file(&out_path).unwrap();
+        for gc_pct in 0..=100 {
+            let w = model.weight_for_gc_fraction(gc_pct as f64 / 100.0);
+            assert!(
+                (w - 1.0).abs() < 1e-6,
+                "Expected weight ~1.0 at GC {}%, got {}",
+                gc_pct,
+                w
+            );
+        }
+    }
+
+    #[test]
+    fn test_bam_input_parity_with_coverage_file() {
+        // Same scenario via both paths must yield numerically identical weights.
+        // Window A: 200 bp AT (0% GC) at depth 10; Window B: 200 bp GC (100% GC)
+        // at depth 30. Expect weight[0%] ~0.5 and weight[100%] ~1.5 under both
+        // input modes.
+        let seq = format!("{}{}", "AT".repeat(100), "GC".repeat(100));
+        let fasta_content = format!(">chr1\n{}\n", seq);
+        let ref_file = write_temp(&fasta_content);
+        let ref_path = ref_file.path().to_path_buf();
+
+        // BAM path: 10 reads of length 200 stacked at pos 1 → depth 10 over
+        // positions 0..200; then 30 reads of length 200 at pos 201 → depth 30
+        // over positions 200..400. Build manually.
+        let temp = tempfile::tempdir().unwrap();
+        let bam_path = temp.path().join("two_window.bam");
+        {
+            use noodles::bam;
+            use noodles::core::Position;
+            use noodles::sam::{
+                self as sam,
+                alignment::{
+                    RecordBuf,
+                    io::Write as _,
+                    record::{cigar::{op::Kind, Op}, Flags, MappingQuality},
+                    record_buf::{Cigar, Sequence},
+                },
+                header::record::value::{Map, map::ReferenceSequence},
+            };
+            let header = sam::Header::builder()
+                .add_reference_sequence(
+                    b"chr1".to_vec(),
+                    Map::<ReferenceSequence>::new(
+                        std::num::NonZero::<usize>::new(400).unwrap(),
+                    ),
+                )
+                .build();
+            let file = std::fs::File::create(&bam_path).unwrap();
+            let mut writer = bam::io::Writer::new(file);
+            writer.write_header(&header).unwrap();
+            let cigar: Cigar = [Op::new(Kind::Match, 200)].into_iter().collect();
+            let seq_bytes = vec![b'A'; 200];
+            for (start, n) in [(1usize, 10usize), (201, 30)] {
+                for _ in 0..n {
+                    let mut record = RecordBuf::default();
+                    *record.flags_mut() = Flags::empty();
+                    *record.cigar_mut() = cigar.clone();
+                    *record.reference_sequence_id_mut() = Some(0);
+                    *record.alignment_start_mut() = Position::new(start);
+                    *record.sequence_mut() = Sequence::from(seq_bytes.as_slice());
+                    *record.mapping_quality_mut() =
+                        Some(MappingQuality::try_from(30u8).unwrap());
+                    writer.write_alignment_record(&header, &record).unwrap();
+                }
+            }
+        }
+
+        // coverage_file equivalent: positions 1..200 at depth 10, 201..400 at depth 30.
+        let cov_lines: String = (1..=200)
+            .map(|i| format!("chr1\t{}\t10\n", i))
+            .chain((201..=400).map(|i| format!("chr1\t{}\t30\n", i)))
+            .collect();
+        let cov_file = write_temp(&cov_lines);
+
+        let out_bam = NamedTempFile::new().unwrap();
+        let out_bam_path = out_bam.path().to_path_buf();
+        drop(out_bam);
+        let out_file = NamedTempFile::new().unwrap();
+        let out_file_path = out_file.path().to_path_buf();
+        drop(out_file);
+
+        // Run BAM path
+        let yaml_bam = format!(
+            "reference: {}\nbam_file: {}\noutput_file: {}\noverwrite_output: true\n\
+             window_size: 200\nwindow_stride: 200\nmin_windows_per_bin: 1\n",
+            ref_path.display(),
+            bam_path.display(),
+            out_bam_path.display(),
+        );
+        let bam_config = write_temp(&yaml_bam);
+        runner(&bam_config.path().to_path_buf()).unwrap();
+
+        // Run coverage_file path
+        let yaml_file = format!(
+            "reference: {}\ncoverage_file: {}\ncoverage_format: samtools-depth\n\
+             output_file: {}\noverwrite_output: true\n\
+             window_size: 200\nwindow_stride: 200\nmin_windows_per_bin: 1\n",
+            ref_path.display(),
+            cov_file.path().display(),
+            out_file_path.display(),
+        );
+        let file_config = write_temp(&yaml_file);
+        runner(&file_config.path().to_path_buf()).unwrap();
+
+        let model_bam = GcBiasModel::from_file(&out_bam_path).unwrap();
+        let model_file = GcBiasModel::from_file(&out_file_path).unwrap();
+
+        for gc_pct in 0..=100 {
+            let frac = gc_pct as f64 / 100.0;
+            let w_bam = model_bam.weight_for_gc_fraction(frac);
+            let w_file = model_file.weight_for_gc_fraction(frac);
+            assert!(
+                (w_bam - w_file).abs() < 1e-9,
+                "BAM and coverage_file paths disagree at GC {}%: {} vs {}",
+                gc_pct,
+                w_bam,
+                w_file
+            );
+        }
+        // Also verify the expected absolute values to catch a both-paths-wrong drift.
+        assert!((model_bam.weight_for_gc_fraction(0.0) - 0.5).abs() < 1e-6);
+        assert!((model_bam.weight_for_gc_fraction(1.0) - 1.5).abs() < 1e-6);
     }
 
     #[test]

--- a/template_config/gen_gc_bias_model.yml
+++ b/template_config/gen_gc_bias_model.yml
@@ -1,21 +1,29 @@
 # Reference FASTA used to compute GC content.
 reference: .
 
-# Per-base coverage file.
-# Supported:
+# Coverage source. Specify exactly ONE of `bam_file` or `coverage_file`.
+
+# Preferred: a BAM file. Coverage is accumulated in process — no need to
+# pre-compute with `samtools depth` or `bedtools genomecov`.
+bam_file: .
+
+# Minimum mapping quality applied when accumulating coverage from bam_file.
+# Default 0 matches `samtools depth`. Ignored on the coverage_file path.
+min_mapq: 0
+
+# Legacy: a pre-computed per-base coverage file. Comment out `bam_file`
+# above to use this path.
+# Supported formats:
 #   samtools-depth
 #   bedtools-genomecov-d
 #   bedtools-genomecov-dz
-coverage_file: .
+# coverage_file: .
 
-# Coverage file format.
-# samtools-depth and bedtools-genomecov-d are:
-#   contig  1-based-position  depth
-#
-# bedtools-genomecov-dz is:
-#   contig  0-based-position  depth
-# and usually omits zero-coverage positions.
-coverage_format: samtools-depth
+# Coverage file format. Required when `coverage_file` is set, must be
+# omitted when `bam_file` is set.
+#   samtools-depth and bedtools-genomecov-d: contig  1-based-position  depth
+#   bedtools-genomecov-dz: contig  0-based-position  depth (zeros often omitted)
+# coverage_format: samtools-depth
 
 # Optional BED file limiting model inference to target regions.
 # Use "." to disable.


### PR DESCRIPTION
Adds a bam_file input mode that accumulates per-base coverage in process via the CoverageObserver introduced in the prior commit, eliminating the need to pre-compute coverage with samtools depth or bedtools genomecov. The legacy coverage_file path is retained behind mutually-exclusive validation: exactly one of bam_file or coverage_file must be set, and coverage_format is now rejected on the BAM path so a misplaced field cannot silently mislead the user.

The runner's window-sweep loop is unchanged. A new CoverageSource enum adapts both inputs to the existing CoverageData::depth_at API, with a new from_depths constructor that wraps the in-memory Vec<u32> the observer hands back. min_mapq (default 0, matching samtools depth defaults) controls the BAM-path filter only.

Tests:
- Config validation: both-set, neither-set, coverage_format-with-bam, and parsing both fields.
- Runner parity: same coverage pattern fed via BAM vs coverage_file produces numerically identical model weights at every GC bin.
- Runner BAM uniform-coverage smoke test parallel to the existing coverage_file uniform-coverage test.

Template config updated with both modes documented.

Phase 4 will remove the legacy coverage_file / coverage_format / CoverageReader once downstream pipelines have migrated.