### PR TITLE
compare-vcfs Phase 4: FN_with_reasons.vcf + optional FP.vcf + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ SUB-COMMANDS:
   gen-frag-length-model  Generates a fragment length model from a BAM or SAM file
   gen-gc-bias-model      Generates a GC bias model from a reference FASTA and aligned BAM
   gen-bam-models         Builds multiple models (frag-length, GC bias) from one BAM in a single pass
+  compare-vcfs           Compares a NEAT-simulated golden VCF against a downstream variant-caller VCF
   help                   Print this message or the help of the given subcommand(s)
 
 Options:
@@ -600,6 +601,55 @@ gc_bias:
 Both sections are optional but at least one must be present. The output models are interchangeable with what `gen-frag-length-model` and `gen-gc-bias-model` would produce on their own, so the resulting files plug into `gen-reads` exactly the same way.
 
 **One filter for the shared walk.** The top-level `min_mapq` is the only MAPQ knob exposed to the unified walker, and it gates *both* observers. The standalone tools differ: `gen-frag-length-model` hard-codes its own MAPQ > 10 cutoff (via `BamWalkFilter::for_frag_length()`), while `gen-gc-bias-model` honors the `min_mapq` you pass it. If you want the unified runner's frag-length output to match the standalone command byte-for-byte, set `min_mapq: 10`; if you want the GC bias output to match a standalone run with `min_mapq: 20`, set `min_mapq: 20`. When the two policies need to differ, run `gen-bam-models` twice — one config per output — and the per-observer BAM iteration savings still beat running the standalone commands.
+
+Comparing a downstream caller's VCF against the golden VCF
+==========================================================
+After running `gen-reads`, you can validate a downstream variant caller against the simulated truth using `rneat compare-vcfs`. The subcommand classifies every variant into TP / FN / FP, catches denotation-different alternates that exact matching would mis-classify as both an FN and an FP (e.g., a left-aligned indel in the called VCF versus the same indel right-aligned in the golden), and attributes the surviving FNs to specific reasons drawn from the simulator's configuration.
+
+```bash
+$ rneat compare-vcfs -c compare_vcfs_config.yml
+```
+
+Copy `template_config/compare_vcfs_template.yml` and fill in:
+
+```yaml
+golden_vcf: /path/to/golden.vcf.gz
+called_vcf: /path/to/called.vcf.gz
+reference:  /path/to/reference.fa
+output_dir: /path/to/report_dir
+overwrite_output: false
+
+# Optional: restrict comparison to these regions.
+target_bed: .
+# Optional: comma-separated list. "." treats every called contig as simulated.
+contigs_simulated: .
+# Optional: BED used by the simulator. Drives FN attribution.
+mutation_bed: .
+# Optional: TSV remapping BED chrom names (e.g., 1<TAB>chr1).
+chrom_aliases: .
+
+# Filters
+include_homs: false       # ALT == REF rows
+include_filtered: false   # FILTER != PASS / "."
+
+# Equivalence sweep (NEAT 2.1 algorithm, ported)
+equivalence_window: 50    # ±N bp around each FP
+fast: false               # skip the sweep entirely
+
+# Outputs
+write_fp_vcf: false       # also produce FP.vcf
+```
+
+The run produces four files under `output_dir`:
+
+- `comparison_summary.json` — schema-versioned (currently `1.2.0`), machine-readable. Includes TP/FN/FP totals + per-contig breakdown, precision / recall / F1, the FN attribution roll-up (`outside_simulated_contigs`, `outside_mutation_bed`, `outside_target_bed`, `unknown`), and any chrom-naming-mismatch warnings.
+- `comparison_summary.txt` — same content, human-readable.
+- `FN_with_reasons.vcf` — every surviving FN, annotated with a `NEAT_REASON` INFO tag listing the attribution reasons.
+- `FP.vcf` (optional) — every surviving FP, as-is. Off by default; enable with `write_fp_vcf: true`.
+
+**Equivalence detection.** For each false-positive variant, `compare-vcfs` takes a ±`equivalence_window` bp window of the reference and applies both the FP set and the FN set within that window. If the resulting byte sequences are identical, the two sets are alternative spellings of the same edit and every consumed FN is promoted to TP. Set `fast: true` to skip this pass; the report's `totals.equivalents_promoted` counts how many TPs were rescued by it.
+
+**FN attribution.** Each surviving FN is tagged with at least one reason. If the FN's contig wasn't in `contigs_simulated`, that reason is reported alone (the BED checks are skipped because they presuppose the contig was simulated). Otherwise the configured BEDs are checked and `unknown` is the fallback. Aliases configured via `chrom_aliases` are applied to BED chrom names at load time, so you can compare against a reference that uses one convention (e.g., `chr1`) when your BED uses another (e.g., `1`). When a BED has any chrom that doesn't appear in the reference's FASTA contig list (post-alias), `compare-vcfs` surfaces a warning in the report — useful for catching single-typo BEDs that would otherwise misattribute every variant on that contig.
 
 Running on HPC
 ==============

--- a/rneat/src/compare_vcfs/utils.rs
+++ b/rneat/src/compare_vcfs/utils.rs
@@ -3,3 +3,4 @@ pub mod config;
 pub mod equivalence;
 pub mod report;
 pub mod runner;
+pub mod vcf_writer;

--- a/rneat/src/compare_vcfs/utils/config.rs
+++ b/rneat/src/compare_vcfs/utils/config.rs
@@ -32,6 +32,10 @@ pub struct RunConfiguration {
     /// canonical names (e.g. `1\tchr1`). Applied to both `mutation_bed`
     /// and `target_bed` at load time. None when not configured.
     pub chrom_aliases: Option<PathBuf>,
+    /// Also write `<output_dir>/FP.vcf` listing every false-positive call.
+    /// Off by default — FP sets can be large on noisy callers and the
+    /// `comparison_summary.json`/`.txt` already report counts.
+    pub write_fp_vcf: bool,
 }
 
 impl RunConfiguration {
@@ -83,6 +87,10 @@ impl RunConfiguration {
             .unwrap_or(false);
         let mutation_bed = optional_path(&scrape, "mutation_bed")?;
         let chrom_aliases = optional_path(&scrape, "chrom_aliases")?;
+        let write_fp_vcf = scrape
+            .get("write_fp_vcf")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         Ok(RunConfiguration {
             golden_vcf,
@@ -98,6 +106,7 @@ impl RunConfiguration {
             fast,
             mutation_bed,
             chrom_aliases,
+            write_fp_vcf,
         })
     }
 }

--- a/rneat/src/compare_vcfs/utils/report.rs
+++ b/rneat/src/compare_vcfs/utils/report.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-pub const SCHEMA_VERSION: &str = "1.1.0";
+pub const SCHEMA_VERSION: &str = "1.2.0";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ContigCounts {
@@ -88,6 +88,20 @@ pub struct ComparisonSummary {
     /// chrom-naming mismatches.
     #[serde(default)]
     pub warnings: Vec<ChromNamingWarning>,
+    /// Absolute paths to every artifact this run wrote. Lets downstream
+    /// tooling locate sibling files without re-deriving them from the
+    /// output_dir layout.
+    pub outputs: SummaryOutputs,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SummaryOutputs {
+    pub comparison_summary_json: PathBuf,
+    pub comparison_summary_txt: PathBuf,
+    pub fn_with_reasons_vcf: PathBuf,
+    /// `None` when `write_fp_vcf` was false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fp_vcf: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -273,6 +287,23 @@ fn render_txt(s: &ComparisonSummary) -> String {
         }
     }
 
+    out.push_str("\nOutputs\n-------\n");
+    out.push_str(&format!(
+        "  Summary (JSON): {}\n",
+        s.outputs.comparison_summary_json.display()
+    ));
+    out.push_str(&format!(
+        "  Summary (TXT):  {}\n",
+        s.outputs.comparison_summary_txt.display()
+    ));
+    out.push_str(&format!(
+        "  Annotated FNs:  {}\n",
+        s.outputs.fn_with_reasons_vcf.display()
+    ));
+    if let Some(p) = &s.outputs.fp_vcf {
+        out.push_str(&format!("  False positives:{}\n", p.display()));
+    }
+
     out
 }
 
@@ -332,6 +363,12 @@ mod tests {
             skipped_called: SkipCounts::default(),
             fn_attribution: BTreeMap::new(),
             warnings: Vec::new(),
+            outputs: SummaryOutputs {
+                comparison_summary_json: PathBuf::from("/out.json"),
+                comparison_summary_txt: PathBuf::from("/out.txt"),
+                fn_with_reasons_vcf: PathBuf::from("/out_fn.vcf"),
+                fp_vcf: None,
+            },
         };
         let txt = render_txt(&s);
         assert!(txt.contains("True positives  (TP): 7"));
@@ -369,11 +406,17 @@ mod tests {
             skipped_called: SkipCounts::default(),
             fn_attribution: BTreeMap::new(),
             warnings: Vec::new(),
+            outputs: SummaryOutputs {
+                comparison_summary_json: PathBuf::from("/out.json"),
+                comparison_summary_txt: PathBuf::from("/out.txt"),
+                fn_with_reasons_vcf: PathBuf::from("/out_fn.vcf"),
+                fp_vcf: None,
+            },
         };
         let path = write_json(&s, dir.path(), false).unwrap();
         let raw = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert_eq!(val["schema_version"], "1.1.0");
+        assert_eq!(val["schema_version"], "1.2.0");
         assert_eq!(val["totals"]["tp"], 3);
     }
 
@@ -409,6 +452,12 @@ mod tests {
             skipped_called: SkipCounts::default(),
             fn_attribution: BTreeMap::new(),
             warnings: Vec::new(),
+            outputs: SummaryOutputs {
+                comparison_summary_json: PathBuf::from("/out.json"),
+                comparison_summary_txt: PathBuf::from("/out.txt"),
+                fn_with_reasons_vcf: PathBuf::from("/out_fn.vcf"),
+                fp_vcf: None,
+            },
         };
         let err = write_json(&s, dir.path(), false).unwrap_err();
         assert!(matches!(err, CompareVcfsError::OverwriteFileError(_)));

--- a/rneat/src/compare_vcfs/utils/runner.rs
+++ b/rneat/src/compare_vcfs/utils/runner.rs
@@ -27,8 +27,9 @@ use crate::compare_vcfs::{
         equivalence,
         report::{
             ComparisonSummary, ContigCounts, Metrics, SCHEMA_VERSION, SkipCounts, SummaryInputs,
-            write_json, write_txt,
+            SummaryOutputs, write_json, write_txt,
         },
+        vcf_writer::{write_fn_with_reasons, write_fp_vcf},
     },
 };
 use common::{
@@ -236,6 +237,33 @@ pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
         warnings.len()
     );
 
+    // Write per-record VCF artifacts before the JSON/TXT report so the
+    // report's `outputs` section can name them. FN_with_reasons.vcf is
+    // always written; FP.vcf is gated on the config flag.
+    let fn_vcf_path = write_fn_with_reasons(
+        &attribution_result,
+        &config.output_dir,
+        config.overwrite_output,
+    )?;
+    info!("Wrote {}", fn_vcf_path.display());
+
+    let fp_vcf_path = if config.write_fp_vcf {
+        let mut fp_pairs: Vec<(String, &Variant)> = Vec::new();
+        for (chrom, b) in &buckets {
+            for v in &b.fps {
+                fp_pairs.push((chrom.clone(), v));
+            }
+        }
+        let p = write_fp_vcf(&fp_pairs, &config.output_dir, config.overwrite_output)?;
+        info!("Wrote {}", p.display());
+        Some(p)
+    } else {
+        None
+    };
+
+    let json_path = config.output_dir.join("comparison_summary.json");
+    let txt_path = config.output_dir.join("comparison_summary.txt");
+
     let summary = ComparisonSummary {
         schema_version: SCHEMA_VERSION,
         inputs: SummaryInputs {
@@ -258,12 +286,18 @@ pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
         skipped_called,
         fn_attribution: attribution_result.counts,
         warnings,
+        outputs: SummaryOutputs {
+            comparison_summary_json: json_path.clone(),
+            comparison_summary_txt: txt_path.clone(),
+            fn_with_reasons_vcf: fn_vcf_path.clone(),
+            fp_vcf: fp_vcf_path.clone(),
+        },
     };
 
-    let json_path = write_json(&summary, &config.output_dir, config.overwrite_output)?;
-    let txt_path = write_txt(&summary, &config.output_dir, config.overwrite_output)?;
-    info!("Wrote {}", json_path.display());
-    info!("Wrote {}", txt_path.display());
+    let written_json = write_json(&summary, &config.output_dir, config.overwrite_output)?;
+    let written_txt = write_txt(&summary, &config.output_dir, config.overwrite_output)?;
+    info!("Wrote {}", written_json.display());
+    info!("Wrote {}", written_txt.display());
     Ok(())
 }
 

--- a/rneat/src/compare_vcfs/utils/vcf_writer.rs
+++ b/rneat/src/compare_vcfs/utils/vcf_writer.rs
@@ -1,0 +1,248 @@
+//! VCF output writers for `compare-vcfs`.
+//!
+//! Two artifacts:
+//!   - `FN_with_reasons.vcf` — every surviving FN annotated with a
+//!     `NEAT_REASON` INFO tag listing the attribution reasons.
+//!   - `FP.vcf` — every surviving FP, as-is. Optional; gated on
+//!     `write_fp_vcf` in the config because some pipelines accumulate
+//!     large FP sets and the user may not want the extra artifact.
+//!
+//! Both writers emit minimal VCFv4.2 headers and reuse the original
+//! Variant's per-column data (ID, QUAL, FILTER, INFO, FORMAT, SAMPLE).
+//! We do **not** preserve the source VCF's `##contig=` lines because
+//! that would require re-reading the input header; downstream tools that
+//! need it can re-create from the reference FASTA.
+use crate::compare_vcfs::errors::CompareVcfsError;
+use crate::compare_vcfs::utils::attribution::{AttributionResult, Reason};
+use common::structs::{nucleotides::sequence_array_to_string, variants::Variant};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const HEADER_BASE: &str = "\
+##fileformat=VCFv4.2
+##source=rneat compare-vcfs
+##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">
+";
+const NEAT_REASON_INFO: &str = "##INFO=<ID=NEAT_REASON,Number=.,Type=String,\
+Description=\"Comma-separated NEAT-aware false-negative attribution reasons\">\n";
+const COLUMN_HEADER: &str = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n";
+
+/// Write FN records with NEAT_REASON annotations to
+/// `<output_dir>/FN_with_reasons.vcf`. Returns the written path.
+///
+/// If `attribution.per_fn` is empty, the file is still written (header
+/// only) so downstream tools can rely on the artifact existing.
+pub fn write_fn_with_reasons(
+    attribution: &AttributionResult,
+    output_dir: &Path,
+    overwrite_output: bool,
+) -> Result<PathBuf, CompareVcfsError> {
+    let path = output_dir.join("FN_with_reasons.vcf");
+    check_overwrite(&path, overwrite_output)?;
+    let mut file = fs::File::create(&path)?;
+    file.write_all(HEADER_BASE.as_bytes())?;
+    file.write_all(NEAT_REASON_INFO.as_bytes())?;
+    file.write_all(COLUMN_HEADER.as_bytes())?;
+    for (chrom, variant, reasons) in &attribution.per_fn {
+        let line = format_record(chrom, variant, Some(reasons));
+        file.write_all(line.as_bytes())?;
+        file.write_all(b"\n")?;
+    }
+    Ok(path)
+}
+
+/// Write FP records to `<output_dir>/FP.vcf`. Returns the written path.
+pub fn write_fp_vcf(
+    fps_by_contig: &[(String, &Variant)],
+    output_dir: &Path,
+    overwrite_output: bool,
+) -> Result<PathBuf, CompareVcfsError> {
+    let path = output_dir.join("FP.vcf");
+    check_overwrite(&path, overwrite_output)?;
+    let mut file = fs::File::create(&path)?;
+    file.write_all(HEADER_BASE.as_bytes())?;
+    file.write_all(COLUMN_HEADER.as_bytes())?;
+    for (chrom, v) in fps_by_contig {
+        let line = format_record(chrom, v, None);
+        file.write_all(line.as_bytes())?;
+        file.write_all(b"\n")?;
+    }
+    Ok(path)
+}
+
+fn check_overwrite(path: &Path, allow: bool) -> Result<(), CompareVcfsError> {
+    if path.is_file() && !allow {
+        return Err(CompareVcfsError::OverwriteFileError(
+            path.display().to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Serialize one Variant as a tab-separated VCF record. If `reasons` is
+/// `Some`, append `NEAT_REASON=<csv>` to the INFO column.
+fn format_record(chrom: &str, v: &Variant, reasons: Option<&[Reason]>) -> String {
+    let id = v.id.as_deref().unwrap_or(".");
+    let ref_str = sequence_array_to_string(&v.reference);
+    let alt_str = sequence_array_to_string(&v.alternate);
+    let qual = match v.quality_score {
+        Some(q) => q.to_string(),
+        None => ".".to_string(),
+    };
+    let filter = v.filter.as_deref().unwrap_or(".");
+    let info_base = v.info.as_deref().unwrap_or(".");
+    let info = match reasons {
+        Some(rs) if !rs.is_empty() => {
+            let reason_csv = rs.iter().map(|r| r.as_str()).collect::<Vec<_>>().join(",");
+            // Preserve an existing INFO blob if present; replace bare "." since
+            // it's the "no info" sentinel.
+            if info_base == "." || info_base.is_empty() {
+                format!("NEAT_REASON={reason_csv}")
+            } else {
+                format!("{info_base};NEAT_REASON={reason_csv}")
+            }
+        }
+        _ => info_base.to_string(),
+    };
+    let (format_col, sample_col) = if v.format.is_empty() {
+        // Synthesize a minimal GT column from genotype_str so the line is
+        // well-formed (we declared GT in the header).
+        ("GT".to_string(), v.genotype_str.clone())
+    } else {
+        (v.format.join(":"), v.sample.join(":"))
+    };
+
+    format!(
+        "{chrom}\t{pos}\t{id}\t{ref_str}\t{alt_str}\t{qual}\t{filter}\t{info}\t{format_col}\t{sample_col}",
+        pos = v.location,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::structs::{
+        nucleotides::Nucleotide,
+        variants::{Genotype, VariantType},
+    };
+
+    fn snp_with(loc: usize, info: Option<&str>) -> Variant {
+        Variant {
+            variant_type: VariantType::SNP,
+            location: loc,
+            reference: vec![Nucleotide::A],
+            alternate: vec![Nucleotide::C],
+            genotype_str: "0/1".to_string(),
+            genotype: Genotype::Heterozygous,
+            id: None,
+            quality_score: Some(60),
+            filter: Some("PASS".to_string()),
+            info: info.map(str::to_string),
+            format: Vec::new(),
+            sample: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn format_record_adds_neat_reason_when_info_is_dot() {
+        let v = snp_with(100, Some("."));
+        let line = format_record("chr1", &v, Some(&[Reason::Unknown]));
+        assert!(line.contains("\tNEAT_REASON=unknown\t"));
+        // Original "." should be replaced, not preserved as ".;NEAT_REASON=...".
+        assert!(!line.contains(".;NEAT_REASON"));
+    }
+
+    #[test]
+    fn format_record_preserves_existing_info_and_appends_reason() {
+        let v = snp_with(100, Some("DP=30;AF=0.5"));
+        let line = format_record(
+            "chr1",
+            &v,
+            Some(&[Reason::OutsideMutationBed, Reason::OutsideTargetBed]),
+        );
+        assert!(
+            line.contains("DP=30;AF=0.5;NEAT_REASON=outside_mutation_bed,outside_target_bed"),
+            "got: {line}"
+        );
+    }
+
+    #[test]
+    fn format_record_without_reasons_keeps_info_unchanged() {
+        let v = snp_with(100, Some("DP=30"));
+        let line = format_record("chr1", &v, None);
+        assert!(line.contains("\tDP=30\tGT\t0/1"));
+        assert!(!line.contains("NEAT_REASON"));
+    }
+
+    #[test]
+    fn format_record_synthesizes_gt_column_when_format_empty() {
+        let v = snp_with(100, None);
+        let line = format_record("chr1", &v, None);
+        // Trailing two tab-separated fields are FORMAT and SAMPLE.
+        let parts: Vec<&str> = line.split('\t').collect();
+        assert_eq!(parts[8], "GT");
+        assert_eq!(parts[9], "0/1");
+    }
+
+    #[test]
+    fn fn_with_reasons_writes_header_and_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let v = snp_with(100, None);
+        let attribution = AttributionResult {
+            per_fn: vec![("chr1".to_string(), v, vec![Reason::Unknown])],
+            counts: Default::default(),
+        };
+        let path = write_fn_with_reasons(&attribution, dir.path(), false).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("##fileformat=VCFv4.2"));
+        assert!(body.contains("##INFO=<ID=NEAT_REASON"));
+        assert!(body.contains("#CHROM\tPOS"));
+        assert!(body.contains("NEAT_REASON=unknown"));
+    }
+
+    #[test]
+    fn fn_with_reasons_writes_header_only_when_no_fns() {
+        let dir = tempfile::tempdir().unwrap();
+        let attribution = AttributionResult {
+            per_fn: Vec::new(),
+            counts: Default::default(),
+        };
+        let path = write_fn_with_reasons(&attribution, dir.path(), false).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("##fileformat=VCFv4.2"));
+        // Last line should be the column header — no data rows past it.
+        let after_header: Vec<&str> = body
+            .lines()
+            .skip_while(|l| l.starts_with('#') && !l.starts_with("#CHROM"))
+            .skip(1)
+            .collect();
+        assert!(
+            after_header.iter().all(|l| l.is_empty()),
+            "expected no data rows, found: {after_header:?}"
+        );
+    }
+
+    #[test]
+    fn fp_vcf_writes_records_without_neat_reason_info() {
+        let dir = tempfile::tempdir().unwrap();
+        let v = snp_with(200, None);
+        let fps: Vec<(String, &Variant)> = vec![("chr2".to_string(), &v)];
+        let path = write_fp_vcf(&fps, dir.path(), false).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(!body.contains("NEAT_REASON"));
+        assert!(body.contains("chr2\t200"));
+    }
+
+    #[test]
+    fn overwrite_refused_when_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("FN_with_reasons.vcf"), "stale").unwrap();
+        let attribution = AttributionResult {
+            per_fn: Vec::new(),
+            counts: Default::default(),
+        };
+        let err = write_fn_with_reasons(&attribution, dir.path(), false).unwrap_err();
+        assert!(matches!(err, CompareVcfsError::OverwriteFileError(_)));
+    }
+}

--- a/rneat/tests/compare_vcfs_phase1.rs
+++ b/rneat/tests/compare_vcfs_phase1.rs
@@ -77,7 +77,7 @@ fn compare_vcfs_perfect_match_yields_all_tp() {
         .success();
 
     let summary = load_summary(&out_dir);
-    assert_eq!(summary["schema_version"], "1.1.0");
+    assert_eq!(summary["schema_version"], "1.2.0");
     assert_eq!(summary["totals"]["tp"], 2);
     assert_eq!(summary["totals"]["fn_"], 0);
     assert_eq!(summary["totals"]["fp"], 0);
@@ -166,7 +166,7 @@ fn compare_vcfs_writes_txt_report_alongside_json() {
 
     let txt = std::fs::read_to_string(out_dir.join("comparison_summary.txt")).unwrap();
     assert!(txt.contains("True positives  (TP): 1"));
-    assert!(txt.contains("Schema version: 1.1.0"));
+    assert!(txt.contains("Schema version: 1.2.0"));
 }
 
 #[test]

--- a/rneat/tests/compare_vcfs_phase4.rs
+++ b/rneat/tests/compare_vcfs_phase4.rs
@@ -1,0 +1,254 @@
+//! Phase 4 integration tests: FN_with_reasons.vcf and optional FP.vcf writers.
+
+mod common;
+
+use common::rneat;
+use std::io::Write;
+use std::path::Path;
+
+fn write_fasta(path: &Path, contig: &str, sequence: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, ">{contig}").unwrap();
+    writeln!(f, "{sequence}").unwrap();
+}
+
+fn write_vcf(path: &Path, body_lines: &[&str]) {
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, "##fileformat=VCFv4.2").unwrap();
+    writeln!(
+        f,
+        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
+    )
+    .unwrap();
+    writeln!(
+        f,
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE"
+    )
+    .unwrap();
+    for line in body_lines {
+        writeln!(f, "{line}").unwrap();
+    }
+}
+
+fn write_text(path: &Path, content: &str) {
+    let mut f = std::fs::File::create(path).unwrap();
+    write!(f, "{content}").unwrap();
+}
+
+fn load_summary(dir: &Path) -> serde_json::Value {
+    let raw = std::fs::read_to_string(dir.join("comparison_summary.json")).unwrap();
+    serde_json::from_str(&raw).unwrap()
+}
+
+/// FN_with_reasons.vcf is written unconditionally and contains the surviving
+/// FN records, each annotated with a NEAT_REASON INFO tag.
+#[test]
+fn fn_with_reasons_vcf_is_written_with_neat_reason_tag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chr1", &"A".repeat(1000));
+    // Golden has two SNPs, called VCF is empty → 2 FNs.
+    write_vcf(
+        &golden,
+        &[
+            "chr1\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1",
+            "chr1\t500\t.\tA\tG\t60\tPASS\t.\tGT\t1/1",
+        ],
+    );
+    write_vcf(&called, &[]);
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_text(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\noverwrite_output: true\n",
+            golden.display(),
+            called.display(),
+            fa.display(),
+            out.display(),
+        ),
+    );
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let fn_vcf = out.join("FN_with_reasons.vcf");
+    assert!(fn_vcf.is_file(), "FN_with_reasons.vcf was not written");
+    let body = std::fs::read_to_string(&fn_vcf).unwrap();
+    assert!(body.contains("##INFO=<ID=NEAT_REASON"));
+    assert!(body.contains("#CHROM\tPOS\tID\tREF\tALT"));
+    // Both FNs should have NEAT_REASON=unknown (no mutation/target BED configured).
+    let data_lines: Vec<&str> = body
+        .lines()
+        .filter(|l| !l.starts_with('#'))
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert_eq!(
+        data_lines.len(),
+        2,
+        "expected 2 FN rows, got: {data_lines:?}"
+    );
+    assert!(data_lines.iter().all(|l| l.contains("NEAT_REASON=unknown")));
+
+    // outputs section in JSON should point at this file.
+    let summary = load_summary(&out);
+    assert!(
+        summary["outputs"]["fn_with_reasons_vcf"]
+            .as_str()
+            .unwrap()
+            .ends_with("FN_with_reasons.vcf")
+    );
+    // FP.vcf should NOT be present unless explicitly opted into.
+    assert!(summary["outputs"].get("fp_vcf").is_none());
+    assert!(!out.join("FP.vcf").exists());
+}
+
+/// `write_fp_vcf: true` produces FP.vcf with the called-only records, and
+/// the JSON report's outputs section references it.
+#[test]
+fn fp_vcf_written_when_opted_in() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chr1", &"A".repeat(1000));
+    write_vcf(&golden, &[]);
+    write_vcf(
+        &called,
+        &[
+            "chr1\t200\t.\tA\tT\t60\tPASS\tDP=42\tGT\t0/1",
+            "chr1\t800\t.\tA\tG\t60\tPASS\t.\tGT\t1/1",
+        ],
+    );
+
+    let yaml = tmp.path().join("cfg.yml");
+    write_text(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\n\
+             overwrite_output: true\nwrite_fp_vcf: true\n",
+            golden.display(),
+            called.display(),
+            fa.display(),
+            out.display(),
+        ),
+    );
+
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let fp_vcf = out.join("FP.vcf");
+    assert!(fp_vcf.is_file(), "FP.vcf was not written");
+    let body = std::fs::read_to_string(&fp_vcf).unwrap();
+    // Two FP records expected.
+    let data_lines: Vec<&str> = body
+        .lines()
+        .filter(|l| !l.starts_with('#'))
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert_eq!(data_lines.len(), 2);
+    // INFO column is preserved (one record has DP=42).
+    assert!(data_lines.iter().any(|l| l.contains("DP=42")));
+    // No NEAT_REASON tag on FP records.
+    assert!(!body.contains("NEAT_REASON"));
+
+    let summary = load_summary(&out);
+    assert!(
+        summary["outputs"]["fp_vcf"]
+            .as_str()
+            .unwrap()
+            .ends_with("FP.vcf")
+    );
+}
+
+/// FN_with_reasons.vcf is well-formed enough to round-trip back through
+/// the existing read_vcf path — i.e., another rneat pipeline could consume
+/// it as input.
+#[test]
+fn fn_with_reasons_vcf_round_trips_via_existing_reader() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chr1", &"A".repeat(1000));
+    write_vcf(&golden, &["chr1\t100\t.\tA\tC\t60\tPASS\tDP=20\tGT\t0/1"]);
+    write_vcf(&called, &[]);
+    let yaml = tmp.path().join("cfg.yml");
+    write_text(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\noverwrite_output: true\n",
+            golden.display(),
+            called.display(),
+            fa.display(),
+            out.display(),
+        ),
+    );
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    // Read back via the same read_vcf path the rest of rneat uses.
+    let fn_vcf = out.join("FN_with_reasons.vcf");
+    let parsed = ::common::file_tools::vcf_tools::read_vcf(fn_vcf).unwrap();
+    let chr1_variants = parsed.get("chr1").expect("chr1 variants present");
+    assert_eq!(chr1_variants.len(), 1);
+    let v = &chr1_variants[0];
+    assert_eq!(v.location, 100);
+    // The reader stores the INFO blob; check our annotation made it through.
+    let info = v.info.as_deref().unwrap_or("");
+    assert!(
+        info.contains("DP=20") && info.contains("NEAT_REASON=unknown"),
+        "info field was: {info:?}"
+    );
+}
+
+/// TXT report should list every output path in the Outputs section.
+#[test]
+fn txt_report_lists_every_output_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fa = tmp.path().join("ref.fa");
+    let golden = tmp.path().join("golden.vcf");
+    let called = tmp.path().join("called.vcf");
+    let out = tmp.path().join("report");
+    write_fasta(&fa, "chr1", &"A".repeat(1000));
+    write_vcf(&golden, &["chr1\t100\t.\tA\tC\t60\tPASS\t.\tGT\t0/1"]);
+    write_vcf(&called, &["chr1\t300\t.\tA\tT\t60\tPASS\t.\tGT\t0/1"]);
+    let yaml = tmp.path().join("cfg.yml");
+    write_text(
+        &yaml,
+        &format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\n\
+             overwrite_output: true\nwrite_fp_vcf: true\n",
+            golden.display(),
+            called.display(),
+            fa.display(),
+            out.display(),
+        ),
+    );
+    rneat()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let txt = std::fs::read_to_string(out.join("comparison_summary.txt")).unwrap();
+    assert!(txt.contains("Outputs"));
+    assert!(txt.contains("comparison_summary.json"));
+    assert!(txt.contains("comparison_summary.txt"));
+    assert!(txt.contains("FN_with_reasons.vcf"));
+    assert!(txt.contains("FP.vcf"));
+}

--- a/template_config/compare_vcfs_template.yml
+++ b/template_config/compare_vcfs_template.yml
@@ -59,3 +59,8 @@ mutation_bed: .
 # `target_bed` at load time. Use when your BEDs are in non-`chr` style but
 # the reference is, or vice versa. "." disables.
 chrom_aliases: .
+
+# Also write `<output_dir>/FP.vcf` listing every false positive call.
+# `<output_dir>/FN_with_reasons.vcf` is always written. FP VCFs can be
+# large on noisy callers so this is off by default. Default false.
+write_fp_vcf: false


### PR DESCRIPTION
Final slice of #127.

## Summary

- New `rneat/src/compare_vcfs/utils/vcf_writer.rs`:
  - `write_fn_with_reasons` — every surviving FN annotated with `NEAT_REASON` INFO listing its attribution reasons. Always written.
  - `write_fp_vcf` — every surviving FP, as-is. Gated on `write_fp_vcf: bool` config (default false) since noisy callers can produce huge sets.
- Report extension (schema 1.1.0 → 1.2.0): new `outputs: SummaryOutputs` field listing every artifact path. TXT report gets a matching "Outputs" section.
- README: full "Comparing a downstream caller's VCF against the golden VCF" section.
- Template config: documents the new `write_fp_vcf` knob.

## Behavior

INFO field handling for `NEAT_REASON`:
- Bare `.` → replaced (since `.` is the no-info sentinel)
- Existing INFO blob (e.g., `DP=20`) → tag appended (`DP=20;NEAT_REASON=...`)
- Round-trip verified: the emitted VCF parses cleanly via the existing `read_vcf` reader, so rneat itself can consume its own output.

GT synthesis: when the source record had no FORMAT/SAMPLE columns, we synthesize `GT` + the variant's `genotype_str` so every emitted row is VCFv4.2-compliant.

## Tests added (+12)

- 8 unit tests in `vcf_writer.rs` covering INFO preservation, bare-"." replacement, GT synthesis, header-only on empty FN sets, overwrite refusal.
- 4 integration tests in `tests/compare_vcfs_phase4.rs` covering default-on FN_with_reasons.vcf, FP.vcf opt-in, round-trip via `read_vcf`, and TXT report enumeration of every output path.

Workspace test count: 459 → 471.

## Test plan

- [ ] `cargo test --workspace` green
- [ ] `cargo fmt --check` + `cargo clippy --workspace --all-targets` clean
- [ ] Spot-check `FN_with_reasons.vcf` on a real run: `bcftools view` or `grep` for `NEAT_REASON=`
- [ ] Spot-check `FP.vcf` with `write_fp_vcf: true`: should mirror the called VCF's FP subset

🤖 Generated with [Claude Code](https://claude.com/claude-code)