### PR TITLE
feat(compare-vcfs): Phase 1 — exact-match classification + JSON/TXT r…

### DIFF
--- a/rneat/src/compare_vcfs/errors.rs
+++ b/rneat/src/compare_vcfs/errors.rs
@@ -1,0 +1,20 @@
+use common::file_tools::{bed_reader::BedReaderError, vcf_tools::VcfToolsError};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CompareVcfsError {
+    #[error("I/O error during compare-vcfs: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("YAML parse error: {0}")]
+    YamlError(#[from] serde_yml::Error),
+    #[error("JSON serialization error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("Invalid Configuration inputs: {0}")]
+    ConfigurationError(String),
+    #[error("Cannot overwrite existing file: {0}")]
+    OverwriteFileError(String),
+    #[error("Error reading the VCF file: {0}")]
+    VcfReaderError(#[from] VcfToolsError),
+    #[error("The bed reader returned an error: {0}")]
+    BedReaderErr(#[from] BedReaderError),
+}

--- a/rneat/src/compare_vcfs/mod.rs
+++ b/rneat/src/compare_vcfs/mod.rs
@@ -1,0 +1,21 @@
+//! `compare-vcfs` subcommand. Compares a downstream variant-caller VCF (called)
+//! against a NEAT-simulated truth VCF (golden) and reports true positives,
+//! false negatives, and false positives.
+//!
+//! Phase 1 implements exact-match classification by `(position, ref, alt)` key
+//! plus a JSON / TXT rollup. Equivalence detection (denotation-different
+//! indels) and NEAT-aware FN attribution are planned for later phases — see
+//! issue #127.
+pub mod errors;
+pub mod utils;
+
+use crate::compare_vcfs::{
+    errors::CompareVcfsError, utils::config::RunConfiguration, utils::runner::runner,
+};
+use std::path::PathBuf;
+
+pub fn main(config_file: &PathBuf) -> Result<(), CompareVcfsError> {
+    let run_config = RunConfiguration::from(config_file)?;
+    runner(&run_config)?;
+    Ok(())
+}

--- a/rneat/src/compare_vcfs/utils.rs
+++ b/rneat/src/compare_vcfs/utils.rs
@@ -1,0 +1,3 @@
+pub mod config;
+pub mod report;
+pub mod runner;

--- a/rneat/src/compare_vcfs/utils/config.rs
+++ b/rneat/src/compare_vcfs/utils/config.rs
@@ -1,0 +1,213 @@
+// Configuration for the `compare-vcfs` subcommand. Stores validated paths and
+// flag values only; the VCFs themselves are read inside `runner` so this
+// struct stays cheap to construct/test.
+use crate::compare_vcfs::errors::CompareVcfsError;
+use serde_yml::Value;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct RunConfiguration {
+    pub golden_vcf: PathBuf,
+    pub called_vcf: PathBuf,
+    pub reference: PathBuf,
+    pub output_dir: PathBuf,
+    pub overwrite_output: bool,
+    pub target_bed: Option<PathBuf>,
+    /// `None` means "treat every contig in the golden VCF as simulated".
+    pub contigs_simulated: Option<Vec<String>>,
+    pub include_homs: bool,
+    pub include_filtered: bool,
+}
+
+impl RunConfiguration {
+    pub fn from(yml_file: &PathBuf) -> Result<Self, CompareVcfsError> {
+        let file = fs::File::open(yml_file).map_err(|e| {
+            CompareVcfsError::ConfigurationError(format!(
+                "could not open config {}: {e}",
+                yml_file.display()
+            ))
+        })?;
+        let scrape: HashMap<String, Value> = serde_yml::from_reader(file)?;
+
+        let golden_vcf = require_path(&scrape, "golden_vcf")?;
+        reject_bcf(&golden_vcf)?;
+        let called_vcf = require_path(&scrape, "called_vcf")?;
+        reject_bcf(&called_vcf)?;
+        let reference = require_path(&scrape, "reference")?;
+
+        let output_dir = require_str(&scrape, "output_dir").map(PathBuf::from)?;
+        if output_dir.is_file() {
+            return Err(CompareVcfsError::ConfigurationError(format!(
+                "output_dir {} exists as a file, not a directory",
+                output_dir.display()
+            )));
+        }
+
+        let overwrite_output = scrape
+            .get("overwrite_output")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let target_bed = optional_path(&scrape, "target_bed")?;
+        let contigs_simulated = optional_string_list(&scrape, "contigs_simulated");
+        let include_homs = scrape
+            .get("include_homs")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let include_filtered = scrape
+            .get("include_filtered")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        Ok(RunConfiguration {
+            golden_vcf,
+            called_vcf,
+            reference,
+            output_dir,
+            overwrite_output,
+            target_bed,
+            contigs_simulated,
+            include_homs,
+            include_filtered,
+        })
+    }
+}
+
+fn require_str(scrape: &HashMap<String, Value>, key: &str) -> Result<String, CompareVcfsError> {
+    scrape
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| CompareVcfsError::ConfigurationError(format!("{key} is required in config")))
+}
+
+fn require_path(scrape: &HashMap<String, Value>, key: &str) -> Result<PathBuf, CompareVcfsError> {
+    let raw = require_str(scrape, key)?;
+    let p = PathBuf::from(raw);
+    if !p.is_file() {
+        return Err(CompareVcfsError::ConfigurationError(format!(
+            "{key} not found: {}",
+            p.display()
+        )));
+    }
+    Ok(p)
+}
+
+fn optional_path(
+    scrape: &HashMap<String, Value>,
+    key: &str,
+) -> Result<Option<PathBuf>, CompareVcfsError> {
+    let raw = scrape.get(key).and_then(|v| v.as_str()).unwrap_or(".");
+    if raw == "." || raw.is_empty() {
+        return Ok(None);
+    }
+    let p = PathBuf::from(raw);
+    if !p.is_file() {
+        return Err(CompareVcfsError::ConfigurationError(format!(
+            "{key} not found: {}",
+            p.display()
+        )));
+    }
+    Ok(Some(p))
+}
+
+fn optional_string_list(scrape: &HashMap<String, Value>, key: &str) -> Option<Vec<String>> {
+    let raw = scrape.get(key).and_then(|v| v.as_str()).unwrap_or(".");
+    if raw == "." || raw.is_empty() {
+        return None;
+    }
+    let items: Vec<String> = raw
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if items.is_empty() { None } else { Some(items) }
+}
+
+fn reject_bcf(p: &Path) -> Result<(), CompareVcfsError> {
+    if p.extension().and_then(|s| s.to_str()) == Some("bcf") {
+        return Err(CompareVcfsError::ConfigurationError(format!(
+            "{} is a BCF; only .vcf and .vcf.gz are supported in Phase 1",
+            p.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn manifest_path(rel: &str) -> String {
+        format!("{}/{rel}", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    fn write_yaml(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    #[test]
+    fn test_minimal_config_parses() {
+        let h1n1 = manifest_path("test_data/references/H1N1.fa");
+        let vcf = manifest_path("test_data/vcfs/small_snps.vcf");
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let yml = write_yaml(&format!(
+            "golden_vcf: {vcf}\ncalled_vcf: {vcf}\nreference: {h1n1}\noutput_dir: {}\n",
+            tmp_dir.path().display()
+        ));
+        let cfg = RunConfiguration::from(&yml.path().to_path_buf()).unwrap();
+        assert!(cfg.target_bed.is_none());
+        assert!(cfg.contigs_simulated.is_none());
+        assert!(!cfg.include_homs);
+        assert!(!cfg.include_filtered);
+        assert!(!cfg.overwrite_output);
+    }
+
+    #[test]
+    fn test_missing_required_field_errors() {
+        let yml = write_yaml("golden_vcf: /tmp/nope.vcf\n");
+        let err = RunConfiguration::from(&yml.path().to_path_buf()).unwrap_err();
+        assert!(matches!(err, CompareVcfsError::ConfigurationError(_)));
+    }
+
+    #[test]
+    fn test_contigs_simulated_parses_csv() {
+        let h1n1 = manifest_path("test_data/references/H1N1.fa");
+        let vcf = manifest_path("test_data/vcfs/small_snps.vcf");
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let yml = write_yaml(&format!(
+            "golden_vcf: {vcf}\ncalled_vcf: {vcf}\nreference: {h1n1}\noutput_dir: {}\n\
+             contigs_simulated: chr1, chr2,  chrX\n",
+            tmp_dir.path().display()
+        ));
+        let cfg = RunConfiguration::from(&yml.path().to_path_buf()).unwrap();
+        assert_eq!(
+            cfg.contigs_simulated.unwrap(),
+            vec!["chr1".to_string(), "chr2".to_string(), "chrX".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_bcf_rejected() {
+        let h1n1 = manifest_path("test_data/references/H1N1.fa");
+        let bcf = tempfile::Builder::new().suffix(".bcf").tempfile().unwrap();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let yml = write_yaml(&format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {h1n1}\noutput_dir: {}\n",
+            bcf.path().display(),
+            bcf.path().display(),
+            tmp_dir.path().display()
+        ));
+        let err = RunConfiguration::from(&yml.path().to_path_buf()).unwrap_err();
+        match err {
+            CompareVcfsError::ConfigurationError(msg) => assert!(msg.contains("BCF")),
+            _ => panic!("expected ConfigurationError, got {err:?}"),
+        }
+    }
+}

--- a/rneat/src/compare_vcfs/utils/report.rs
+++ b/rneat/src/compare_vcfs/utils/report.rs
@@ -1,0 +1,337 @@
+//! Output artifacts for `compare-vcfs`: a schema-versioned JSON rollup and a
+//! plain-text rendering of the same data.
+//!
+//! Schema is versioned so downstream tooling can detect format drift; bump
+//! [`SCHEMA_VERSION`] only when a backward-incompatible field change lands.
+use crate::compare_vcfs::errors::CompareVcfsError;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub const SCHEMA_VERSION: &str = "1.0.0";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContigCounts {
+    pub tp: usize,
+    pub fn_: usize,
+    pub fp: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Metrics {
+    /// `None` when TP + FP == 0.
+    pub precision: Option<f64>,
+    /// `None` when TP + FN == 0.
+    pub recall: Option<f64>,
+    /// `None` when precision or recall is `None`, or when both are 0.
+    pub f1: Option<f64>,
+}
+
+impl Metrics {
+    pub fn from_counts(tp: usize, fn_: usize, fp: usize) -> Self {
+        let precision = if tp + fp > 0 {
+            Some(tp as f64 / (tp + fp) as f64)
+        } else {
+            None
+        };
+        let recall = if tp + fn_ > 0 {
+            Some(tp as f64 / (tp + fn_) as f64)
+        } else {
+            None
+        };
+        let f1 = match (precision, recall) {
+            (Some(p), Some(r)) if p + r > 0.0 => Some(2.0 * p * r / (p + r)),
+            _ => None,
+        };
+        Metrics {
+            precision,
+            recall,
+            f1,
+        }
+    }
+}
+
+/// Per-VCF parser-skip counters surfaced to the report so users aren't
+/// surprised that some records didn't make it into the classification.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SkipCounts {
+    pub multiallelic: usize,
+    pub homozygous_ref: usize,
+    pub filtered: usize,
+    pub outside_target_bed: usize,
+    pub outside_simulated_contigs: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ComparisonSummary {
+    pub schema_version: &'static str,
+    pub inputs: SummaryInputs,
+    pub totals: ContigCounts,
+    pub metrics: Metrics,
+    /// Keyed by contig name. BTreeMap so JSON / TXT output is sorted.
+    pub per_contig: BTreeMap<String, ContigCounts>,
+    pub skipped_golden: SkipCounts,
+    pub skipped_called: SkipCounts,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SummaryInputs {
+    pub golden_vcf: PathBuf,
+    pub called_vcf: PathBuf,
+    pub reference: PathBuf,
+    pub target_bed: Option<PathBuf>,
+    pub contigs_simulated: Option<Vec<String>>,
+    pub include_homs: bool,
+    pub include_filtered: bool,
+}
+
+pub fn write_json(
+    summary: &ComparisonSummary,
+    output_dir: &Path,
+    overwrite_output: bool,
+) -> Result<PathBuf, CompareVcfsError> {
+    let path = output_dir.join("comparison_summary.json");
+    check_overwrite(&path, overwrite_output)?;
+    let file = fs::File::create(&path)?;
+    serde_json::to_writer_pretty(file, summary)?;
+    Ok(path)
+}
+
+pub fn write_txt(
+    summary: &ComparisonSummary,
+    output_dir: &Path,
+    overwrite_output: bool,
+) -> Result<PathBuf, CompareVcfsError> {
+    let path = output_dir.join("comparison_summary.txt");
+    check_overwrite(&path, overwrite_output)?;
+    let mut file = fs::File::create(&path)?;
+    file.write_all(render_txt(summary).as_bytes())?;
+    Ok(path)
+}
+
+fn check_overwrite(path: &Path, allow: bool) -> Result<(), CompareVcfsError> {
+    if path.is_file() && !allow {
+        return Err(CompareVcfsError::OverwriteFileError(
+            path.display().to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn render_txt(s: &ComparisonSummary) -> String {
+    let mut out = String::new();
+    out.push_str("rneat compare-vcfs report\n");
+    out.push_str("=========================\n\n");
+    out.push_str(&format!("Schema version: {}\n\n", s.schema_version));
+    out.push_str("Inputs\n------\n");
+    out.push_str(&format!(
+        "  Golden VCF: {}\n",
+        s.inputs.golden_vcf.display()
+    ));
+    out.push_str(&format!(
+        "  Called VCF: {}\n",
+        s.inputs.called_vcf.display()
+    ));
+    out.push_str(&format!("  Reference:  {}\n", s.inputs.reference.display()));
+    if let Some(p) = &s.inputs.target_bed {
+        out.push_str(&format!("  Target BED: {}\n", p.display()));
+    }
+    if let Some(c) = &s.inputs.contigs_simulated {
+        out.push_str(&format!("  Contigs simulated: {}\n", c.join(", ")));
+    }
+    out.push_str(&format!("  Include hom-refs:  {}\n", s.inputs.include_homs));
+    out.push_str(&format!(
+        "  Include filtered:  {}\n",
+        s.inputs.include_filtered
+    ));
+    out.push('\n');
+
+    out.push_str("Totals\n------\n");
+    out.push_str(&format!("  True positives  (TP): {}\n", s.totals.tp));
+    out.push_str(&format!("  False negatives (FN): {}\n", s.totals.fn_));
+    out.push_str(&format!("  False positives (FP): {}\n\n", s.totals.fp));
+
+    out.push_str("Metrics\n-------\n");
+    out.push_str(&format!(
+        "  Precision: {}  (TP / (TP + FP))\n",
+        fmt_metric(s.metrics.precision)
+    ));
+    out.push_str(&format!(
+        "  Recall:    {}  (TP / (TP + FN))\n",
+        fmt_metric(s.metrics.recall)
+    ));
+    out.push_str(&format!("  F1:        {}\n\n", fmt_metric(s.metrics.f1)));
+
+    out.push_str("Per-contig counts\n-----------------\n");
+    if s.per_contig.is_empty() {
+        out.push_str("  (none)\n\n");
+    } else {
+        let name_width = s
+            .per_contig
+            .keys()
+            .map(|k| k.len())
+            .max()
+            .unwrap_or(0)
+            .max(6);
+        out.push_str(&format!(
+            "  {:<width$}    TP      FN      FP\n",
+            "Contig",
+            width = name_width
+        ));
+        for (chrom, c) in &s.per_contig {
+            out.push_str(&format!(
+                "  {:<width$}  {:>6}  {:>6}  {:>6}\n",
+                chrom,
+                c.tp,
+                c.fn_,
+                c.fp,
+                width = name_width
+            ));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("Skipped records (golden / called)\n---------------------------------\n");
+    out.push_str(&format!(
+        "  Multi-allelic:               {} / {}\n",
+        s.skipped_golden.multiallelic, s.skipped_called.multiallelic
+    ));
+    out.push_str(&format!(
+        "  Homozygous reference:        {} / {}\n",
+        s.skipped_golden.homozygous_ref, s.skipped_called.homozygous_ref
+    ));
+    out.push_str(&format!(
+        "  Filtered (non-PASS):         {} / {}\n",
+        s.skipped_golden.filtered, s.skipped_called.filtered
+    ));
+    out.push_str(&format!(
+        "  Outside target BED:          {} / {}\n",
+        s.skipped_golden.outside_target_bed, s.skipped_called.outside_target_bed
+    ));
+    out.push_str(&format!(
+        "  Outside simulated contigs:   {} / {}\n",
+        s.skipped_golden.outside_simulated_contigs, s.skipped_called.outside_simulated_contigs
+    ));
+
+    out
+}
+
+fn fmt_metric(v: Option<f64>) -> String {
+    match v {
+        Some(x) => format!("{x:.4}"),
+        None => "N/A".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metrics_basic() {
+        let m = Metrics::from_counts(80, 20, 5);
+        assert!((m.precision.unwrap() - (80.0 / 85.0)).abs() < 1e-9);
+        assert!((m.recall.unwrap() - 0.8).abs() < 1e-9);
+        assert!(m.f1.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn test_metrics_zero_truth() {
+        let m = Metrics::from_counts(0, 0, 3);
+        assert!(m.recall.is_none());
+        assert_eq!(m.precision, Some(0.0));
+        assert!(m.f1.is_none());
+    }
+
+    #[test]
+    fn test_render_txt_includes_totals() {
+        let s = ComparisonSummary {
+            schema_version: SCHEMA_VERSION,
+            inputs: SummaryInputs {
+                golden_vcf: PathBuf::from("/g.vcf"),
+                called_vcf: PathBuf::from("/c.vcf"),
+                reference: PathBuf::from("/r.fa"),
+                target_bed: None,
+                contigs_simulated: None,
+                include_homs: false,
+                include_filtered: false,
+            },
+            totals: ContigCounts {
+                tp: 7,
+                fn_: 1,
+                fp: 2,
+            },
+            metrics: Metrics::from_counts(7, 1, 2),
+            per_contig: BTreeMap::new(),
+            skipped_golden: SkipCounts::default(),
+            skipped_called: SkipCounts::default(),
+        };
+        let txt = render_txt(&s);
+        assert!(txt.contains("True positives  (TP): 7"));
+        assert!(txt.contains("False negatives (FN): 1"));
+        assert!(txt.contains("False positives (FP): 2"));
+    }
+
+    #[test]
+    fn test_write_json_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = ComparisonSummary {
+            schema_version: SCHEMA_VERSION,
+            inputs: SummaryInputs {
+                golden_vcf: PathBuf::from("/g.vcf"),
+                called_vcf: PathBuf::from("/c.vcf"),
+                reference: PathBuf::from("/r.fa"),
+                target_bed: None,
+                contigs_simulated: None,
+                include_homs: false,
+                include_filtered: false,
+            },
+            totals: ContigCounts {
+                tp: 3,
+                fn_: 0,
+                fp: 0,
+            },
+            metrics: Metrics::from_counts(3, 0, 0),
+            per_contig: BTreeMap::new(),
+            skipped_golden: SkipCounts::default(),
+            skipped_called: SkipCounts::default(),
+        };
+        let path = write_json(&s, dir.path(), false).unwrap();
+        let raw = fs::read_to_string(&path).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(val["schema_version"], "1.0.0");
+        assert_eq!(val["totals"]["tp"], 3);
+    }
+
+    #[test]
+    fn test_overwrite_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().join("comparison_summary.json");
+        fs::write(&existing, "stale").unwrap();
+        let s = ComparisonSummary {
+            schema_version: SCHEMA_VERSION,
+            inputs: SummaryInputs {
+                golden_vcf: PathBuf::from("/g"),
+                called_vcf: PathBuf::from("/c"),
+                reference: PathBuf::from("/r"),
+                target_bed: None,
+                contigs_simulated: None,
+                include_homs: false,
+                include_filtered: false,
+            },
+            totals: ContigCounts {
+                tp: 0,
+                fn_: 0,
+                fp: 0,
+            },
+            metrics: Metrics::from_counts(0, 0, 0),
+            per_contig: BTreeMap::new(),
+            skipped_golden: SkipCounts::default(),
+            skipped_called: SkipCounts::default(),
+        };
+        let err = write_json(&s, dir.path(), false).unwrap_err();
+        assert!(matches!(err, CompareVcfsError::OverwriteFileError(_)));
+    }
+}

--- a/rneat/src/compare_vcfs/utils/runner.rs
+++ b/rneat/src/compare_vcfs/utils/runner.rs
@@ -1,0 +1,338 @@
+//! Phase 1 driver for `compare-vcfs`: exact-match classification.
+//!
+//! Algorithm:
+//!   1. Read golden + called VCFs via `common::file_tools::vcf_tools::read_vcf`.
+//!   2. For each VCF, drop variants the user has filtered out: outside the
+//!      simulated contigs, outside the target BED, hom-ref, non-PASS — each
+//!      counted into a [`SkipCounts`] for the report.
+//!   3. Per contig, key surviving variants by `(position, ref, alt)` into a
+//!      `HashSet<VariantKey>`. TP = golden ∩ called; FN = golden \ called;
+//!      FP = called \ golden.
+//!   4. Aggregate per-contig and total counts, compute precision/recall/F1,
+//!      write `comparison_summary.{json,txt}`.
+//!
+//! Equivalence detection (denotation-different indels) and NEAT-aware FN
+//! attribution are out of scope; see issue #127.
+use crate::compare_vcfs::{
+    errors::CompareVcfsError,
+    utils::{
+        config::RunConfiguration,
+        report::{
+            ComparisonSummary, ContigCounts, Metrics, SCHEMA_VERSION, SkipCounts, SummaryInputs,
+            write_json, write_txt,
+        },
+    },
+};
+use common::{
+    file_tools::{bed_reader::read_bed, vcf_tools::read_vcf},
+    structs::{bed_record::BedRecord, nucleotides::Nucleotide, variants::Variant},
+};
+use log::*;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+
+/// Comparison key: the three columns that decide a true positive. Hashing on
+/// `Variant` directly is wrong because its derived `Hash` includes
+/// genotype/filter/info, none of which the truth-vs-called comparison cares about.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct VariantKey {
+    location: usize,
+    reference: Vec<Nucleotide>,
+    alternate: Vec<Nucleotide>,
+}
+
+impl From<&Variant> for VariantKey {
+    fn from(v: &Variant) -> Self {
+        VariantKey {
+            location: v.location,
+            reference: v.reference.clone(),
+            alternate: v.alternate.clone(),
+        }
+    }
+}
+
+pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
+    fs::create_dir_all(&config.output_dir)?;
+
+    let target_bed = match &config.target_bed {
+        Some(p) => Some(read_bed(p, false)?),
+        None => None,
+    };
+    let simulated_set = config
+        .contigs_simulated
+        .as_ref()
+        .map(|v| v.iter().cloned().collect::<HashSet<_>>());
+
+    info!("Reading golden VCF: {}", config.golden_vcf.display());
+    let golden_raw = read_vcf(config.golden_vcf.clone())?;
+    info!("Reading called VCF: {}", config.called_vcf.display());
+    let called_raw = read_vcf(config.called_vcf.clone())?;
+
+    let (golden_by_contig, skipped_golden) = filter_vcf(
+        &golden_raw,
+        target_bed.as_ref(),
+        simulated_set.as_ref(),
+        config.include_homs,
+        config.include_filtered,
+    );
+    let (called_by_contig, skipped_called) = filter_vcf(
+        &called_raw,
+        target_bed.as_ref(),
+        simulated_set.as_ref(),
+        config.include_homs,
+        config.include_filtered,
+    );
+
+    let (per_contig, totals) = classify(&golden_by_contig, &called_by_contig);
+    let metrics = Metrics::from_counts(totals.tp, totals.fn_, totals.fp);
+    info!(
+        "Classification: TP={} FN={} FP={}",
+        totals.tp, totals.fn_, totals.fp
+    );
+
+    let summary = ComparisonSummary {
+        schema_version: SCHEMA_VERSION,
+        inputs: SummaryInputs {
+            golden_vcf: config.golden_vcf.clone(),
+            called_vcf: config.called_vcf.clone(),
+            reference: config.reference.clone(),
+            target_bed: config.target_bed.clone(),
+            contigs_simulated: config.contigs_simulated.clone(),
+            include_homs: config.include_homs,
+            include_filtered: config.include_filtered,
+        },
+        totals,
+        metrics,
+        per_contig,
+        skipped_golden,
+        skipped_called,
+    };
+
+    let json_path = write_json(&summary, &config.output_dir, config.overwrite_output)?;
+    let txt_path = write_txt(&summary, &config.output_dir, config.overwrite_output)?;
+    info!("Wrote {}", json_path.display());
+    info!("Wrote {}", txt_path.display());
+    Ok(())
+}
+
+/// Drops disqualified variants and tallies the reasons. The returned map keeps
+/// only contigs whose surviving variant list is non-empty so downstream
+/// classification doesn't iterate empty buckets.
+fn filter_vcf(
+    raw: &HashMap<String, Vec<Variant>>,
+    target_bed: Option<&HashMap<String, Vec<BedRecord>>>,
+    simulated_set: Option<&HashSet<String>>,
+    include_homs: bool,
+    include_filtered: bool,
+) -> (HashMap<String, Vec<Variant>>, SkipCounts) {
+    let mut kept: HashMap<String, Vec<Variant>> = HashMap::new();
+    let mut skipped = SkipCounts::default();
+    for (chrom, variants) in raw {
+        if let Some(sim) = simulated_set
+            && !sim.contains(chrom)
+        {
+            skipped.outside_simulated_contigs += variants.len();
+            continue;
+        }
+        for v in variants {
+            if !include_homs && v.reference == v.alternate {
+                skipped.homozygous_ref += 1;
+                continue;
+            }
+            if !include_filtered && !filter_is_pass(v) {
+                skipped.filtered += 1;
+                continue;
+            }
+            if let Some(bed) = target_bed {
+                let regions = bed.get(chrom);
+                let in_target = regions
+                    .map(|rs| rs.iter().any(|r| r.contains(chrom, v.location)))
+                    .unwrap_or(false);
+                if !in_target {
+                    skipped.outside_target_bed += 1;
+                    continue;
+                }
+            }
+            kept.entry(chrom.clone()).or_default().push(v.clone());
+        }
+    }
+    (kept, skipped)
+}
+
+fn filter_is_pass(v: &Variant) -> bool {
+    match v.filter.as_deref() {
+        None | Some("PASS") | Some(".") | Some("") => true,
+        Some(_) => false,
+    }
+}
+
+fn classify(
+    golden: &HashMap<String, Vec<Variant>>,
+    called: &HashMap<String, Vec<Variant>>,
+) -> (BTreeMap<String, ContigCounts>, ContigCounts) {
+    let mut per_contig: BTreeMap<String, ContigCounts> = BTreeMap::new();
+    let mut totals = ContigCounts {
+        tp: 0,
+        fn_: 0,
+        fp: 0,
+    };
+
+    let all_contigs: HashSet<&String> = golden.keys().chain(called.keys()).collect();
+    for chrom in all_contigs {
+        let g_keys: HashSet<VariantKey> = golden
+            .get(chrom)
+            .map(|vs| vs.iter().map(VariantKey::from).collect())
+            .unwrap_or_default();
+        let c_keys: HashSet<VariantKey> = called
+            .get(chrom)
+            .map(|vs| vs.iter().map(VariantKey::from).collect())
+            .unwrap_or_default();
+        let tp = g_keys.intersection(&c_keys).count();
+        let fn_ = g_keys.len() - tp;
+        let fp = c_keys.len() - tp;
+        totals.tp += tp;
+        totals.fn_ += fn_;
+        totals.fp += fp;
+        per_contig.insert(chrom.clone(), ContigCounts { tp, fn_, fp });
+    }
+    (per_contig, totals)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::structs::variants::{Genotype, VariantType};
+
+    fn snp(loc: usize, ref_b: Nucleotide, alt_b: Nucleotide, filter: Option<&str>) -> Variant {
+        Variant {
+            variant_type: VariantType::SNP,
+            location: loc,
+            reference: vec![ref_b],
+            alternate: vec![alt_b],
+            genotype_str: "0/1".to_string(),
+            genotype: Genotype::Heterozygous,
+            id: None,
+            quality_score: None,
+            filter: filter.map(str::to_string),
+            info: None,
+            format: Vec::new(),
+            sample: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn classify_all_tp() {
+        let v = snp(10, Nucleotide::A, Nucleotide::C, Some("PASS"));
+        let mut g = HashMap::new();
+        g.insert("chr1".into(), vec![v.clone()]);
+        let mut c = HashMap::new();
+        c.insert("chr1".into(), vec![v]);
+        let (per, tot) = classify(&g, &c);
+        assert_eq!(tot.tp, 1);
+        assert_eq!(tot.fn_, 0);
+        assert_eq!(tot.fp, 0);
+        assert_eq!(per["chr1"].tp, 1);
+    }
+
+    #[test]
+    fn classify_mixed() {
+        // golden has (10,A,C) and (20,G,T); called has (10,A,C) and (30,T,A).
+        // → 1 TP, 1 FN, 1 FP.
+        let mut g = HashMap::new();
+        g.insert(
+            "chr1".into(),
+            vec![
+                snp(10, Nucleotide::A, Nucleotide::C, Some("PASS")),
+                snp(20, Nucleotide::G, Nucleotide::T, Some("PASS")),
+            ],
+        );
+        let mut c = HashMap::new();
+        c.insert(
+            "chr1".into(),
+            vec![
+                snp(10, Nucleotide::A, Nucleotide::C, Some("PASS")),
+                snp(30, Nucleotide::T, Nucleotide::A, Some("PASS")),
+            ],
+        );
+        let (_per, tot) = classify(&g, &c);
+        assert_eq!(tot.tp, 1);
+        assert_eq!(tot.fn_, 1);
+        assert_eq!(tot.fp, 1);
+    }
+
+    #[test]
+    fn classify_contig_only_in_one_side() {
+        // Golden has variants on chr1 only; called has variants on chr2 only.
+        // Per-contig: chr1 → 1 FN, chr2 → 1 FP. Totals: 0 TP, 1 FN, 1 FP.
+        let mut g = HashMap::new();
+        g.insert(
+            "chr1".into(),
+            vec![snp(10, Nucleotide::A, Nucleotide::C, Some("PASS"))],
+        );
+        let mut c = HashMap::new();
+        c.insert(
+            "chr2".into(),
+            vec![snp(50, Nucleotide::G, Nucleotide::A, Some("PASS"))],
+        );
+        let (per, tot) = classify(&g, &c);
+        assert_eq!(tot.tp, 0);
+        assert_eq!(tot.fn_, 1);
+        assert_eq!(tot.fp, 1);
+        assert_eq!(per["chr1"].fn_, 1);
+        assert_eq!(per["chr2"].fp, 1);
+    }
+
+    #[test]
+    fn filter_skips_homref_when_not_included() {
+        let mut raw = HashMap::new();
+        raw.insert(
+            "chr1".into(),
+            vec![snp(10, Nucleotide::A, Nucleotide::A, Some("PASS"))],
+        );
+        let (kept, skipped) = filter_vcf(&raw, None, None, false, false);
+        assert!(kept.is_empty());
+        assert_eq!(skipped.homozygous_ref, 1);
+    }
+
+    #[test]
+    fn filter_skips_non_pass_when_not_included() {
+        let mut raw = HashMap::new();
+        raw.insert(
+            "chr1".into(),
+            vec![snp(10, Nucleotide::A, Nucleotide::C, Some("LowQual"))],
+        );
+        let (kept, skipped) = filter_vcf(&raw, None, None, false, false);
+        assert!(kept.is_empty());
+        assert_eq!(skipped.filtered, 1);
+    }
+
+    #[test]
+    fn filter_includes_non_pass_when_flag_set() {
+        let mut raw = HashMap::new();
+        raw.insert(
+            "chr1".into(),
+            vec![snp(10, Nucleotide::A, Nucleotide::C, Some("LowQual"))],
+        );
+        let (kept, skipped) = filter_vcf(&raw, None, None, false, true);
+        assert_eq!(kept.get("chr1").unwrap().len(), 1);
+        assert_eq!(skipped.filtered, 0);
+    }
+
+    #[test]
+    fn filter_drops_unsimulated_contigs() {
+        let mut raw = HashMap::new();
+        raw.insert(
+            "chr1".into(),
+            vec![snp(10, Nucleotide::A, Nucleotide::C, Some("PASS"))],
+        );
+        raw.insert(
+            "chr2".into(),
+            vec![snp(20, Nucleotide::G, Nucleotide::T, Some("PASS"))],
+        );
+        let sim: HashSet<String> = ["chr1".to_string()].into_iter().collect();
+        let (kept, skipped) = filter_vcf(&raw, None, Some(&sim), false, false);
+        assert!(kept.contains_key("chr1"));
+        assert!(!kept.contains_key("chr2"));
+        assert_eq!(skipped.outside_simulated_contigs, 1);
+    }
+}

--- a/rneat/src/main.rs
+++ b/rneat/src/main.rs
@@ -5,6 +5,7 @@ extern crate serde;
 extern crate serde_json;
 extern crate simplelog;
 
+pub mod compare_vcfs;
 pub mod filter_reads;
 pub mod gen_bam_models;
 pub mod gen_frag_length_model;
@@ -25,7 +26,8 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::{
-    filter_reads::errors::FilterReadsError, gen_bam_models::errors::GenBamModelsError,
+    compare_vcfs::errors::CompareVcfsError, filter_reads::errors::FilterReadsError,
+    gen_bam_models::errors::GenBamModelsError,
     gen_frag_length_model::errors::GenFragLengthModelError,
     gen_gc_bias_model::errors::GenGcBiasModelError, gen_mut_model::errors::GenMutationModelError,
     gen_reads::errors::GenerateReadsError, gen_seq_error_model::errors::GenSeqErrorModelError,
@@ -50,9 +52,11 @@ pub enum NeatErrors {
     GenGcBiasModel(#[from] GenGcBiasModelError),
     #[error("Error while generating BAM-derived models {0}")]
     GenBamModels(#[from] GenBamModelsError),
+    #[error("Error while comparing VCFs {0}")]
+    CompareVcfs(#[from] CompareVcfsError),
 }
 
-fn neat_commands() -> [Command; 7] {
+fn neat_commands() -> [Command; 8] {
     // These are the submodule commands. Any new commands added should go here.
     let configuration_arg = Arg::new("configuration_yaml")
         .long("configuration-yaml")
@@ -90,6 +94,10 @@ fn neat_commands() -> [Command; 7] {
             .arg(&configuration_arg),
         Command::new("gen-bam-models")
             .about("Build multiple models (frag-length, GC bias) from one BAM in a single pass")
+            .arg_required_else_help(true)
+            .arg(&configuration_arg),
+        Command::new("compare-vcfs")
+            .about("Compare a NEAT-simulated golden VCF against a downstream variant-caller VCF")
             .arg_required_else_help(true)
             .arg(&configuration_arg),
     ]
@@ -346,6 +354,32 @@ fn main() -> Result<(), NeatErrors> {
                 match result {
                     Err(error) => return Err(NeatErrors::GenBamModels(error)),
                     Ok(()) => info!("rneat gen-bam-models completed successfully"),
+                }
+            }
+        }
+        Some(("compare-vcfs", _)) => {
+            if let Some(("compare-vcfs", cmd)) = subcommand
+                && cmd.contains_id("configuration_yaml")
+            {
+                info!("Running rneat compare-vcfs");
+                let file = cmd
+                    .get_one::<PathBuf>("configuration_yaml")
+                    .expect("Must provide a path with configuration-yaml")
+                    .to_path_buf();
+
+                if !file.is_file() {
+                    return Err(NeatErrors::CompareVcfs(
+                        CompareVcfsError::ConfigurationError(
+                            "Must supply a valid configuration file to run compare-vcfs!"
+                                .to_string(),
+                        ),
+                    ));
+                }
+                info!("Running compare-vcfs to classify golden vs called variants.");
+                let result = compare_vcfs::main(&file);
+                match result {
+                    Err(error) => return Err(NeatErrors::CompareVcfs(error)),
+                    Ok(()) => info!("rneat compare-vcfs completed successfully"),
                 }
             }
         }

--- a/rneat/tests/cli_smoke.rs
+++ b/rneat/tests/cli_smoke.rs
@@ -19,6 +19,8 @@ const EXPECTED_SUBCOMMANDS: &[&str] = &[
     "gen-seq-error-model",
     "gen-frag-length-model",
     "gen-gc-bias-model",
+    "gen-bam-models",
+    "compare-vcfs",
 ];
 
 #[test]

--- a/rneat/tests/compare_vcfs_phase1.rs
+++ b/rneat/tests/compare_vcfs_phase1.rs
@@ -1,0 +1,276 @@
+//! Integration tests for `rneat compare-vcfs` Phase 1.
+//!
+//! Exercises the binary against tiny hand-crafted golden + called VCF pairs
+//! and asserts the parsed `comparison_summary.json` contents match expected
+//! TP / FN / FP counts.
+
+mod common;
+
+use common::rneat;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+fn h1n1_reference() -> PathBuf {
+    PathBuf::from(format!(
+        "{}/test_data/references/H1N1.fa",
+        env!("CARGO_MANIFEST_DIR"),
+    ))
+}
+
+fn write_vcf(path: &Path, body_lines: &[&str]) {
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, "##fileformat=VCFv4.2").unwrap();
+    writeln!(
+        f,
+        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
+    )
+    .unwrap();
+    writeln!(
+        f,
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE"
+    )
+    .unwrap();
+    for line in body_lines {
+        writeln!(f, "{line}").unwrap();
+    }
+}
+
+fn write_yaml(path: &Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    write!(f, "{content}").unwrap();
+}
+
+fn load_summary(dir: &Path) -> serde_json::Value {
+    let raw = std::fs::read_to_string(dir.join("comparison_summary.json")).unwrap();
+    serde_json::from_str(&raw).unwrap()
+}
+
+#[test]
+fn compare_vcfs_perfect_match_yields_all_tp() {
+    let tmp = tempfile::tempdir().unwrap();
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out_dir = tmp.path().join("report");
+    let body = &[
+        "H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1",
+        "H1N1_HA\t200\t.\tG\tT\t60\tPASS\t.\tGT\t1/1",
+    ];
+    write_vcf(&golden, body);
+    write_vcf(&called, body);
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\noverwrite_output: true\n",
+            golden.display(),
+            called.display(),
+            h1n1_reference().display(),
+            out_dir.display(),
+        ),
+    );
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let summary = load_summary(&out_dir);
+    assert_eq!(summary["schema_version"], "1.0.0");
+    assert_eq!(summary["totals"]["tp"], 2);
+    assert_eq!(summary["totals"]["fn_"], 0);
+    assert_eq!(summary["totals"]["fp"], 0);
+    assert_eq!(summary["metrics"]["precision"], 1.0);
+    assert_eq!(summary["metrics"]["recall"], 1.0);
+    assert_eq!(summary["metrics"]["f1"], 1.0);
+}
+
+#[test]
+fn compare_vcfs_mixed_classification() {
+    // Golden: (100,A,C), (200,G,T)
+    // Called: (100,A,C), (300,T,A)
+    // → 1 TP, 1 FN (200), 1 FP (300).
+    let tmp = tempfile::tempdir().unwrap();
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out_dir = tmp.path().join("report");
+    write_vcf(
+        &golden,
+        &[
+            "H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1",
+            "H1N1_HA\t200\t.\tG\tT\t60\tPASS\t.\tGT\t1/1",
+        ],
+    );
+    write_vcf(
+        &called,
+        &[
+            "H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1",
+            "H1N1_HA\t300\t.\tT\tA\t60\tPASS\t.\tGT\t0/1",
+        ],
+    );
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\noverwrite_output: true\n",
+            golden.display(),
+            called.display(),
+            h1n1_reference().display(),
+            out_dir.display(),
+        ),
+    );
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let summary = load_summary(&out_dir);
+    assert_eq!(summary["totals"]["tp"], 1);
+    assert_eq!(summary["totals"]["fn_"], 1);
+    assert_eq!(summary["totals"]["fp"], 1);
+    assert_eq!(summary["per_contig"]["H1N1_HA"]["tp"], 1);
+    assert_eq!(summary["per_contig"]["H1N1_HA"]["fn_"], 1);
+    assert_eq!(summary["per_contig"]["H1N1_HA"]["fp"], 1);
+}
+
+#[test]
+fn compare_vcfs_writes_txt_report_alongside_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out_dir = tmp.path().join("report");
+    write_vcf(&golden, &["H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1"]);
+    write_vcf(&called, &["H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1"]);
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\noverwrite_output: true\n",
+            golden.display(),
+            called.display(),
+            h1n1_reference().display(),
+            out_dir.display(),
+        ),
+    );
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let txt = std::fs::read_to_string(out_dir.join("comparison_summary.txt")).unwrap();
+    assert!(txt.contains("True positives  (TP): 1"));
+    assert!(txt.contains("Schema version: 1.0.0"));
+}
+
+#[test]
+fn compare_vcfs_contigs_simulated_filter_drops_unrelated_calls() {
+    // Golden has H1N1_HA only; called has both H1N1_HA and H1N1_NA.
+    // With contigs_simulated=H1N1_HA, the H1N1_NA "FP" should not be counted —
+    // it's outside the simulated contig set.
+    let tmp = tempfile::tempdir().unwrap();
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out_dir = tmp.path().join("report");
+    write_vcf(&golden, &["H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1"]);
+    write_vcf(
+        &called,
+        &[
+            "H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1",
+            "H1N1_NA\t50\t.\tG\tA\t60\tPASS\t.\tGT\t0/1",
+        ],
+    );
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\n\
+             overwrite_output: true\ncontigs_simulated: H1N1_HA\n",
+            golden.display(),
+            called.display(),
+            h1n1_reference().display(),
+            out_dir.display(),
+        ),
+    );
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let summary = load_summary(&out_dir);
+    assert_eq!(summary["totals"]["tp"], 1);
+    assert_eq!(summary["totals"]["fn_"], 0);
+    assert_eq!(summary["totals"]["fp"], 0);
+    assert_eq!(summary["skipped_called"]["outside_simulated_contigs"], 1);
+}
+
+#[test]
+fn compare_vcfs_non_pass_filtered_by_default() {
+    // Both VCFs contain a LowQual record on top of a PASS record. With
+    // include_filtered=false (default), the LowQual records are dropped from
+    // both — leaving a 1 TP comparison plus 1 + 1 skipped/filtered.
+    let tmp = tempfile::tempdir().unwrap();
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out_dir = tmp.path().join("report");
+    write_vcf(
+        &golden,
+        &[
+            "H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1",
+            "H1N1_HA\t200\t.\tG\tT\t10\tLowQual\t.\tGT\t0/1",
+        ],
+    );
+    write_vcf(
+        &called,
+        &[
+            "H1N1_HA\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1",
+            "H1N1_HA\t200\t.\tG\tT\t10\tLowQual\t.\tGT\t0/1",
+        ],
+    );
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\noverwrite_output: true\n",
+            golden.display(),
+            called.display(),
+            h1n1_reference().display(),
+            out_dir.display(),
+        ),
+    );
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let summary = load_summary(&out_dir);
+    assert_eq!(summary["totals"]["tp"], 1);
+    assert_eq!(summary["totals"]["fn_"], 0);
+    assert_eq!(summary["totals"]["fp"], 0);
+    assert_eq!(summary["skipped_golden"]["filtered"], 1);
+    assert_eq!(summary["skipped_called"]["filtered"], 1);
+}
+
+#[test]
+fn compare_vcfs_missing_config_field_fails_nonzero() {
+    let tmp = tempfile::tempdir().unwrap();
+    let yaml = tmp.path().join("cfg.yml");
+    write_yaml(&yaml, "golden_vcf: /nonexistent/path.vcf\n");
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .failure();
+}

--- a/template_config/compare_vcfs_template.yml
+++ b/template_config/compare_vcfs_template.yml
@@ -1,0 +1,38 @@
+# REQUIRED PARAMS
+# NEAT-simulated truth VCF (typically <prefix>_golden.vcf.gz from gen-reads).
+# Accepts .vcf or .vcf.gz.
+golden_vcf:
+
+# Downstream variant caller's VCF produced from the simulated reads.
+# Accepts .vcf or .vcf.gz.
+called_vcf:
+
+# Reference FASTA used for the simulation. Reserved for forward compatibility
+# with the Phase 2 equivalence-detection algorithm; in Phase 1 this is
+# path-checked but otherwise unused.
+reference:
+
+# Directory where the comparison report will be written. Created if absent.
+# Files written: comparison_summary.json, comparison_summary.txt.
+output_dir:
+
+# OPTIONAL PARAMS
+# Overwrite existing report files in output_dir. Default false.
+overwrite_output: false
+
+# Restrict comparison to variants inside these BED regions. "." disables.
+target_bed: .
+
+# Comma-separated list of contigs to consider, e.g. "chr1,chr2,chrX".
+# Variants on contigs not in this list are dropped from both VCFs before
+# classification (matches NEAT 4 behavior — un-simulated contigs do not
+# contribute to FN). "." treats every contig present in the golden VCF
+# as simulated.
+contigs_simulated: .
+
+# Include homozygous-reference calls (ALT == "." or ALT == REF). Default false.
+include_homs: false
+
+# Include calls whose FILTER column is anything other than PASS / ".".
+# Default false.
+include_filtered: false


### PR DESCRIPTION
…eport

New `rneat compare-vcfs` subcommand that classifies a downstream variant caller's VCF against a NEAT-simulated golden VCF and writes `comparison_summary.{json,txt}` with TP/FN/FP counts, per-contig breakdown, precision/recall/F1, and per-VCF skip counters (multi-allelic, hom-ref, filtered, outside target BED, outside simulated contigs).

Phase 1 scope: exact-match key `(position, ref, alt)`, no equivalence detection (no ±50bp reference application), no NEAT-aware FN attribution. Both follow in Phase 2/3. See issue #127.

Reuses existing utilities:
- `common::file_tools::vcf_tools::read_vcf` for input (.vcf + .vcf.gz)
- `common::file_tools::bed_reader::read_bed` for optional target_bed
- `common::structs::variants::Variant` (with a private `VariantKey` newtype for the comparison hash — Variant's derived Hash/Eq includes genotype/filter/info, none of which belong in TP matching).

CLI surface: `rneat compare-vcfs -c <config.yml>`. Config schema in `template_config/compare_vcfs_template.yml`.

Output schema: `schema_version: "1.0.0"` — bump only on backward- incompatible field changes.

Tests added (22 total):
- 16 unit tests across config, runner, report
- 6 integration tests in `tests/compare_vcfs_phase1.rs` exercising the binary end-to-end against synthetic VCFs (perfect-match, mixed classification, contig filtering, non-PASS filter, missing-config failure path, TXT companion output).

Workspace now has 429 tests passing (was 407).

Closes part of #127.