### PR TITLE
Harden symbolic-ALT unwraps and gen_mut_model skip (PR #167 follow-up)

### DIFF
--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -302,6 +302,14 @@ fn generate_read(
             // Don't try to modify this base.
         } else if flagged_positions.contains(&fragment_position) {
             let variant = variant_map[&fragment_position];
+            // MutatedMap::from_interval routes symbolic / structural ALTs to
+            // sv_records, so anything in variant_map should be literal. Assert
+            // that invariant in debug builds — a regression here would otherwise
+            // panic at as_literal().unwrap() with no context.
+            debug_assert!(
+                variant.alternate.is_literal(),
+                "symbolic ALT reached generate_read at position {fragment_position}"
+            );
             if (variant.genotype == Genotype::Homozygous) || (rng.random()? < 0.5) {
                 base_to_write = match read_strand {
                     Strand::Forward => variant.alternate

--- a/common/src/file_tools/vcf_tools.rs
+++ b/common/src/file_tools/vcf_tools.rs
@@ -439,9 +439,9 @@ chr1\t200\t.\tG\tC\t60\tPASS\t.\tGT\t0/1\n";
 
     #[test]
     fn test_read_vcf_symbolic_del_parses_to_symbolic_with_info() {
-        // Phase 2: a `<DEL>` ALT becomes AlternateType::Symbolic carrying the
-        // parsed INFO fields (SVTYPE / END), with the raw ALT preserved
-        // verbatim so the writer can round-trip it.
+        // A `<DEL>` ALT becomes AlternateType::Symbolic carrying the parsed
+        // INFO fields (SVTYPE / END), with the raw ALT preserved verbatim so
+        // the writer can round-trip it.
         let vcf_content = "\
 ##fileformat=VCFv4.1\n\
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n\
@@ -505,9 +505,9 @@ chr1\t500\t.\tA\t<CNV>\t60\tPASS\tSVTYPE=CNV;END=2500;CN=4\tGT\t0/1\n";
     #[test]
     fn test_read_vcf_symbolic_round_trip_through_writer() {
         // End-to-end: a symbolic ALT read from input survives through the
-        // writer back to a verbatim ALT string. This is the Phase 2 contract
-        // — read + write together. The Phase 1 writer test stubbed in a
-        // synthetic Variant; this one drives the real reader path.
+        // writer back to a verbatim ALT string — read + write together,
+        // driving the real reader path (the companion writer-only test below
+        // stubs in a synthetic Variant).
         let vcf_content = "\
 ##fileformat=VCFv4.1\n\
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n\
@@ -660,10 +660,10 @@ chr1\t100\t.\tA\tT\t60\tPASS\t.\tDP:GQ\t30:99\n";
 
     #[test]
     fn test_write_vcf_symbolic_alt_round_trips_raw_string() {
-        // Phase 1 contract: even though Variant::from_file still rejects
-        // symbolic ALTs, the writer must serialize an AlternateType::Symbolic
-        // payload verbatim via SvData.raw_alt. This locks in the round-trip
-        // shape that Phase 2's reader will rely on.
+        // Writer contract: an AlternateType::Symbolic payload serializes
+        // verbatim via SvData.raw_alt. Driven from a synthetic Variant
+        // (not the reader) so the writer is exercised in isolation —
+        // the reader+writer round-trip is covered separately.
         let temp_dir = tempfile::tempdir().unwrap();
         let sv = Variant {
             variant_type: VariantType::Complex,

--- a/common/src/structs/variants.rs
+++ b/common/src/structs/variants.rs
@@ -128,9 +128,10 @@ impl SvType {
 /// Parsed payload for a symbolic / structural ALT.
 ///
 /// Stores the original ALT string for verbatim round-trip, plus optional
-/// INFO-derived fields (`END=`, `SVLEN=`, `CN=`). The Phase 2 reader will
-/// populate the optional fields from the VCF INFO column; today, anything
-/// constructing an `SvData` must fill them in itself.
+/// INFO-derived fields (`END=`, `SVLEN=`, `CN=`). `Variant::from_file`
+/// populates the optional fields from the VCF INFO column via `parse_sv_info`;
+/// other constructors (e.g. `SvData::new`) start them as `None` and let the
+/// caller fill in whatever it has.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct SvData {
     /// The original ALT field, verbatim — used to round-trip back to the
@@ -299,9 +300,10 @@ impl Variant {
                 sv_data.end = parsed_info.end;
                 sv_data.svlen = parsed_info.svlen;
                 sv_data.copy_number = parsed_info.copy_number;
-                // Phase 2 tags symbolic SVs as Complex so the existing
-                // gen_reads filter (filter_input_vcf) drops them along with
-                // other complex variants until Phase 3 adds depth modulation.
+                // Symbolic SVs share the `Complex` variant_type with literal
+                // multi-base substitutions; downstream code distinguishes them
+                // by the `AlternateType` enum (literal vs symbolic), not by
+                // variant_type.
                 (VariantType::Complex, AlternateType::Symbolic(sv_data))
             }
         };
@@ -414,9 +416,10 @@ fn parse_alternate(reference: &str, alt: &str) -> Result<ParsedAlt, VariantError
         )));
     }
     // Symbolic / structural / breakend ALTs (e.g. <DUP:TANDEM>, <DEL>,
-    // <INS:ME:ALU>, `G]17:198982]`) are classified here but not yet
-    // generatable — gen_reads will filter them along with other Complex
-    // variants until Phase 3 lands the depth-modulation pipeline.
+    // <INS:ME:ALU>, `G]17:198982]`) classify into ParsedAlt::Symbolic with
+    // the raw ALT preserved verbatim. gen_reads uses the resulting SvData
+    // for per-region depth modulation and round-trips the raw ALT to the
+    // output VCF; rneat does not yet generate symbolic SVs de novo.
     if !is_acgtn(alt) {
         return match SvType::from_alt_string(alt) {
             Some(sv_type) => Ok(ParsedAlt::Symbolic {
@@ -444,7 +447,7 @@ pub struct ParsedSvInfo {
     pub end: Option<usize>,
     pub svlen: Option<i64>,
     pub copy_number: Option<u32>,
-    /// The `SVTYPE=` value verbatim (e.g. `DEL`, `DUP`, `CNV`). Phase 2's
+    /// The `SVTYPE=` value verbatim (e.g. `DEL`, `DUP`, `CNV`).
     /// `Variant::from_file` uses this only to log a warning if it disagrees
     /// with the symbolic ALT tag — the ALT is the source of truth.
     pub svtype: Option<String>,
@@ -677,9 +680,9 @@ mod tests {
 
     #[test]
     fn parse_alternate_symbolic_alts_round_trip_with_correct_type() {
-        // Phase 2: VCF 4.2 symbolic ALTs now classify into ParsedAlt::Symbolic
-        // with the correct SvType derived from the tag. The raw_alt string
-        // is preserved verbatim so the writer can round-trip the original.
+        // VCF 4.2 symbolic ALTs classify into ParsedAlt::Symbolic with the
+        // correct SvType derived from the tag. The raw_alt string is preserved
+        // verbatim so the writer can round-trip the original.
         let cases = [
             ("<DUP:TANDEM>", SvType::Dup),
             ("<DEL>", SvType::Del),

--- a/common/src/structs/variants.rs
+++ b/common/src/structs/variants.rs
@@ -758,6 +758,59 @@ mod tests {
     }
 
     #[test]
+    fn parse_sv_info_tolerates_empty_entries_and_trailing_semicolons() {
+        // Real-world VCFs sometimes carry trailing semicolons or doubled
+        // separators (`END=200;;SVLEN=-50`). The parser should treat each
+        // empty entry as a no-op and still pick up the surrounding fields
+        // rather than dropping the variant or panicking on `split_once`.
+        let parsed = parse_sv_info("END=200;;SVLEN=-50;");
+        assert_eq!(parsed.end, Some(200));
+        assert_eq!(parsed.svlen, Some(-50));
+    }
+
+    #[test]
+    fn parse_sv_info_last_value_wins_on_duplicate_keys() {
+        // Spec-violating but real: some upstream tools emit the same key
+        // twice. Lock in last-value-wins so a future refactor doesn't
+        // silently flip to first-value-wins and break round-tripping.
+        let parsed = parse_sv_info("END=100;END=999;CN=2");
+        assert_eq!(parsed.end, Some(999));
+        assert_eq!(parsed.copy_number, Some(2));
+    }
+
+    #[test]
+    fn from_file_literal_complex_with_end_info_stays_literal() {
+        // A literal-base Complex variant (multi-base REF *and* literal multi-
+        // base ALT) is unusual but legal. parse_sv_info is gated on the ALT
+        // being symbolic, so an `END=` field on a literal Complex record must
+        // NOT promote it to Symbolic — the AlternateType stays Literal and the
+        // raw INFO string is preserved verbatim for the writer. Locks in that
+        // the two paths don't bleed.
+        let v = Variant::from_file(
+            42,
+            ".",
+            "PASS",
+            "END=999;SVLEN=-3",
+            "ACG",
+            "TTT",
+            60,
+            vec!["GT".to_string()],
+            vec!["0/1".to_string()],
+        )
+        .unwrap();
+        assert_eq!(v.variant_type, VariantType::Complex);
+        assert!(v.alternate.is_literal());
+        assert!(v.alternate.as_symbolic().is_none());
+        assert_eq!(
+            v.alternate.as_literal().unwrap(),
+            &[Nucleotide::T, Nucleotide::T, Nucleotide::T][..]
+        );
+        // INFO survives verbatim for the writer to round-trip; nothing has
+        // re-interpreted END/SVLEN on a literal record.
+        assert_eq!(v.info.as_deref(), Some("END=999;SVLEN=-3"));
+    }
+
+    #[test]
     fn sv_type_matches_svtype_strict_and_unknown_passthrough() {
         // Exact match (case-insensitive)
         assert!(sv_type_matches_svtype(SvType::Del, "DEL"));

--- a/rneat/src/compare_vcfs/utils/equivalence.rs
+++ b/rneat/src/compare_vcfs/utils/equivalence.rs
@@ -131,6 +131,13 @@ fn apply_variants(
         if offset + ref_len > result.len() {
             continue;
         }
+        // filter_vcf strips symbolic ALTs into the `symbolic` skip bucket before
+        // they reach the equivalence sweep, so anything here must be literal.
+        debug_assert!(
+            v.alternate.is_literal(),
+            "symbolic ALT reached apply_variants at location {}",
+            v.location
+        );
         let alt_bytes: Vec<u8> = v
             .alternate
             .as_literal()

--- a/rneat/src/compare_vcfs/utils/runner.rs
+++ b/rneat/src/compare_vcfs/utils/runner.rs
@@ -54,10 +54,21 @@ struct VariantKey {
 
 impl From<&Variant> for VariantKey {
     fn from(v: &Variant) -> Self {
+        // filter_vcf removes symbolic ALTs (`<DEL>`, `<DUP>`, ...) into the
+        // `symbolic` skip bucket before any VariantKey is built, so by the
+        // time we get here the ALT must be literal. Assert it in debug builds
+        // so a future regression fails loudly with context instead of a bare
+        // `unwrap()` panic in release.
+        debug_assert!(
+            v.alternate.is_literal(),
+            "symbolic ALT reached VariantKey::from at location {}",
+            v.location
+        );
         VariantKey {
             location: v.location,
             reference: v.reference.clone(),
-            alternate: v.alternate.as_literal().unwrap().to_vec(), }
+            alternate: v.alternate.as_literal().unwrap().to_vec(),
+        }
     }
 }
 

--- a/rneat/src/gen_mut_model/utils/runner.rs
+++ b/rneat/src/gen_mut_model/utils/runner.rs
@@ -82,6 +82,18 @@ pub fn runner(
         };
 
         for variant in matching_variants {
+            // Symbolic / structural ALTs (`<DEL>`, `<DUP>`, ...) have no literal
+            // base content for the trinucleotide / indel-length stats to consume,
+            // and rneat doesn't yet model SV generation from a trained model.
+            // Skip them before they reach any per-base accounting (including the
+            // homozygous_count tally) so the model isn't biased by their presence.
+            if variant.alternate.is_symbolic() {
+                debug!(
+                    "Skipping symbolic / structural variant at {}:{} for mutation-model training",
+                    contig_name, variant.location
+                );
+                continue;
+            }
             match variant.variant_type {
                 VariantType::SNP => {
                     snp_count += 1;
@@ -116,6 +128,10 @@ pub fn runner(
                         continue;
                     }
                     let ref_frame = TrinucFrame::from((n0, n1, n2));
+                    debug_assert!(
+                        variant.alternate.is_literal(),
+                        "symbolic ALT reached SNP arm in gen_mut_model"
+                    );
                     let alt = variant.alternate.as_literal().unwrap();
                     let alt_frame = TrinucFrame::from((n0, alt[0], n2));
                     *trinuc_transition_count
@@ -126,11 +142,21 @@ pub fn runner(
                         .or_default() += 1;
                 }
                 VariantType::Insertion => {
-                    let variant_len = variant.alternate.as_literal().unwrap().len() - variant.reference.len();
+                    debug_assert!(
+                        variant.alternate.is_literal(),
+                        "symbolic ALT reached Insertion arm in gen_mut_model"
+                    );
+                    let variant_len =
+                        variant.alternate.as_literal().unwrap().len() - variant.reference.len();
                     *insertion_count.entry(variant_len).or_default() += 1;
                 }
                 VariantType::Deletion => {
-                    let variant_len = variant.reference.len() - variant.alternate.as_literal().unwrap().len();
+                    debug_assert!(
+                        variant.alternate.is_literal(),
+                        "symbolic ALT reached Deletion arm in gen_mut_model"
+                    );
+                    let variant_len =
+                        variant.reference.len() - variant.alternate.as_literal().unwrap().len();
                     *deletion_count.entry(variant_len).or_default() += 1;
                 }
                 _ => debug!("Unknown variant type, skipping for this analysis."),
@@ -420,6 +446,48 @@ H1N1_HA\t25\t.\tA\tG\t60\tPASS\t.\tGT\t0/1\n",
             model.mutation_rate > 0.01,
             "BED-constrained rate should exceed 0.01, got {}",
             model.mutation_rate
+        );
+    }
+
+    #[test]
+    fn test_runner_skips_symbolic_variants_without_panicking() {
+        // A mixed input VCF (literal SNP + symbolic <DEL>) used to risk a panic
+        // at as_literal().unwrap() if a symbolic record ever reached the SNP /
+        // Insertion / Deletion arms. They're tagged VariantType::Complex today
+        // so the match arm wouldn't fire, but the homozygous_count tally would
+        // still count them and bias the model. The explicit symbolic-skip at
+        // the top of the loop must drop them before any per-base accounting.
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let reference = PathBuf::from(format!("{}/test_data/references/H1N1.fa", manifest_dir));
+        let out_dir = tempdir().unwrap();
+
+        let vcf_path = out_dir.path().join("mixed_sv.vcf");
+        std::fs::write(
+            &vcf_path,
+            "##fileformat=VCFv4.2\n\
+##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position\">\n\
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n\
+H1N1_HA\t22\t.\tC\tT\t60\tPASS\t.\tGT\t0/1\n\
+H1N1_HA\t100\t.\tA\t<DEL>\t60\tPASS\tEND=500\tGT\t1/1\n\
+H1N1_HA\t600\t.\tT\t<DUP>\t60\tPASS\tEND=700\tGT\t1/1\n",
+        )
+        .unwrap();
+
+        let mutations = read_vcf(vcf_path).unwrap();
+        let output_file = out_dir.path().join("mixed_sv_model.json.gz");
+        // Must not panic — symbolic records skip past the as_literal().unwrap()
+        // sites and never reach the homozygous_count tally.
+        runner(&reference, mutations, HashMap::new(), &output_file, None).unwrap();
+        assert!(output_file.exists());
+        let model = MutationModel::from_file(&output_file).unwrap();
+        // Only the SNP contributes — and it's heterozygous, so homozygous_count
+        // stays at 0 and the model falls back to the tiny default frequency
+        // (0.001 / allowed_variant_count) rather than picking up the symbolic homs.
+        assert!(model.mutation_rate > 0.0);
+        assert!(
+            model.homozygous_frequency < 0.5,
+            "symbolic homozygous SVs must not be counted as homozygous SNPs; got {}",
+            model.homozygous_frequency
         );
     }
 }

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -1084,8 +1084,9 @@ mod tests {
             format: vec![],
             sample: vec![],
         };
-        // Symbolic SV — tagged Complex like Phase 2 but must NOT be dropped:
-        // Phase 3 needs it downstream for coverage modulation.
+        // Symbolic SV — tagged Complex but must NOT be dropped by
+        // filter_input_vcf: gen_reads uses it downstream for coverage
+        // modulation and round-trips the raw ALT to the output VCF.
         use common::structs::variants::{SvData, SvType};
         let v3 = Variant {
             location: 500,

--- a/rneat/tests/compare_vcfs_phase1.rs
+++ b/rneat/tests/compare_vcfs_phase1.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `rneat compare-vcfs` Phase 1.
+//! Integration tests for `rneat compare-vcfs`: exact-match classification.
 //!
 //! Exercises the binary against tiny hand-crafted golden + called VCF pairs
 //! and asserts the parsed `comparison_summary.json` contents match expected

--- a/rneat/tests/compare_vcfs_phase2.rs
+++ b/rneat/tests/compare_vcfs_phase2.rs
@@ -1,4 +1,4 @@
-//! Phase 2 integration tests: equivalence sweep on synthetic indels.
+//! Integration tests for `rneat compare-vcfs`: equivalence sweep on synthetic indels.
 //!
 //! Each test writes a tiny custom FASTA and a golden + called VCF pair where
 //! the called VCF intentionally uses a different denotation of the same edit.

--- a/rneat/tests/compare_vcfs_phase3.rs
+++ b/rneat/tests/compare_vcfs_phase3.rs
@@ -1,4 +1,4 @@
-//! Phase 3 integration tests: NEAT-aware FN attribution + chrom aliases.
+//! Integration tests for `rneat compare-vcfs`: NEAT-aware FN attribution and chrom aliases.
 //!
 //! Each test arranges golden + called VCFs so the surviving FN(s) hit a
 //! specific reason path, then asserts the JSON report's `fn_attribution`

--- a/rneat/tests/compare_vcfs_phase4.rs
+++ b/rneat/tests/compare_vcfs_phase4.rs
@@ -1,4 +1,4 @@
-//! Phase 4 integration tests: FN_with_reasons.vcf and optional FP.vcf writers.
+//! Integration tests for `rneat compare-vcfs`: FN_with_reasons.vcf and optional FP.vcf writers.
 
 mod common;
 

--- a/rneat/tests/pipeline_e2e.rs
+++ b/rneat/tests/pipeline_e2e.rs
@@ -120,19 +120,18 @@ fn train_binned_model_then_gen_reads_emits_only_bin_qualities() {
 
 #[test]
 fn gen_reads_with_symbolic_del_modulates_depth_and_round_trips_to_vcf() {
-    // Phase 3 contract: a symbolic <DEL> in the input VCF must (a) be preserved
-    // verbatim in the output golden VCF (Phase 1+3 round-trip), and (b) drive
-    // per-region depth modulation in gen_reads (Phase 3 fragment splitting).
-    // We park a homozygous <DEL> at H1N1_HA:500-1500 (1-based, inclusive),
-    // which corresponds to 0-based half-open [499, 1500). At a hom DEL the
-    // multiplier is 0, so zero reads should start in that span; reads outside
-    // it should still be generated at full coverage.
+    // End-to-end contract: a symbolic <DEL> in the input VCF must (a) be
+    // preserved verbatim in the output golden VCF, and (b) drive per-region
+    // depth modulation in gen_reads. We park a homozygous <DEL> at
+    // H1N1_HA:500-1500 (1-based, inclusive), which corresponds to 0-based
+    // half-open [499, 1500). At a hom DEL the multiplier is 0, so zero reads
+    // should start in that span; reads outside it should still be generated
+    // at full coverage.
     use std::io::Write as _;
 
     let (_dir, work) = fresh_workdir();
 
-    // Phase 3 only consumes input VCFs that already define the SV's span via
-    // INFO/END, so include it here.
+    // Coverage modulation needs the SV's span — supply it via INFO/END.
     let input_vcf = work.join("input_sv.vcf");
     {
         let mut f = std::fs::File::create(&input_vcf).unwrap();


### PR DESCRIPTION
## Summary

Follow-up to PR #167 review, addressing the brittleness of `.as_literal().unwrap()` callsites and a related test gap around `parse_sv_info`.

- Adds `debug_assert!(v.alternate.is_literal(), ...)` at the four `.as_literal().unwrap()` sites so a future regression that leaks a symbolic `Variant` past upstream filtering fails loudly in test builds with location context, rather than panicking opaquely in release:
  - `common/src/file_tools/fastq_tools.rs` — `generate_read` (relies on `MutatedMap` routing)
  - `common/src/structs/variants.rs` — covered indirectly by the SNP/Ins/Del-arm asserts below
  - `rneat/src/compare_vcfs/utils/equivalence.rs` — `apply_variants` (relies on `filter_vcf`)
  - `rneat/src/compare_vcfs/utils/runner.rs` — `VariantKey::from` (also fixes the formatting nit on the closing brace)
  - `rneat/src/gen_mut_model/utils/runner.rs` — SNP/Insertion/Deletion arms
- Adds an explicit `is_symbolic()` skip at the top of `gen_mut_model::runner`'s variant loop. Symbolic records were already falling into the `_` arm of the `variant_type` match (they're tagged `Complex`), but the loop still incremented `homozygous_count` for them — biasing the trained model. The early skip drops them before any per-base accounting and logs at `debug` level.
- Backfills tests called out in the review:
  - `gen_mut_model::tests::test_runner_skips_symbolic_variants_without_panicking` — mixed SNP + `<DEL>` + `<DUP>` builds a model without inflating `homozygous_frequency`.
  - `variants::tests::parse_sv_info_tolerates_empty_entries_and_trailing_semicolons` — `END=200;;SVLEN=-50;` still parses both fields.
  - `variants::tests::parse_sv_info_last_value_wins_on_duplicate_keys` — locks in current behavior so a future refactor doesn't silently flip semantics.
  - `variants::tests::from_file_literal_complex_with_end_info_stays_literal` — a literal multi-base Complex variant with `INFO/END` stays `Literal`; the symbolic INFO path is gated correctly and does not re-interpret it.

No production behavior change for well-formed inputs — the new assertions only fire in `debug_assertions` builds, and the gen_mut_model skip removes a small pre-existing bias that previously affected nobody because no SV-aware training data flowed through that path.

## Test plan

- [x] `cargo build --tests` — clean
- [x] `cargo test` — 524 tests pass (4 new)
- [x] Verified each new test runs and passes individually
- [x] Reviewer: confirm the gen_mut_model skip + log level reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)