### PR TITLE
chore: v1.8.1 — config refactors (#148, #149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 5/23/2026
 =========
+## rneat v1.8.1
+
+### Internal refactors (no user-visible behavior change)
+- **Split `gen-gc-bias-model` `RunConfiguration` into walker params + `GcBiasModelParams` (#148).** `run_from_coverage` now takes only the FASTA-sweep / model-write fields it actually uses (`reference`, `bed_table`, `output_file`, `overwrite_output`, `window_size`, `window_stride`, `min_windows_per_bin`). The standalone CLI keeps `bam_file` and `min_mapq` for its own walk and embeds the model params as `config.model`. The unified `gen-bam-models` runner now constructs `GcBiasModelParams` directly from its `GcBiasSection` — no more dummy `bam_file` clone or hard-coded `min_mapq: 0`.
+- **Factor `check_overwrite` into `common::file_tools::file_io` (#149).** Replaces four duplicated "output already exists and `overwrite_output` is false" checks in `gen_bam_models` (frag_length + gc_bias sub-sections), `gen_frag_length_model`, `gen_seq_error_model`, and `gen_gc_bias_model`. Standalone error messages are uniform; each module wraps the returned `io::Error` into its own error type.
+
+5/22/2026
+=========
 ## rneat v1.8.0
 
 ### `compare-vcfs`: new subcommand for validating a downstream caller against a NEAT golden VCF

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bincode",
  "bstr",
@@ -1074,7 +1074,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.8.0'
+version = '1.8.1'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/common/src/file_tools/file_io.rs
+++ b/common/src/file_tools/file_io.rs
@@ -1,9 +1,30 @@
 //! This contains only one function at the moment, a general opener and reader
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Lines, Read, Result, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use flate2::read::GzDecoder;
+
+/// Errors with `ErrorKind::AlreadyExists` if `path` is an existing regular
+/// file and `allow_overwrite` is false. `label` is the human-facing name of
+/// the field that produced `path` (e.g. `"frag_length.output_file"`) and is
+/// embedded in the error message so the user can locate the offending
+/// config entry.
+///
+/// Each subcommand's config parser typically wraps the returned `io::Error`
+/// into its own module error via `.map_err(...)`.
+pub fn check_overwrite(label: &str, path: &Path, allow_overwrite: bool) -> Result<()> {
+    if !allow_overwrite && path.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!(
+                "{label} already exists and overwrite_output is false: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
+}
 
 pub fn read_lines(filename: &PathBuf) -> Result<Lines<BufReader<File>>> {
     // This opens file and creates a buffer to read lines

--- a/rneat/src/gen_bam_models/utils/config.rs
+++ b/rneat/src/gen_bam_models/utils/config.rs
@@ -7,7 +7,10 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-use common::{file_tools::bed_reader::read_bed, structs::bed_record::BedRecord};
+use common::{
+    file_tools::{bed_reader::read_bed, file_io::check_overwrite},
+    structs::bed_record::BedRecord,
+};
 
 use crate::gen_bam_models::errors::GenBamModelsError;
 
@@ -108,12 +111,8 @@ fn parse_frag_length_section(v: &Value) -> Result<FragLengthSection, GenBamModel
         GenBamModelsError::ConfigError("frag_length.output_file is required".to_string())
     })?);
     let overwrite_output = get_bool("overwrite_output").unwrap_or(false);
-    if !overwrite_output && output_file.is_file() {
-        return Err(GenBamModelsError::ConfigError(format!(
-            "frag_length.output_file already exists and overwrite_output is false: {:?}",
-            output_file
-        )));
-    }
+    check_overwrite("frag_length.output_file", &output_file, overwrite_output)
+        .map_err(|e| GenBamModelsError::ConfigError(e.to_string()))?;
     let min_reads = get_u64("min_reads").unwrap_or(2) as usize;
 
     Ok(FragLengthSection {
@@ -155,12 +154,8 @@ fn parse_gc_bias_section(v: &Value) -> Result<GcBiasSection, GenBamModelsError> 
         GenBamModelsError::ConfigError("gc_bias.output_file is required".to_string())
     })?);
     let overwrite_output = get_bool("overwrite_output").unwrap_or(false);
-    if !overwrite_output && output_file.is_file() {
-        return Err(GenBamModelsError::ConfigError(format!(
-            "gc_bias.output_file already exists and overwrite_output is false: {:?}",
-            output_file
-        )));
-    }
+    check_overwrite("gc_bias.output_file", &output_file, overwrite_output)
+        .map_err(|e| GenBamModelsError::ConfigError(e.to_string()))?;
 
     let window_size = get_u64("window_size").unwrap_or(100) as usize;
     if window_size == 0 {

--- a/rneat/src/gen_bam_models/utils/runner.rs
+++ b/rneat/src/gen_bam_models/utils/runner.rs
@@ -13,7 +13,7 @@ use crate::gen_bam_models::{
     utils::config::{GcBiasSection, RunConfiguration},
 };
 use crate::gen_frag_length_model::utils::runner::run_from_tlens;
-use crate::gen_gc_bias_model::utils::config::RunConfiguration as GcBiasRunConfig;
+use crate::gen_gc_bias_model::utils::config::GcBiasModelParams;
 use crate::gen_gc_bias_model::utils::runner::run_from_coverage as gc_bias_run_from_coverage;
 
 pub fn runner(config_path: &PathBuf) -> Result<(), GenBamModelsError> {
@@ -54,22 +54,19 @@ pub fn runner(config_path: &PathBuf) -> Result<(), GenBamModelsError> {
 
     if let Some(gc) = &config.gc_bias {
         info!("Building GC bias model");
-        let gc_config = build_gc_bias_run_config(&config.bam_file, gc);
-        gc_bias_run_from_coverage(&gc_config, cov_obs.into_by_contig())?;
+        let gc_params = build_gc_bias_model_params(gc);
+        gc_bias_run_from_coverage(&gc_params, cov_obs.into_by_contig())?;
     }
 
     Ok(())
 }
 
-/// Adapts a unified `GcBiasSection` into the standalone gc-bias `RunConfiguration`
-/// shape. The standalone struct carries `bam_file` and `min_mapq` for its own
-/// walk path, but `run_from_coverage` ignores both — we just pass the unified
-/// BAM path through to keep the struct happy.
-fn build_gc_bias_run_config(bam_file: &PathBuf, gc: &GcBiasSection) -> GcBiasRunConfig {
-    GcBiasRunConfig {
+/// Adapts a unified `GcBiasSection` into a `GcBiasModelParams` for the
+/// shared sweep + model-write stage. No walker fields are involved because
+/// the unified runner has already done the BAM walk by the time we get here.
+fn build_gc_bias_model_params(gc: &GcBiasSection) -> GcBiasModelParams {
+    GcBiasModelParams {
         reference: gc.reference.clone(),
-        bam_file: bam_file.clone(),
-        min_mapq: 0,
         bed_table: gc.bed_table.clone(),
         output_file: gc.output_file.clone(),
         overwrite_output: gc.overwrite_output,

--- a/rneat/src/gen_frag_length_model/utils/config.rs
+++ b/rneat/src/gen_frag_length_model/utils/config.rs
@@ -1,4 +1,5 @@
 use crate::gen_frag_length_model::errors::GenFragLengthModelError;
+use common::file_tools::file_io::check_overwrite;
 use serde_yml::Value;
 use std::collections::HashMap;
 use std::fs;
@@ -62,12 +63,8 @@ impl RunConfiguration {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        if !overwrite_output && output_file.is_file() {
-            return Err(GenFragLengthModelError::ConfigurationError(format!(
-                "output_file already exists and overwrite_output is false: {:?}",
-                output_file
-            )));
-        }
+        check_overwrite("output_file", &output_file, overwrite_output)
+            .map_err(|e| GenFragLengthModelError::ConfigurationError(e.to_string()))?;
 
         let min_reads = scrape_config
             .get("min_reads")

--- a/rneat/src/gen_gc_bias_model/utils/config.rs
+++ b/rneat/src/gen_gc_bias_model/utils/config.rs
@@ -2,29 +2,45 @@
 // various side functions. It is build with a ConfigurationBuilder, which can take either a
 // config yaml file or command line arguments and turn them into the configuration.
 use crate::gen_gc_bias_model::errors::GenGcBiasModelError;
-use common::{file_tools::bed_reader::read_bed, structs::bed_record::BedRecord};
+use common::{
+    file_tools::{bed_reader::read_bed, file_io::check_overwrite},
+    structs::bed_record::BedRecord,
+};
 use serde_yml::Value;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
+/// Parameters consumed by `run_from_coverage` — the FASTA-sweep + model-write
+/// stage. Does not carry BAM/walker state because `run_from_coverage` works
+/// from pre-computed per-contig coverage and never reads the BAM itself.
+///
+/// Both the standalone CLI path (which fills these from a YAML
+/// `RunConfiguration`) and the unified `gen-bam-models` runner (which fills
+/// these from its own `GcBiasSection` after one shared BAM walk) construct
+/// this directly.
 #[derive(Debug, Clone)]
-pub struct RunConfiguration {
-    // This struct holds all the parameters for running GC Bias modeling.
-    // It is built from user-supplied input in the form of a configuration yaml file.
+pub struct GcBiasModelParams {
     pub reference: PathBuf,
-    /// Aligned BAM. Coverage is accumulated in process via
-    /// `common::file_tools::bam_reader::CoverageObserver`.
-    pub bam_file: PathBuf,
-    /// Minimum mapping quality applied while accumulating coverage from `bam_file`.
-    /// Default 0 matches `samtools depth` defaults.
-    pub min_mapq: u8,
     pub bed_table: HashMap<String, Vec<BedRecord>>,
     pub output_file: PathBuf,
     pub overwrite_output: bool,
     pub window_size: usize,
     pub window_stride: usize,
     pub min_windows_per_bin: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct RunConfiguration {
+    // This struct holds all the parameters for running GC Bias modeling
+    // from a standalone YAML config: BAM walker inputs + model params.
+    /// Aligned BAM. Coverage is accumulated in process via
+    /// `common::file_tools::bam_reader::CoverageObserver`.
+    pub bam_file: PathBuf,
+    /// Minimum mapping quality applied while accumulating coverage from `bam_file`.
+    /// Default 0 matches `samtools depth` defaults.
+    pub min_mapq: u8,
+    pub model: GcBiasModelParams,
 }
 
 impl RunConfiguration {
@@ -89,12 +105,8 @@ impl RunConfiguration {
                 GenGcBiasModelError::ConfigError("Missing output_file".to_string())
             })?);
 
-        if !overwrite_output && output_file.is_file() {
-            return Err(GenGcBiasModelError::ConfigError(format!(
-                "Attempting to overwrite existing file {:?}",
-                output_file
-            )));
-        }
+        check_overwrite("output_file", &output_file, overwrite_output)
+            .map_err(|e| GenGcBiasModelError::ConfigError(e.to_string()))?;
 
         let window_size = scrape_config
             .get("window_size")
@@ -132,15 +144,17 @@ impl RunConfiguration {
             .unwrap_or(10) as usize;
 
         Ok(RunConfiguration {
-            reference,
             bam_file,
             min_mapq,
-            bed_table,
-            output_file,
-            overwrite_output,
-            window_size,
-            window_stride,
-            min_windows_per_bin,
+            model: GcBiasModelParams {
+                reference,
+                bed_table,
+                output_file,
+                overwrite_output,
+                window_size,
+                window_stride,
+                min_windows_per_bin,
+            },
         })
     }
 }
@@ -197,15 +211,15 @@ min_windows_per_bin: 10
 
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
 
-        assert_eq!(config.reference, reference.path());
+        assert_eq!(config.model.reference, reference.path());
         assert_eq!(config.bam_file, bam.path());
         assert_eq!(config.min_mapq, 0);
-        assert!(config.bed_table.is_empty());
-        assert_eq!(config.output_file, output_path);
-        assert!(config.overwrite_output);
-        assert_eq!(config.window_size, 100);
-        assert_eq!(config.window_stride, 100);
-        assert_eq!(config.min_windows_per_bin, 10);
+        assert!(config.model.bed_table.is_empty());
+        assert_eq!(config.model.output_file, output_path);
+        assert!(config.model.overwrite_output);
+        assert_eq!(config.model.window_size, 100);
+        assert_eq!(config.model.window_stride, 100);
+        assert_eq!(config.model.min_windows_per_bin, 10);
     }
 
     #[test]
@@ -225,10 +239,10 @@ min_windows_per_bin: 10
         let config_file = write_config(&yaml);
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
 
-        assert!(config.bed_table.is_empty());
-        assert_eq!(config.window_size, 100);
-        assert_eq!(config.window_stride, 100);
-        assert_eq!(config.min_windows_per_bin, 10);
+        assert!(config.model.bed_table.is_empty());
+        assert_eq!(config.model.window_size, 100);
+        assert_eq!(config.model.window_stride, 100);
+        assert_eq!(config.model.min_windows_per_bin, 10);
         assert_eq!(config.min_mapq, 0);
     }
 
@@ -271,6 +285,7 @@ min_windows_per_bin: 10
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
 
         let chr1_records = config
+            .model
             .bed_table
             .get("chr1")
             .expect("Expected chr1 BED records");
@@ -419,7 +434,7 @@ min_windows_per_bin: 10
         );
         let config_file = write_config(&yaml);
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
-        assert_eq!(config.window_stride, 100);
+        assert_eq!(config.model.window_stride, 100);
     }
 
     #[test]
@@ -452,7 +467,7 @@ min_windows_per_bin: 10
         );
         let config_file = write_config(&yaml);
         let config = RunConfiguration::from(&config_file.path().to_path_buf()).unwrap();
-        assert_eq!(config.output_file, output.path());
-        assert!(config.overwrite_output);
+        assert_eq!(config.model.output_file, output.path());
+        assert!(config.model.overwrite_output);
     }
 }

--- a/rneat/src/gen_gc_bias_model/utils/runner.rs
+++ b/rneat/src/gen_gc_bias_model/utils/runner.rs
@@ -1,7 +1,10 @@
 use log::*;
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::gen_gc_bias_model::{errors::GenGcBiasModelError, utils::config::RunConfiguration};
+use crate::gen_gc_bias_model::{
+    errors::GenGcBiasModelError,
+    utils::config::{GcBiasModelParams, RunConfiguration},
+};
 use common::{
     file_tools::{
         bam_reader::{BamWalkFilter, CoverageObserver, walk_bam},
@@ -19,17 +22,16 @@ pub fn runner(path: &PathBuf) -> Result<(), GenGcBiasModelError> {
     let mut filter = BamWalkFilter::for_coverage();
     filter.min_mapq = config.min_mapq;
     walk_bam(&config.bam_file, &filter, &mut [&mut obs])?;
-    run_from_coverage(&config, obs.into_by_contig())
+    run_from_coverage(&config.model, obs.into_by_contig())
 }
 
 /// Builds and writes a GC bias model from a pre-computed per-contig coverage
 /// map (e.g. produced by `CoverageObserver` during a shared BAM walk in the
 /// unified `gen-bam-models` runner). Reads the reference FASTA, sweeps
 /// windows, accumulates GC% vs mean-coverage, and writes the gzipped JSON
-/// model to `config.output_file`. `config.bam_file` and `config.min_mapq`
-/// are ignored on this path.
+/// model to `config.output_file`.
 pub fn run_from_coverage(
-    config: &RunConfiguration,
+    config: &GcBiasModelParams,
     mut cov_by_contig: HashMap<String, Vec<u32>>,
 ) -> Result<(), GenGcBiasModelError> {
     let mut gc_weight_sum = [0.0f64; 101];

--- a/rneat/src/gen_seq_error_model/utils/config.rs
+++ b/rneat/src/gen_seq_error_model/utils/config.rs
@@ -1,4 +1,5 @@
 use crate::gen_seq_error_model::errors::GenSeqErrorModelError;
+use common::file_tools::file_io::check_overwrite;
 use serde_yml::Value;
 use std::collections::HashMap;
 use std::fs;
@@ -69,12 +70,8 @@ impl RunConfiguration {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        if !overwrite_output && output_file.is_file() {
-            return Err(GenSeqErrorModelError::ConfigurationError(format!(
-                "output_file already exists and overwrite_output is false: {:?}",
-                output_file
-            )));
-        }
+        check_overwrite("output_file", &output_file, overwrite_output)
+            .map_err(|e| GenSeqErrorModelError::ConfigurationError(e.to_string()))?;
 
         let max_reads = scrape_config
             .get("max_reads")


### PR DESCRIPTION
Two internal-only refactors surfaced in PR #147 review. No user-visible behavior change; full test suite passes.

#149 — Factor `check_overwrite` into `common::file_tools::file_io`. Replaces four duplicated "output already exists and overwrite_output is false" checks in `gen_bam_models` (frag_length + gc_bias sub-sections), `gen_frag_length_model`, `gen_seq_error_model`, and `gen_gc_bias_model`. Each call site wraps the returned `io::Error` into its own module error via `.map_err(|e| ...::ConfigError(e.to_string()))`. Standalone error messages are now uniform across modules.

#148 — Split `gen-gc-bias-model` `RunConfiguration` into walker params
+ `GcBiasModelParams`. The new struct carries only the FASTA-sweep / model-write fields `run_from_coverage` actually consumes (`reference`, `bed_table`, `output_file`, `overwrite_output`, `window_size`, `window_stride`, `min_windows_per_bin`). The standalone CLI keeps `bam_file` and `min_mapq` for its own walk and embeds the model params as `config.model`. The unified `gen-bam-models` runner now constructs `GcBiasModelParams` directly from its `GcBiasSection`, removing the dead-field adapter (`build_gc_bias_run_config`) that previously cloned `bam_file` and hard-coded `min_mapq: 0`.

Closes #148 and #149