### PR TITLE
compare-vcfs Phase 2: ±N bp equivalence sweep

### DIFF
--- a/rneat/src/compare_vcfs/utils.rs
+++ b/rneat/src/compare_vcfs/utils.rs
@@ -1,3 +1,4 @@
 pub mod config;
+pub mod equivalence;
 pub mod report;
 pub mod runner;

--- a/rneat/src/compare_vcfs/utils/config.rs
+++ b/rneat/src/compare_vcfs/utils/config.rs
@@ -19,6 +19,11 @@ pub struct RunConfiguration {
     pub contigs_simulated: Option<Vec<String>>,
     pub include_homs: bool,
     pub include_filtered: bool,
+    /// Half-width of the ±N bp window used for equivalence detection.
+    /// Default 50 (matches NEAT 2.1's `EV_BPRANGE`).
+    pub equivalence_window: usize,
+    /// Skip the equivalence sweep entirely. Matches NEAT 2.1's `--fast`.
+    pub fast: bool,
 }
 
 impl RunConfiguration {
@@ -60,6 +65,14 @@ impl RunConfiguration {
             .get("include_filtered")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let equivalence_window = scrape
+            .get("equivalence_window")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(50) as usize;
+        let fast = scrape
+            .get("fast")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         Ok(RunConfiguration {
             golden_vcf,
@@ -71,6 +84,8 @@ impl RunConfiguration {
             contigs_simulated,
             include_homs,
             include_filtered,
+            equivalence_window,
+            fast,
         })
     }
 }

--- a/rneat/src/compare_vcfs/utils/equivalence.rs
+++ b/rneat/src/compare_vcfs/utils/equivalence.rs
@@ -1,0 +1,287 @@
+//! Equivalence detection: catch FPs and FNs that are different denotations of
+//! the same edit.
+//!
+//! Port of NEAT 2.1's `vcf_compare.py` algorithm:
+//!
+//! For each raw FP, take a ±`window_bp` byte window around its 0-based
+//! reference position. Find every other raw FP and raw FN whose position
+//! falls inside that window. Apply each subset to a copy of the window
+//! (left-to-right, tracking the cumulative length delta from earlier indels).
+//! If the FP-applied window and FN-applied window are byte-identical, the
+//! two subsets are alternative spellings of the same edit — promote every
+//! consumed FN to TP and remove the consumed FPs from FP, and ditto for FNs.
+//!
+//! Why per-FP windows: left/right-aligned indels and equivalent multi-base
+//! substitutions usually anchor on a single called-but-mis-denoted variant.
+//! Centering each window on an FP catches the canonical case without an
+//! O(n²) all-pairs scan.
+use common::structs::variants::Variant;
+use std::collections::HashSet;
+
+/// Indices of FP and FN entries that were "consumed" by the sweep — i.e.,
+/// found to be denotation-different alternate spellings of golden variants.
+pub struct SweepResult {
+    /// Number of FNs that got promoted to TP. Each consumed FN counts once.
+    pub equivalents_promoted: usize,
+    /// Indices into the input `fps` slice to delete.
+    pub fp_consumed: Vec<usize>,
+    /// Indices into the input `fns` slice to delete.
+    pub fn_consumed: Vec<usize>,
+}
+
+/// Run the equivalence sweep for one contig.
+///
+/// `reference` is the contig's raw byte sequence (case-preserved as read from
+/// the FASTA). `fps` and `fns` are the raw, contig-restricted variant lists.
+/// `window_bp` is the half-width of the equivalence window (e.g. 50 → 101 bp
+/// total).
+///
+/// The comparison is case-folded to ASCII uppercase so that a reference with
+/// soft-masked bases compares cleanly against ALT alleles emitted in
+/// canonical uppercase.
+pub fn sweep(fps: &[Variant], fns: &[Variant], reference: &[u8], window_bp: usize) -> SweepResult {
+    let mut fp_consumed: HashSet<usize> = HashSet::new();
+    let mut fn_consumed: HashSet<usize> = HashSet::new();
+    let mut promoted = 0usize;
+
+    for fp_idx in 0..fps.len() {
+        if fp_consumed.contains(&fp_idx) {
+            continue;
+        }
+        let center = fps[fp_idx].location;
+        // Convert VCF 1-based pos to 0-based, then expand by `window_bp` on
+        // each side. End is exclusive, capped at reference length.
+        let center0 = center.saturating_sub(1);
+        let start = center0.saturating_sub(window_bp);
+        let end = (center0 + window_bp + 1).min(reference.len());
+        if start >= end {
+            continue;
+        }
+        let window = &reference[start..end];
+
+        let fps_in_window = variants_in_window(fps, &fp_consumed, start, end);
+        let fns_in_window = variants_in_window(fns, &fn_consumed, start, end);
+        if fns_in_window.is_empty() {
+            // Without a candidate FN partner, this window cannot be equivalent
+            // (applying the FP alone shifts bytes; nothing on the FN side matches).
+            continue;
+        }
+
+        let altered_fp = apply_variants(window, start, &fps_in_window, fps);
+        let altered_fn = apply_variants(window, start, &fns_in_window, fns);
+        if eq_ignore_case(&altered_fp, &altered_fn) {
+            for i in &fps_in_window {
+                fp_consumed.insert(*i);
+            }
+            promoted += fns_in_window.len();
+            for i in &fns_in_window {
+                fn_consumed.insert(*i);
+            }
+        }
+    }
+
+    SweepResult {
+        equivalents_promoted: promoted,
+        fp_consumed: fp_consumed.into_iter().collect(),
+        fn_consumed: fn_consumed.into_iter().collect(),
+    }
+}
+
+/// Indices of variants whose 0-based position falls inside `[start, end)`.
+fn variants_in_window(
+    variants: &[Variant],
+    consumed: &HashSet<usize>,
+    start: usize,
+    end: usize,
+) -> Vec<usize> {
+    let mut out = Vec::new();
+    for (i, v) in variants.iter().enumerate() {
+        if consumed.contains(&i) {
+            continue;
+        }
+        let pos0 = v.location.saturating_sub(1);
+        if pos0 >= start && pos0 < end {
+            out.push(i);
+        }
+    }
+    out
+}
+
+/// Apply the variants at `indices` (resolved in `variants`) to a copy of
+/// `window` (whose 0-based reference offset is `window_start`). Returns the
+/// resulting byte sequence.
+fn apply_variants(
+    window: &[u8],
+    window_start: usize,
+    indices: &[usize],
+    variants: &[Variant],
+) -> Vec<u8> {
+    let mut ordered: Vec<&Variant> = indices.iter().map(|&i| &variants[i]).collect();
+    ordered.sort_by_key(|v| v.location);
+
+    let mut result: Vec<u8> = window.to_vec();
+    let mut adj: isize = 0;
+    for v in ordered {
+        let offset_signed = v.location as isize - 1 - window_start as isize + adj;
+        if offset_signed < 0 {
+            continue;
+        }
+        let offset = offset_signed as usize;
+        let ref_len = v.reference.len();
+        if offset + ref_len > result.len() {
+            continue;
+        }
+        let alt_bytes: Vec<u8> = v.alternate.iter().map(|n| char::from(*n) as u8).collect();
+        let alt_len = alt_bytes.len();
+        result.splice(offset..offset + ref_len, alt_bytes);
+        adj += alt_len as isize - ref_len as isize;
+    }
+    result
+}
+
+fn eq_ignore_case(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .all(|(x, y)| x.eq_ignore_ascii_case(y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::structs::{
+        nucleotides::Nucleotide,
+        variants::{Genotype, VariantType},
+    };
+
+    fn variant(
+        loc: usize,
+        ref_seq: &[Nucleotide],
+        alt_seq: &[Nucleotide],
+        vt: VariantType,
+    ) -> Variant {
+        Variant {
+            variant_type: vt,
+            location: loc,
+            reference: ref_seq.to_vec(),
+            alternate: alt_seq.to_vec(),
+            genotype_str: "0/1".to_string(),
+            genotype: Genotype::Heterozygous,
+            id: None,
+            quality_score: None,
+            filter: Some("PASS".to_string()),
+            info: None,
+            format: Vec::new(),
+            sample: Vec::new(),
+        }
+    }
+
+    /// Reference: ACGTACGTACGT. A deletion at pos 5 (1-based) of "CGTA" can
+    /// equivalently be denoted as a deletion at pos 1 of "ACGT" — same alt
+    /// sequence either way. The sweep should catch this.
+    #[test]
+    fn detects_left_vs_right_aligned_deletion() {
+        let reference = b"ACGTACGTACGT";
+        // FN (golden): delete CGTA starting at 1-based pos 5 (REF=ACGTA, ALT=A)
+        let fn_v = variant(
+            5,
+            &[
+                Nucleotide::A,
+                Nucleotide::C,
+                Nucleotide::G,
+                Nucleotide::T,
+                Nucleotide::A,
+            ],
+            &[Nucleotide::A],
+            VariantType::Deletion,
+        );
+        // FP (called): same deletion left-aligned at pos 1 (REF=ACGTA, ALT=A)
+        let fp_v = variant(
+            1,
+            &[
+                Nucleotide::A,
+                Nucleotide::C,
+                Nucleotide::G,
+                Nucleotide::T,
+                Nucleotide::A,
+            ],
+            &[Nucleotide::A],
+            VariantType::Deletion,
+        );
+        let res = sweep(&[fp_v], &[fn_v], reference, 50);
+        assert_eq!(res.equivalents_promoted, 1);
+        assert_eq!(res.fp_consumed.len(), 1);
+        assert_eq!(res.fn_consumed.len(), 1);
+    }
+
+    /// SNPs at the same position with the same ALT but different REF cases
+    /// (uppercase vs soft-masked lowercase in the reference) should still
+    /// equivalence-match because the case-fold compare absorbs the case
+    /// mismatch.
+    #[test]
+    fn handles_case_mismatch_on_reference() {
+        let reference = b"ACgTACGT"; // pos 3 is lowercase 'g'
+        let fn_v = variant(3, &[Nucleotide::G], &[Nucleotide::A], VariantType::SNP);
+        let fp_v = variant(3, &[Nucleotide::G], &[Nucleotide::A], VariantType::SNP);
+        let res = sweep(&[fp_v], &[fn_v], reference, 50);
+        assert_eq!(res.equivalents_promoted, 1);
+    }
+
+    /// Two FPs at adjacent positions that together produce the same alt
+    /// sequence as a single FN multi-base substitution should
+    /// equivalence-match. The Variant struct collapses MNP-style records
+    /// into the `Complex` type.
+    #[test]
+    fn detects_compound_snp_vs_mnp() {
+        let reference = b"ACGTACGT";
+        // FN: pos 3 REF=GT → ALT=AA (a complex multi-base substitution)
+        let fn_v = variant(
+            3,
+            &[Nucleotide::G, Nucleotide::T],
+            &[Nucleotide::A, Nucleotide::A],
+            VariantType::Complex,
+        );
+        // FP1: pos 3 G→A, FP2: pos 4 T→A
+        let fp1 = variant(3, &[Nucleotide::G], &[Nucleotide::A], VariantType::SNP);
+        let fp2 = variant(4, &[Nucleotide::T], &[Nucleotide::A], VariantType::SNP);
+        let res = sweep(&[fp1, fp2], &[fn_v], reference, 50);
+        assert_eq!(res.equivalents_promoted, 1);
+        assert_eq!(res.fp_consumed.len(), 2);
+        assert_eq!(res.fn_consumed.len(), 1);
+    }
+
+    /// Genuinely different variants should not equivalence-match.
+    #[test]
+    fn unrelated_variants_are_not_equivalent() {
+        let reference = b"ACGTACGTACGT";
+        let fn_v = variant(3, &[Nucleotide::G], &[Nucleotide::A], VariantType::SNP);
+        let fp_v = variant(8, &[Nucleotide::T], &[Nucleotide::C], VariantType::SNP);
+        let res = sweep(&[fp_v], &[fn_v], reference, 50);
+        assert_eq!(res.equivalents_promoted, 0);
+        assert!(res.fp_consumed.is_empty());
+        assert!(res.fn_consumed.is_empty());
+    }
+
+    /// With no FNs in the window, a lonely FP cannot be equivalent.
+    #[test]
+    fn lonely_fp_is_not_consumed() {
+        let reference = b"ACGTACGTACGT";
+        let fp_v = variant(5, &[Nucleotide::A], &[Nucleotide::T], VariantType::SNP);
+        let res = sweep(&[fp_v], &[], reference, 50);
+        assert_eq!(res.equivalents_promoted, 0);
+        assert!(res.fp_consumed.is_empty());
+    }
+
+    /// Variant near the contig start: window should clamp at 0 and the
+    /// algorithm should still run.
+    #[test]
+    fn handles_window_clamp_at_start() {
+        let reference = b"ACGTACGT";
+        let fn_v = variant(1, &[Nucleotide::A], &[Nucleotide::G], VariantType::SNP);
+        let fp_v = variant(1, &[Nucleotide::A], &[Nucleotide::G], VariantType::SNP);
+        let res = sweep(&[fp_v], &[fn_v], reference, 50);
+        assert_eq!(res.equivalents_promoted, 1);
+    }
+}

--- a/rneat/src/compare_vcfs/utils/report.rs
+++ b/rneat/src/compare_vcfs/utils/report.rs
@@ -17,6 +17,11 @@ pub struct ContigCounts {
     pub tp: usize,
     pub fn_: usize,
     pub fp: usize,
+    /// FNs promoted to TP by the equivalence sweep. Already included in `tp`
+    /// and excluded from `fn_`; surfaced separately so users can see how many
+    /// matches were rescued by denotation-aware comparison.
+    #[serde(default)]
+    pub equivalents_promoted: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -85,6 +90,8 @@ pub struct SummaryInputs {
     pub contigs_simulated: Option<Vec<String>>,
     pub include_homs: bool,
     pub include_filtered: bool,
+    pub equivalence_window: usize,
+    pub fast: bool,
 }
 
 pub fn write_json(
@@ -146,10 +153,22 @@ fn render_txt(s: &ComparisonSummary) -> String {
         "  Include filtered:  {}\n",
         s.inputs.include_filtered
     ));
+    if s.inputs.fast {
+        out.push_str("  Equivalence sweep: SKIPPED (fast mode)\n");
+    } else {
+        out.push_str(&format!(
+            "  Equivalence window: ±{} bp\n",
+            s.inputs.equivalence_window
+        ));
+    }
     out.push('\n');
 
     out.push_str("Totals\n------\n");
     out.push_str(&format!("  True positives  (TP): {}\n", s.totals.tp));
+    out.push_str(&format!(
+        "    ↳ promoted by equivalence sweep: {}\n",
+        s.totals.equivalents_promoted
+    ));
     out.push_str(&format!("  False negatives (FN): {}\n", s.totals.fn_));
     out.push_str(&format!("  False positives (FP): {}\n\n", s.totals.fp));
 
@@ -257,11 +276,14 @@ mod tests {
                 contigs_simulated: None,
                 include_homs: false,
                 include_filtered: false,
+                equivalence_window: 50,
+                fast: false,
             },
             totals: ContigCounts {
                 tp: 7,
                 fn_: 1,
                 fp: 2,
+                equivalents_promoted: 0,
             },
             metrics: Metrics::from_counts(7, 1, 2),
             per_contig: BTreeMap::new(),
@@ -287,11 +309,14 @@ mod tests {
                 contigs_simulated: None,
                 include_homs: false,
                 include_filtered: false,
+                equivalence_window: 50,
+                fast: false,
             },
             totals: ContigCounts {
                 tp: 3,
                 fn_: 0,
                 fp: 0,
+                equivalents_promoted: 0,
             },
             metrics: Metrics::from_counts(3, 0, 0),
             per_contig: BTreeMap::new(),
@@ -320,11 +345,14 @@ mod tests {
                 contigs_simulated: None,
                 include_homs: false,
                 include_filtered: false,
+                equivalence_window: 50,
+                fast: false,
             },
             totals: ContigCounts {
                 tp: 0,
                 fn_: 0,
                 fp: 0,
+                equivalents_promoted: 0,
             },
             metrics: Metrics::from_counts(0, 0, 0),
             per_contig: BTreeMap::new(),

--- a/rneat/src/compare_vcfs/utils/runner.rs
+++ b/rneat/src/compare_vcfs/utils/runner.rs
@@ -1,4 +1,4 @@
-//! Phase 1 driver for `compare-vcfs`: exact-match classification.
+//! Driver for `compare-vcfs`.
 //!
 //! Algorithm:
 //!   1. Read golden + called VCFs via `common::file_tools::vcf_tools::read_vcf`.
@@ -8,15 +8,19 @@
 //!   3. Per contig, key surviving variants by `(position, ref, alt)` into a
 //!      `HashSet<VariantKey>`. TP = golden ∩ called; FN = golden \ called;
 //!      FP = called \ golden.
-//!   4. Aggregate per-contig and total counts, compute precision/recall/F1,
+//!   4. (Phase 2) Unless `fast: true`, stream the reference FASTA and for
+//!      each contig with FPs, run [`equivalence::sweep`] to catch
+//!      denotation-different alternates. FNs consumed by the sweep are
+//!      promoted to TP; FPs consumed are removed from FP.
+//!   5. Aggregate per-contig and total counts, compute precision/recall/F1,
 //!      write `comparison_summary.{json,txt}`.
 //!
-//! Equivalence detection (denotation-different indels) and NEAT-aware FN
-//! attribution are out of scope; see issue #127.
+//! NEAT-aware FN attribution is Phase 3; see issue #127.
 use crate::compare_vcfs::{
     errors::CompareVcfsError,
     utils::{
         config::RunConfiguration,
+        equivalence,
         report::{
             ComparisonSummary, ContigCounts, Metrics, SCHEMA_VERSION, SkipCounts, SummaryInputs,
             write_json, write_txt,
@@ -24,7 +28,7 @@ use crate::compare_vcfs::{
     },
 };
 use common::{
-    file_tools::{bed_reader::read_bed, vcf_tools::read_vcf},
+    file_tools::{bed_reader::read_bed, fasta_stream::FastaStream, vcf_tools::read_vcf},
     structs::{bed_record::BedRecord, nucleotides::Nucleotide, variants::Variant},
 };
 use log::*;
@@ -49,6 +53,15 @@ impl From<&Variant> for VariantKey {
             alternate: v.alternate.clone(),
         }
     }
+}
+
+/// Per-contig comparison buckets retained between exact-match classification
+/// and the optional equivalence sweep. TP records are not retained — only
+/// the count, since the sweep cannot promote to or out of TP.
+struct ContigBuckets {
+    tp_count: usize,
+    fns: Vec<Variant>,
+    fps: Vec<Variant>,
 }
 
 pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
@@ -83,11 +96,25 @@ pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
         config.include_filtered,
     );
 
-    let (per_contig, totals) = classify(&golden_by_contig, &called_by_contig);
+    let mut buckets = classify(&golden_by_contig, &called_by_contig);
+    let raw_tp: usize = buckets.values().map(|b| b.tp_count).sum();
+    let raw_fn: usize = buckets.values().map(|b| b.fns.len()).sum();
+    let raw_fp: usize = buckets.values().map(|b| b.fps.len()).sum();
+    info!("Exact-match classification: TP={raw_tp} FN={raw_fn} FP={raw_fp}");
+
+    let promoted_total = if !config.fast {
+        run_equivalence_sweep(&mut buckets, &config.reference, config.equivalence_window)?
+    } else {
+        info!("Skipping equivalence sweep (fast mode)");
+        0
+    };
+
+    let (per_contig, mut totals) = aggregate(&buckets);
+    totals.equivalents_promoted = promoted_total;
     let metrics = Metrics::from_counts(totals.tp, totals.fn_, totals.fp);
     info!(
-        "Classification: TP={} FN={} FP={}",
-        totals.tp, totals.fn_, totals.fp
+        "Final classification: TP={} (promoted={}) FN={} FP={}",
+        totals.tp, totals.equivalents_promoted, totals.fn_, totals.fp
     );
 
     let summary = ComparisonSummary {
@@ -100,6 +127,8 @@ pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
             contigs_simulated: config.contigs_simulated.clone(),
             include_homs: config.include_homs,
             include_filtered: config.include_filtered,
+            equivalence_window: config.equivalence_window,
+            fast: config.fast,
         },
         totals,
         metrics,
@@ -113,6 +142,56 @@ pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
     info!("Wrote {}", json_path.display());
     info!("Wrote {}", txt_path.display());
     Ok(())
+}
+
+/// Stream the reference FASTA and run the equivalence sweep on each contig
+/// with at least one FP. Mutates `buckets` in place: consumed FNs are
+/// removed from the bucket's `fns` list (and tracked separately as a count
+/// of promoted equivalents); consumed FPs are removed from `fps`.
+fn run_equivalence_sweep(
+    buckets: &mut BTreeMap<String, ContigBuckets>,
+    reference_path: &std::path::Path,
+    window_bp: usize,
+) -> Result<usize, CompareVcfsError> {
+    let need_reference = buckets.values().any(|b| !b.fps.is_empty());
+    if !need_reference {
+        return Ok(0);
+    }
+
+    let stream = FastaStream::open(&reference_path.to_path_buf())
+        .map_err(|e| CompareVcfsError::ConfigurationError(format!("reference: {e}")))?;
+    let mut total_promoted = 0usize;
+    for result in stream {
+        let (contig, sequence) =
+            result.map_err(|e| CompareVcfsError::ConfigurationError(format!("FASTA: {e}")))?;
+        let Some(bucket) = buckets.get_mut(&contig) else {
+            continue;
+        };
+        if bucket.fps.is_empty() {
+            continue;
+        }
+        let ref_bytes = sequence.as_bytes();
+        let sweep = equivalence::sweep(&bucket.fps, &bucket.fns, ref_bytes, window_bp);
+        if sweep.equivalents_promoted == 0 {
+            continue;
+        }
+        let promoted = sweep.equivalents_promoted;
+        // Sort indices descending so each `swap_remove` doesn't disturb the next.
+        let mut fp_idx = sweep.fp_consumed;
+        fp_idx.sort_unstable_by(|a, b| b.cmp(a));
+        for i in fp_idx {
+            bucket.fps.swap_remove(i);
+        }
+        let mut fn_idx = sweep.fn_consumed;
+        fn_idx.sort_unstable_by(|a, b| b.cmp(a));
+        for i in fn_idx {
+            bucket.fns.swap_remove(i);
+        }
+        bucket.tp_count += promoted;
+        total_promoted += promoted;
+        debug!("{contig}: {promoted} equivalents promoted by sweep");
+    }
+    Ok(total_promoted)
 }
 
 /// Drops disqualified variants and tallies the reasons. The returned map keeps
@@ -166,17 +245,14 @@ fn filter_is_pass(v: &Variant) -> bool {
     }
 }
 
+/// Exact-match classification. Splits each contig's variants into
+/// TP (count only), FN (kept as `Variant` so equivalence sweep can apply
+/// them), and FP (same).
 fn classify(
     golden: &HashMap<String, Vec<Variant>>,
     called: &HashMap<String, Vec<Variant>>,
-) -> (BTreeMap<String, ContigCounts>, ContigCounts) {
-    let mut per_contig: BTreeMap<String, ContigCounts> = BTreeMap::new();
-    let mut totals = ContigCounts {
-        tp: 0,
-        fn_: 0,
-        fp: 0,
-    };
-
+) -> BTreeMap<String, ContigBuckets> {
+    let mut out: BTreeMap<String, ContigBuckets> = BTreeMap::new();
     let all_contigs: HashSet<&String> = golden.keys().chain(called.keys()).collect();
     for chrom in all_contigs {
         let g_keys: HashSet<VariantKey> = golden
@@ -188,13 +264,63 @@ fn classify(
             .map(|vs| vs.iter().map(VariantKey::from).collect())
             .unwrap_or_default();
         let tp = g_keys.intersection(&c_keys).count();
-        let fn_ = g_keys.len() - tp;
-        let fp = c_keys.len() - tp;
-        totals.tp += tp;
-        totals.fn_ += fn_;
-        totals.fp += fp;
-        per_contig.insert(chrom.clone(), ContigCounts { tp, fn_, fp });
+        let fns: Vec<Variant> = golden
+            .get(chrom)
+            .into_iter()
+            .flatten()
+            .filter(|v| !c_keys.contains(&VariantKey::from(*v)))
+            .cloned()
+            .collect();
+        let fps: Vec<Variant> = called
+            .get(chrom)
+            .into_iter()
+            .flatten()
+            .filter(|v| !g_keys.contains(&VariantKey::from(*v)))
+            .cloned()
+            .collect();
+        out.insert(
+            chrom.clone(),
+            ContigBuckets {
+                tp_count: tp,
+                fns,
+                fps,
+            },
+        );
     }
+    out
+}
+
+/// Roll `ContigBuckets` (post-sweep) into the report's `ContigCounts` shape.
+fn aggregate(
+    buckets: &BTreeMap<String, ContigBuckets>,
+) -> (BTreeMap<String, ContigCounts>, ContigCounts) {
+    let mut per_contig: BTreeMap<String, ContigCounts> = BTreeMap::new();
+    let mut totals = ContigCounts {
+        tp: 0,
+        fn_: 0,
+        fp: 0,
+        equivalents_promoted: 0,
+    };
+    for (chrom, b) in buckets {
+        let cc = ContigCounts {
+            tp: b.tp_count,
+            fn_: b.fns.len(),
+            fp: b.fps.len(),
+            // We don't currently track per-contig equivalents_promoted as a
+            // standalone counter; surface it at the rollup level via the
+            // difference between final TP and raw TP if needed in future.
+            equivalents_promoted: 0,
+        };
+        totals.tp += cc.tp;
+        totals.fn_ += cc.fn_;
+        totals.fp += cc.fp;
+        per_contig.insert(chrom.clone(), cc);
+    }
+    // totals.equivalents_promoted is computed in the runner from the sweep
+    // results — we'd lose it here. Instead, keep it as 0 in aggregate and
+    // let the caller patch it in. (Actually we don't need that: the runner
+    // already tracks per-bucket TP, which already includes promoted FNs;
+    // we just don't separately attribute. Set this at the caller.)
     (per_contig, totals)
 }
 
@@ -227,11 +353,12 @@ mod tests {
         g.insert("chr1".into(), vec![v.clone()]);
         let mut c = HashMap::new();
         c.insert("chr1".into(), vec![v]);
-        let (per, tot) = classify(&g, &c);
+        let buckets = classify(&g, &c);
+        let (_per, tot) = aggregate(&buckets);
         assert_eq!(tot.tp, 1);
         assert_eq!(tot.fn_, 0);
         assert_eq!(tot.fp, 0);
-        assert_eq!(per["chr1"].tp, 1);
+        assert_eq!(buckets["chr1"].tp_count, 1);
     }
 
     #[test]
@@ -254,10 +381,13 @@ mod tests {
                 snp(30, Nucleotide::T, Nucleotide::A, Some("PASS")),
             ],
         );
-        let (_per, tot) = classify(&g, &c);
+        let buckets = classify(&g, &c);
+        let (_per, tot) = aggregate(&buckets);
         assert_eq!(tot.tp, 1);
         assert_eq!(tot.fn_, 1);
         assert_eq!(tot.fp, 1);
+        assert_eq!(buckets["chr1"].fns.len(), 1);
+        assert_eq!(buckets["chr1"].fps.len(), 1);
     }
 
     #[test]
@@ -274,7 +404,8 @@ mod tests {
             "chr2".into(),
             vec![snp(50, Nucleotide::G, Nucleotide::A, Some("PASS"))],
         );
-        let (per, tot) = classify(&g, &c);
+        let buckets = classify(&g, &c);
+        let (per, tot) = aggregate(&buckets);
         assert_eq!(tot.tp, 0);
         assert_eq!(tot.fn_, 1);
         assert_eq!(tot.fp, 1);

--- a/rneat/tests/compare_vcfs_phase2.rs
+++ b/rneat/tests/compare_vcfs_phase2.rs
@@ -1,0 +1,218 @@
+//! Phase 2 integration tests: equivalence sweep on synthetic indels.
+//!
+//! Each test writes a tiny custom FASTA and a golden + called VCF pair where
+//! the called VCF intentionally uses a different denotation of the same edit.
+//! The compare-vcfs binary should classify these as TP after the sweep.
+
+mod common;
+
+use common::rneat;
+use std::io::Write;
+use std::path::Path;
+
+fn write_fasta(path: &Path, contig: &str, sequence: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, ">{contig}").unwrap();
+    writeln!(f, "{sequence}").unwrap();
+}
+
+fn write_vcf(path: &Path, body_lines: &[&str]) {
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, "##fileformat=VCFv4.2").unwrap();
+    writeln!(
+        f,
+        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
+    )
+    .unwrap();
+    writeln!(
+        f,
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE"
+    )
+    .unwrap();
+    for line in body_lines {
+        writeln!(f, "{line}").unwrap();
+    }
+}
+
+fn write_yaml(path: &Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    write!(f, "{content}").unwrap();
+}
+
+fn load_summary(dir: &Path) -> serde_json::Value {
+    let raw = std::fs::read_to_string(dir.join("comparison_summary.json")).unwrap();
+    serde_json::from_str(&raw).unwrap()
+}
+
+fn cfg_yaml(out: &Path, golden: &Path, called: &Path, reference: &Path, extra: &str) -> String {
+    format!(
+        "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\noverwrite_output: true\n{extra}",
+        golden.display(),
+        called.display(),
+        reference.display(),
+        out.display(),
+    )
+}
+
+/// Reference contains `ACGTACGTACGT`. A `CGTA` deletion can be denoted at
+/// either pos 1 (REF=ACGTA, ALT=A) or pos 5 (REF=ACGTA, ALT=A). With the
+/// equivalence sweep enabled, the two should match as TP.
+#[test]
+fn equivalence_catches_left_vs_right_aligned_deletion() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chrTest", "ACGTACGTACGT");
+    // Golden VCF: deletion described starting at pos 5
+    write_vcf(&golden, &["chrTest\t5\t.\tACGTA\tA\t60\tPASS\t.\tGT\t0/1"]);
+    // Called VCF: same deletion left-aligned at pos 1
+    write_vcf(&called, &["chrTest\t1\t.\tACGTA\tA\t60\tPASS\t.\tGT\t0/1"]);
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(&yaml, &cfg_yaml(&out, &golden, &called, &fa, ""));
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let summary = load_summary(&out);
+    assert_eq!(summary["totals"]["tp"], 1, "{:?}", summary);
+    assert_eq!(summary["totals"]["fn_"], 0);
+    assert_eq!(summary["totals"]["fp"], 0);
+    assert_eq!(summary["totals"]["equivalents_promoted"], 1);
+}
+
+/// With `fast: true`, the same input should classify as 1 FN + 1 FP (no
+/// sweep). This confirms the fast knob disables the equivalence pass and
+/// confirms the sweep was the thing closing the gap above.
+#[test]
+fn fast_mode_skips_sweep_so_denotation_differs_as_fp_fn() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chrTest", "ACGTACGTACGT");
+    write_vcf(&golden, &["chrTest\t5\t.\tACGTA\tA\t60\tPASS\t.\tGT\t0/1"]);
+    write_vcf(&called, &["chrTest\t1\t.\tACGTA\tA\t60\tPASS\t.\tGT\t0/1"]);
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(
+        &yaml,
+        &cfg_yaml(&out, &golden, &called, &fa, "fast: true\n"),
+    );
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let summary = load_summary(&out);
+    assert_eq!(summary["totals"]["tp"], 0);
+    assert_eq!(summary["totals"]["fn_"], 1);
+    assert_eq!(summary["totals"]["fp"], 1);
+    assert_eq!(summary["totals"]["equivalents_promoted"], 0);
+    assert_eq!(summary["inputs"]["fast"], true);
+}
+
+/// A compound SNP pair (two FPs, one at each of two adjacent positions)
+/// producing the same alt sequence as a single multi-base substitution FN
+/// should be caught by the sweep.
+#[test]
+fn equivalence_catches_compound_snps_vs_multibase_substitution() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chrTest", "ACGTACGTACGT");
+    // Golden: pos 3 GT → AA (one MNP-style record)
+    write_vcf(&golden, &["chrTest\t3\t.\tGT\tAA\t60\tPASS\t.\tGT\t0/1"]);
+    // Called: pos 3 G→A AND pos 4 T→A (two SNPs)
+    write_vcf(
+        &called,
+        &[
+            "chrTest\t3\t.\tG\tA\t60\tPASS\t.\tGT\t0/1",
+            "chrTest\t4\t.\tT\tA\t60\tPASS\t.\tGT\t0/1",
+        ],
+    );
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(&yaml, &cfg_yaml(&out, &golden, &called, &fa, ""));
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let summary = load_summary(&out);
+    // 1 FN got promoted; the 2 FPs got consumed.
+    assert_eq!(summary["totals"]["tp"], 1, "{summary:#?}");
+    assert_eq!(summary["totals"]["fn_"], 0);
+    assert_eq!(summary["totals"]["fp"], 0);
+    assert_eq!(summary["totals"]["equivalents_promoted"], 1);
+}
+
+/// Genuinely different variants must not be equivalence-matched.
+#[test]
+fn unrelated_variants_remain_fp_and_fn() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chrTest", "ACGTACGTACGT");
+    write_vcf(&golden, &["chrTest\t3\t.\tG\tA\t60\tPASS\t.\tGT\t0/1"]);
+    write_vcf(&called, &["chrTest\t8\t.\tT\tC\t60\tPASS\t.\tGT\t0/1"]);
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(&yaml, &cfg_yaml(&out, &golden, &called, &fa, ""));
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let summary = load_summary(&out);
+    assert_eq!(summary["totals"]["tp"], 0);
+    assert_eq!(summary["totals"]["fn_"], 1);
+    assert_eq!(summary["totals"]["fp"], 1);
+    assert_eq!(summary["totals"]["equivalents_promoted"], 0);
+}
+
+/// The TXT report should announce the equivalence window in its header and
+/// the promoted-count line. (Smoke test on string contents.)
+#[test]
+fn txt_report_mentions_equivalence_window_and_promoted_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chrTest", "ACGTACGTACGT");
+    write_vcf(&golden, &["chrTest\t5\t.\tACGTA\tA\t60\tPASS\t.\tGT\t0/1"]);
+    write_vcf(&called, &["chrTest\t1\t.\tACGTA\tA\t60\tPASS\t.\tGT\t0/1"]);
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(&yaml, &cfg_yaml(&out, &golden, &called, &fa, ""));
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+    let txt = std::fs::read_to_string(out.join("comparison_summary.txt")).unwrap();
+    assert!(
+        txt.contains("Equivalence window: ±50 bp"),
+        "txt missing window header:\n{txt}"
+    );
+    assert!(
+        txt.contains("promoted by equivalence sweep: 1"),
+        "txt missing promoted line:\n{txt}"
+    );
+}

--- a/template_config/compare_vcfs_template.yml
+++ b/template_config/compare_vcfs_template.yml
@@ -36,3 +36,14 @@ include_homs: false
 # Include calls whose FILTER column is anything other than PASS / ".".
 # Default false.
 include_filtered: false
+
+# Half-width of the ±N bp window used for equivalence detection. The sweep
+# catches FPs and FNs that are denotation-different spellings of the same
+# edit (e.g., a left-aligned indel in the called VCF versus the same indel
+# right-aligned in the golden). Default 50, matching NEAT 2.1's EV_BPRANGE.
+equivalence_window: 50
+
+# Skip the equivalence sweep entirely. Matches NEAT 2.1's `--fast`. When
+# true, only exact (position, ref, alt) matches count as TP — denotation-
+# different alternates show up as FP + FN pairs. Default false.
+fast: false


### PR DESCRIPTION
Stacked on top of #152 (Phase 1). After Phase 1 merges into develop, retarget this PR's base to develop.

## Summary

- Ports NEAT 2.1's `vcf_compare.py` equivalence-detection algorithm to Rust. After exact-match classification, for each contig with FPs the runner walks the reference (via existing `FastaStream`) and runs a per-FP windowed comparison: take a ±`equivalence_window` bp slice around each FP, apply every FP and FN whose position falls inside, and compare the byte-altered windows. When the FP-applied and FN-applied bytes match (case-insensitive), every consumed FN is promoted to TP and every consumed FP is dropped.
- Catches left/right-aligned indels, multi-base substitutions written as adjacent SNPs vs a single multi-base record, and other denotation-different spellings of the same edit that exact matching mis-classifies.
- New config knobs: `equivalence_window` (default 50, matching NEAT 2.1's `EV_BPRANGE`) and `fast` (default false; skips the sweep entirely).
- Report extensions: `totals.equivalents_promoted`, `inputs.equivalence_window`, `inputs.fast`. TXT report shows the window or "SKIPPED (fast mode)" and a `↳ promoted by equivalence sweep` line under TP.

## Tests added (+11)

- 6 unit tests in `equivalence.rs` covering: left/right-aligned deletion, case-mismatched reference, compound SNPs vs single multi-base substitution, unrelated variants, lonely FP, window-clamp at contig start.
- 5 integration tests in `tests/compare_vcfs_phase2.rs` that drive the binary against synthetic FASTA + VCF pairs and assert the JSON report's `tp`/`fn_`/`fp`/`equivalents_promoted` counts. Includes a `fast: true` negative-control that re-classifies the canonical left/right-aligned deletion case as 1 FN + 1 FP.

Workspace test count: 429 → 440.

## Test plan

- [x] `cargo test --workspace` is green
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets` clean
- [x] Spot-check the TXT report on the canonical left/right-aligned case: verify the `↳ promoted by equivalence sweep: 1` line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)