### PR TITLE
ci: fix rust_binaries release workflow (cmake + fail-fast)

### DIFF
--- a/.github/workflows/rust_binaries.yml
+++ b/.github/workflows/rust_binaries.yml
@@ -8,6 +8,12 @@ on:
 jobs:
   build:
     strategy:
+      # Don't cancel sibling jobs when one target fails — a Linux build
+      # failure shouldn't take out the macOS / Windows / aarch64 binaries
+      # that are otherwise ready to ship. Each target stands or falls on
+      # its own merits, and the release just attaches whichever ones
+      # succeeded.
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -35,7 +41,12 @@ jobs:
       - name: Install build dependencies (RHEL container)
         if: matrix.container != ''
         run: |
-          dnf install -y gcc gcc-c++ make curl git openssl-devel pkgconfig perl
+          # `cmake` is required by the libz-ng-sys build script (transitive
+          # dependency via flate2's zlib-ng feature). GitHub-hosted Linux,
+          # macOS, and Windows runners all ship cmake by default, but the
+          # rockylinux:8 container does not — the v1.9.0 release build
+          # failed here with "is `cmake` not installed?".
+          dnf install -y gcc gcc-c++ make cmake curl git openssl-devel pkgconfig perl
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The v1.9.0 release workflow (https://github.com/ncsa/rusty-neat/actions/runs/26354324733) attached only the macOS binary because two problems compounded. This PR fixes both with a two-line change.

## Root cause

### 1. Missing `cmake` in the rockylinux:8 container

The `libz-ng-sys` build script (transitive dependency via `flate2`'s `zlib-ng` feature) requires `cmake` and the dnf install step didn't include it:

```
error: failed to run custom build command for `libz-ng-sys v1.1.22`
...
  failed to execute command: No such file or directory (os error 2)
  is `cmake` not installed?
```

GitHub-hosted Linux, macOS, and Windows runners all ship `cmake` out of the box — this only hit the two container-based jobs (`x86_64-unknown-linux-gnu rockylinux:8` and `aarch64-unknown-linux-gnu rockylinux:8`).

### 2. No `fail-fast: false` on the matrix

GitHub Actions' default matrix behavior cancels sibling jobs when one fails. When the rhel8 x86_64 job blew up, Actions killed three other in-flight jobs (`x86_64-linux`, `windows`, `aarch64-rhel8`). The macOS binary survived only because that job had already finished before the failure landed.

That's why the release ended up with **one** binary instead of zero or five.

## Fix

```yaml
strategy:
  fail-fast: false   # NEW: each target ships independently
  matrix:
    include: …
```

```yaml
- name: Install build dependencies (RHEL container)
  if: matrix.container != ''
  run: |
    dnf install -y gcc gcc-c++ make cmake curl git openssl-devel pkgconfig perl
                                   ^^^^^ NEW
```

## Test plan

The workflow only triggers on `v*.*.*` tags, so it can't be exercised from a PR. Validated by:

- [x] Reading the workflow against the failed run log (the cmake panic and exit 101 are unambiguous).
- [x] `libz-ng-sys` build script docs confirm cmake is required.
- [ ] Reviewer: confirm the next release tag attaches all five binaries.

## Follow-up worth knowing about (out of scope)

The same run logged an `actions/checkout@v4` Node 20 deprecation warning. Not blocking and not causing the failure, but a future patch can bump to `v5` whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)