### PR TITLE
Inv variant support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,18 @@ End-to-end smoke run on chr22 + bundled COSMIC model + `--tumor-mutation-rate 1e
 - Pass 2 (tumor, 15× chr22 with input_vcf=normal_golden): ~50 min, 56,318 variants (55,811 germline carried through + 507 somatic de-novo)
 - Merge step: 55,811 `NEAT_ORIGIN=shared` + 507 `NEAT_ORIGIN=somatic`, 0 `germline`-only (every germline variant round-tripped, as expected when `input_vcf` is the normal pass's golden VCF)
 - GATK Mutect2 + FilterMutectCalls scored via som.py against the somatic-filtered truth: **67.5% SNV recall, 96.7% precision; 12.1% indel recall, 66.7% precision.** Single-end alignment defaults; PE + panel-of-normals + contamination model would substantially lift indel numbers.
+=======
+5/27/2026
+=========
+## rneat v1.11.2
+
+### Structural variant (SV) modeling improvements
+- **Full support for symbolic `<INS>` (Insertions) in `SvModel`.** The statistical model now learns the rate and length distribution of symbolic insertions from training VCFs (gnomAD-SV, etc.). Sampled `<INS>` records now carry appropriate `SVLEN` and `END` tags in the output golden VCF.
+- **Improved VCF output for structural variants.** De novo sampled SVs now include `SVLEN` in their INFO field (negative for deletions, positive for others).
+- **VCF header completeness.** The output VCF header now includes missing `ALT` definitions for `<DUP>` and `<CNV>`, plus standard `INFO` definitions for `SVTYPE`, `SVLEN`, `END`, and `CN`.
+- **Refined SV length statistics.** Introduced `SvData::event_length` to correctly distinguish between reference span (bases removed/replaced) and event length (bases inserted), ensuring more accurate log-normal fitting for insertions.
+- **Bundled default SV model updated.** Updated `default_sv_model` with heuristic parameters for `<INS>` (median ~300bp, matching Alu MEIs) and `<INV>` (median ~4.9kb), and adjusted type probabilities to better reflect human genome diversity.
+- **Fix:** `SvModel::affected_range_for_existing` now correctly handles `<INS>` and breakends as point events (1-bp reference span) rather than using their `SVLEN` as the span. This prevents point insertions from blocking nearby variants during de novo sampling.
 
 5/25/2026
 =========

--- a/common/src/file_tools/vcf_tools.rs
+++ b/common/src/file_tools/vcf_tools.rs
@@ -78,6 +78,28 @@ pub fn write_vcf(
         &mut buffer,
         "##ALT=<ID=INS,Description=\"Insertion of novel sequence\">"
     )?;
+    writeln!(&mut buffer, "##ALT=<ID=DUP,Description=\"Duplication\">")?;
+    writeln!(&mut buffer, "##ALT=<ID=INV,Description=\"Inversion\">")?;
+    writeln!(
+        &mut buffer,
+        "##ALT=<ID=CNV,Description=\"Copy number variant\">"
+    )?;
+    writeln!(
+        &mut buffer,
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of structural variant\">"
+    )?;
+    writeln!(
+        &mut buffer,
+        "##INFO=<ID=SVLEN,Number=.,Type=Integer,Description=\"Difference in length between REF and ALT alleles\">"
+    )?;
+    writeln!(
+        &mut buffer,
+        "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End position of the variant described in this record\">"
+    )?;
+    writeln!(
+        &mut buffer,
+        "##INFO=<ID=CN,Number=1,Type=Integer,Description=\"Copy number of segment\">"
+    )?;
     writeln!(
         &mut buffer,
         "##INFO=<ID=NEAT_PROVENANCE,Number=1,Type=String,\
@@ -798,6 +820,24 @@ chr1\t150\t.\tG\t<DEL>\t60\tPASS\tSVTYPE=DEL;END=300\tGT\t1/1\n";
             "expected <DEL> ALT to round-trip; got: {:?}",
             body
         );
+    }
+
+    #[test]
+    fn test_read_vcf_symbolic_inv() {
+        let vcf_content = "\
+##fileformat=VCFv4.1\n\
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n\
+chr1\t500\t.\tA\t<INV>\t60\tPASS\tSVTYPE=INV;END=2500\tGT\t0/1\n";
+        let mut tmp = tempfile::Builder::new().suffix(".vcf").tempfile().unwrap();
+        write!(tmp, "{}", vcf_content).unwrap();
+        let records = read_vcf(tmp.path().to_path_buf()).unwrap();
+        let v = &records.get("chr1").unwrap()[0];
+        assert_eq!(v.variant_type, VariantType::Complex);
+        let sv = v.alternate.as_symbolic().unwrap();
+        assert_eq!(sv.sv_type, SvType::Inv);
+        assert_eq!(sv.end, Some(2500));
+        // span() = END - POS + 1 = 2500 - 500 + 1 = 2001
+        assert_eq!(sv.span(500), Some(2001));
     }
 
     #[test]

--- a/common/src/models/sv_model_defaults.rs
+++ b/common/src/models/sv_model_defaults.rs
@@ -41,12 +41,16 @@ pub fn default_sv_model() -> SvModel {
     let per_base_rate = 6.009e-4;
 
     // Type breakdown: fitted from the full gnomAD-SV v4.1 run.
-    // Deletions dominate; BNDs are now included at ~19%.
+    // Deletions dominate; BNDs are included at ~19%.
+    // Inversions and Insertions are added here at nominal rates (heuristic) since they
+    // were filtered in the original validation fit.
     let mut type_probabilities: HashMap<SvType, f64> = HashMap::new();
-    type_probabilities.insert(SvType::Del, 0.6583);
+    type_probabilities.insert(SvType::Del, 0.6433);
     type_probabilities.insert(SvType::Dup, 0.1470);
     type_probabilities.insert(SvType::Cnv, 0.0004);
     type_probabilities.insert(SvType::Bnd, 0.1943);
+    type_probabilities.insert(SvType::Inv, 0.0050);
+    type_probabilities.insert(SvType::Ins, 0.0100);
 
     // Length log-normals: fitted from the full-genome run via MLE on
     // ln(span). Quick gut-check on the medians (= exp(mu)):
@@ -54,6 +58,8 @@ pub fn default_sv_model() -> SvModel {
     //   DUP: median ≈ 863 bp
     //   CNV: median ≈ 15.3 kb
     //   BND: nominal 1 bp (fixed)
+    //   INV: median ≈ 4.9 kb (heuristic)
+    //   INS: median ≈ 300 bp (heuristic, matching Alu MEI)
     // Sigmas reflect the heavy right tail of DUPs (multi-megabase calls
     // pull sigma out to ~2.5) and the tighter clustering of DELs / CNVs.
     let mut length_log_normal: HashMap<SvType, (f64, f64)> = HashMap::new();
@@ -61,6 +67,8 @@ pub fn default_sv_model() -> SvModel {
     length_log_normal.insert(SvType::Dup, (6.761, 2.530));
     length_log_normal.insert(SvType::Cnv, (9.637, 1.152));
     length_log_normal.insert(SvType::Bnd, (0.0, 0.0));
+    length_log_normal.insert(SvType::Inv, (8.5, 1.5));
+    length_log_normal.insert(SvType::Ins, (5.7, 1.0));
 
     // Copy-number distribution for `<CNV>` records. gnomAD-SV's sites
     // VCF leaves `INFO/CN` unset (CN varies per-sample, in
@@ -115,12 +123,19 @@ mod tests {
     }
 
     #[test]
-    fn default_sv_model_carries_all_four_supported_types() {
+    fn default_sv_model_carries_all_six_supported_types() {
         // Sampler skips types missing from `type_probabilities`. The
-        // default must include DEL, DUP, CNV, and BND so users see all four
+        // default must include DEL, DUP, CNV, BND, INV, and INS so users see all six
         // when they enable generation.
         let m = default_sv_model();
-        for t in [SvType::Del, SvType::Dup, SvType::Cnv, SvType::Bnd] {
+        for t in [
+            SvType::Del,
+            SvType::Dup,
+            SvType::Cnv,
+            SvType::Bnd,
+            SvType::Inv,
+            SvType::Ins,
+        ] {
             assert!(
                 m.type_probabilities.contains_key(&t),
                 "missing type probability for {:?}",

--- a/common/src/structs/sv_model.rs
+++ b/common/src/structs/sv_model.rs
@@ -1,16 +1,15 @@
 //! Statistical model for generating symbolic / structural variants
-//! (`<DEL>` / `<DUP>` / `<CNV>` / `<BND>`) de novo from a learned distribution.
+//! (`<DEL>` / `<DUP>` / `<CNV>` / `<BND>` / `<INV>` / `<INS>`) de novo from a learned distribution.
 //!
 //! `SvModel` is fit by [`SvModel::fit_from_observations`] (called from
 //! `gen-mut-model` after the SNP/indel pass completes) and lives on
 //! [`crate::models::mutation_model::MutationModel`] as
-//! `Option<SvModel>` — `None` whenever the training VCF didn't carry
+//! [`Option<SvModel>`] — `None` whenever the training VCF didn't carry
 //! enough usable SV observations, or whenever the model JSON was
 //! written by a pre-v1.10 build (the field defaults to `None` via
 //! `#[serde(default)]`).
 //!
-//! Supported types in this release: `<DEL>` / `<DUP>` / `<CNV>` / `<BND>`. `<INV>`
-//! records are dropped at fit time (logged with a count).
+//! Supported types: `<DEL>` / `<DUP>` / `<CNV>` / `<BND>` / `<INV>` / `<INS>`.
 //! `gen-reads` consumes the model via [`SvModel::sample_variants`],
 //! gated behind the `sv_rate_scale` config knob (default 0.0 — opt-in).
 
@@ -76,7 +75,7 @@ pub struct SvModel {
     pub per_base_rate: f64,
 
     /// Probability that a generated SV is of a given type. Keys are
-    /// limited to `SvType::Del` / `SvType::Dup` / `SvType::Cnv` / `SvType::Bnd`;
+    /// limited to `SvType::Del` / `SvType::Dup` / `SvType::Cnv` / `SvType::Bnd` / `SvType::Inv` / `SvType::Ins`;
     /// probabilities sum to ~1.0 across present keys. A type with
     /// fewer than [`MIN_OBS_FOR_LENGTH_FIT`] observations is dropped
     /// from this map (its length distribution couldn't be fit), and
@@ -125,13 +124,12 @@ impl SvModel {
     /// Filtering applied (in order):
     ///   - records whose ALT isn't `AlternateType::Symbolic` are
     ///     ignored;
-    ///   - `<INV>` / unknown tags are dropped (this release
-    ///     generates `<DEL>` / `<DUP>` / `<CNV>` / `<BND>`);
-    ///   - records with no derivable span (no `END`, no `SVLEN`) are
+    ///   - records with no derivable span/length (no `END`, no `SVLEN`) are
     ///     dropped;
     ///   - records below [`MIN_SV_LENGTH_BP`] are dropped (they're
     ///     indels, not SVs), except for `<BND>` which uses a nominal
     ///     1bp length;
+    ///   - unknown tags are dropped;
     ///   - types with fewer than [`MIN_OBS_FOR_LENGTH_FIT`] surviving
     ///     observations are dropped from the model entirely, so the
     ///     resulting `type_probabilities` and `length_log_normal` have
@@ -166,28 +164,28 @@ impl SvModel {
                 }
             };
             match sv.sv_type {
-                SvType::Del | SvType::Dup | SvType::Cnv | SvType::Bnd => {}
+                SvType::Del | SvType::Dup | SvType::Cnv | SvType::Bnd | SvType::Inv | SvType::Ins => {}
                 _ => {
                     dropped_unsupported_type += 1;
                     continue;
                 }
             }
-            let span = match sv.sv_type {
-                SvType::Bnd => Some(1), // BNDs have no span in the traditional sense; use 1 for length stats
-                _ => sv.span(v.location),
+            let length = match sv.sv_type {
+                SvType::Bnd => Some(1), // BNDs have no length in the traditional sense; use 1 for stats
+                _ => sv.event_length(v.location),
             };
-            let span = match span {
+            let length = match length {
                 Some(s) if s > 0 => s,
                 _ => {
                     dropped_no_span += 1;
                     continue;
                 }
             };
-            if sv.sv_type != SvType::Bnd && span < MIN_SV_LENGTH_BP {
+            if sv.sv_type != SvType::Bnd && length < MIN_SV_LENGTH_BP {
                 dropped_below_min_length += 1;
                 continue;
             }
-            by_type.entry(sv.sv_type).or_default().push((span, v));
+            by_type.entry(sv.sv_type).or_default().push((length, v));
         }
 
         // Drop types that don't have enough observations for a real
@@ -212,7 +210,7 @@ impl SvModel {
         }
         if dropped_unsupported_type > 0 {
             info!(
-                "SvModel: dropped {} <INV>/unknown record(s) — not yet generatable",
+                "SvModel: dropped {} unknown record(s) — not yet generatable",
                 dropped_unsupported_type
             );
         }
@@ -494,6 +492,8 @@ impl SvModel {
                 SvType::Del => ("<DEL>".to_string(), None, None),
                 SvType::Dup => ("<DUP>".to_string(), None, None),
                 SvType::Cnv => ("<CNV>".to_string(), None, None),
+                SvType::Inv => ("<INV>".to_string(), None, None),
+                SvType::Ins => ("<INS>".to_string(), None, None),
                 SvType::Bnd => {
                     // For de novo BNDs, generate an intra-chromosomal translocation
                     // to a random mate position on the same contig.
@@ -510,11 +510,19 @@ impl SvModel {
             };
             let mut sv_data = SvData::new(raw_alt, sv_type);
             sv_data.end = Some(sv_end_1based);
+            sv_data.svlen = if sv_type != SvType::Bnd {
+                Some(match sv_type {
+                    SvType::Del => -(length as i64),
+                    _ => length as i64,
+                })
+            } else {
+                None
+            };
             sv_data.copy_number = copy_number;
             sv_data.mate_contig = m_contig;
             sv_data.mate_pos = m_pos;
 
-            let info_field = build_info_field(sv_type, sv_end_1based, copy_number);
+            let info_field = build_info_field(sv_type, sv_end_1based, length, copy_number);
 
             occupied.push((affected_start, affected_end));
             out.push(Variant {
@@ -717,6 +725,12 @@ fn place_sv(
             // bases, so END_1based = anchor_1based + length = anchor + 1 + length.
             (s, e, anchor + 1 + length)
         }
+        SvType::Ins => {
+            // Insertions are point events in the reference.
+            let s = anchor;
+            let e = s + 1;
+            (s, e, anchor + 1)
+        }
         _ => {
             let s = anchor;
             let e = s + length;
@@ -732,7 +746,10 @@ fn place_sv(
 /// isn't symbolic or has no usable span.
 fn affected_range_for_existing(v: &Variant, block_end: usize) -> Option<(usize, usize)> {
     let sv = v.alternate.as_symbolic()?;
-    let span = sv.span(v.location.saturating_add(1))?;
+    let span = match sv.sv_type {
+        SvType::Ins | SvType::Bnd => Some(1),
+        _ => sv.span(v.location.saturating_add(1)),
+    }?;
     if span == 0 {
         return None;
     }
@@ -754,7 +771,12 @@ fn ranges_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) ->
 /// Emit a single-line VCF `INFO` field carrying the structural-variant
 /// fields downstream readers expect, so de novo records round-trip
 /// through the writer with the same shape as user-supplied input.
-fn build_info_field(sv_type: SvType, end_1based: usize, copy_number: Option<u32>) -> String {
+fn build_info_field(
+    sv_type: SvType,
+    end_1based: usize,
+    length: usize,
+    copy_number: Option<u32>,
+) -> String {
     let mut parts: Vec<String> = Vec::new();
     let svtype = match sv_type {
         SvType::Del => "DEL",
@@ -767,6 +789,13 @@ fn build_info_field(sv_type: SvType, end_1based: usize, copy_number: Option<u32>
     };
     parts.push(format!("SVTYPE={svtype}"));
     parts.push(format!("END={end_1based}"));
+    if sv_type != SvType::Bnd {
+        let svlen = match sv_type {
+            SvType::Del => -(length as i64),
+            _ => length as i64,
+        };
+        parts.push(format!("SVLEN={svlen}"));
+    }
     if let Some(cn) = copy_number {
         parts.push(format!("CN={cn}"));
     }
@@ -1104,29 +1133,42 @@ mod tests {
     }
 
     #[test]
-    fn sample_variants_emits_only_supported_types() {
-        // Even if the model is hand-rolled with an INV in
-        // type_probabilities (which fit_from_observations would never
-        // produce), the sampler skips the unsupported branch — the
-        // resulting output contains only DEL/DUP/CNV/BND.
+    fn sample_variants_emits_all_supported_types() {
+        // The sampler must emit DEL/DUP/CNV/INS/BND/INV if they are in the model.
         let mut m = SvModel::default();
-        m.per_base_rate = 5e-3;
+        m.per_base_rate = 5e-2;
         m.homozygous_frequency = 0.5;
-        m.type_probabilities.insert(SvType::Del, 0.5);
-        m.type_probabilities.insert(SvType::Inv, 0.5);
-        m.length_log_normal.insert(SvType::Del, (7.0, 0.3));
-        m.length_log_normal.insert(SvType::Inv, (7.0, 0.3));
-        let seq = acgt_sequence(100_000);
+        m.type_probabilities.insert(SvType::Del, 0.16);
+        m.type_probabilities.insert(SvType::Dup, 0.16);
+        m.type_probabilities.insert(SvType::Cnv, 0.17);
+        m.type_probabilities.insert(SvType::Ins, 0.17);
+        m.type_probabilities.insert(SvType::Bnd, 0.17);
+        m.type_probabilities.insert(SvType::Inv, 0.17);
+        for t in [
+            SvType::Del,
+            SvType::Dup,
+            SvType::Cnv,
+            SvType::Ins,
+            SvType::Bnd,
+            SvType::Inv,
+        ] {
+            m.length_log_normal.insert(t, (7.0, 0.3));
+        }
+        let seq = acgt_sequence(200_000);
         let mut rng = deterministic_rng();
-        let out = m.sample_variants("chr1", 100_000, &[], &seq, 2, 1.0, &mut rng);
+        let out = m.sample_variants("chr1", 200_000, &[], &seq, 2, 1.0, &mut rng);
+        let mut seen_types = std::collections::HashSet::new();
         for v in &out {
             let sv = v.alternate.as_symbolic().expect("must be symbolic");
-            assert!(
-                matches!(sv.sv_type, SvType::Del | SvType::Dup | SvType::Cnv | SvType::Bnd),
-                "v1 sampler must only emit DEL/DUP/CNV/BND, got {:?}",
-                sv.sv_type
-            );
+            seen_types.insert(sv.sv_type);
         }
+        // At this rate and probability we expect to see all six types
+        assert!(seen_types.contains(&SvType::Del));
+        assert!(seen_types.contains(&SvType::Dup));
+        assert!(seen_types.contains(&SvType::Cnv));
+        assert!(seen_types.contains(&SvType::Ins));
+        assert!(seen_types.contains(&SvType::Bnd));
+        assert!(seen_types.contains(&SvType::Inv));
     }
 
     #[test]
@@ -1177,6 +1219,43 @@ mod tests {
             let length = end - v.location;
             assert!(length >= MIN_SV_LENGTH_BP);
             assert!(end <= 100_000);
+        }
+    }
+
+    #[test]
+    fn sampled_invs_have_correct_pos_and_end_invariant() {
+        let m = model_with_single_type(SvType::Inv, 5e-3);
+        let seq = acgt_sequence(100_000);
+        let mut rng = deterministic_rng();
+        let out = m.sample_variants("chr1", 100_000, &[], &seq, 2, 1.0, &mut rng);
+        assert!(!out.is_empty());
+        for v in &out {
+            let sv = v.alternate.as_symbolic().expect("must be symbolic");
+            assert_eq!(sv.sv_type, SvType::Inv);
+            let end = sv.end.expect("END must be populated");
+            // For INV, the inverted region is 0-based [location, end).
+            let length = end - v.location;
+            assert!(length >= MIN_SV_LENGTH_BP);
+            assert!(end <= 100_000);
+        }
+    }
+
+    #[test]
+    fn sampled_ins_have_correct_pos_and_end_invariant() {
+        let m = model_with_single_type(SvType::Ins, 5e-3);
+        let seq = acgt_sequence(100_000);
+        let mut rng = deterministic_rng();
+        let out = m.sample_variants("chr1", 100_000, &[], &seq, 2, 1.0, &mut rng);
+        assert!(!out.is_empty());
+        for v in &out {
+            let sv = v.alternate.as_symbolic().expect("must be symbolic");
+            assert_eq!(sv.sv_type, SvType::Ins);
+            // For symbolic INS, location is where it's inserted. END usually equals location + 1.
+            let end = sv.end.expect("END must be populated");
+            assert_eq!(end, v.location + 1);
+            // SVLEN should be set and >= MIN_SV_LENGTH_BP
+            let svlen = sv.svlen.expect("SVLEN must be populated for symbolic INS");
+            assert!(svlen >= MIN_SV_LENGTH_BP as i64);
         }
     }
 
@@ -1352,7 +1431,7 @@ mod tests {
         // The INFO string we emit must round-trip through the existing
         // parser so the writer + downstream readers behave like
         // user-supplied input.
-        let info = build_info_field(SvType::Cnv, 1500, Some(4));
+        let info = build_info_field(SvType::Cnv, 1500, 1000, Some(4));
         let parsed = parse_sv_info(&info);
         assert_eq!(parsed.svtype.as_deref(), Some("CNV"));
         assert_eq!(parsed.end, Some(1500));
@@ -1368,13 +1447,15 @@ mod tests {
     }
 
     #[test]
-    fn ranges_overlap_helper_is_half_open() {
-        // Adjacent (touching at boundary) does NOT count as overlap.
-        assert!(!ranges_overlap(0, 50, 50, 100));
-        assert!(!ranges_overlap(50, 100, 0, 50));
-        // Any real intersection does.
-        assert!(ranges_overlap(0, 51, 50, 100));
-        assert!(ranges_overlap(0, 200, 50, 100));
+    fn affected_range_for_existing_ins_is_point_event() {
+        let mut v = sv(1000, None, SvType::Ins, Genotype::Heterozygous, None);
+        if let AlternateType::Symbolic(ref mut sv) = v.alternate {
+            sv.svlen = Some(500);
+        }
+        let range = affected_range_for_existing(&v, 10_000).expect("must have range");
+        // POS=1000 (0-based in the 'sv' helper) -> location=1000
+        // Insertions should only affect the anchor base in terms of reference overlap.
+        assert_eq!(range, (1000, 1001));
     }
 
     // ── sample_poisson tests ─────────────────────────────────────────
@@ -1482,5 +1563,25 @@ mod tests {
              This used to silently emit zero due to Poisson `exp(-λ)` underflow.",
             out.len()
         );
+    }
+
+    #[test]
+    fn fit_from_observations_handles_ins() {
+        // Build a training set with only symbolic insertions. Fitter
+        // must use SVLEN as length and produce a usable model.
+        let mut obs = Vec::new();
+        for i in 0..10 {
+            let mut v = sv(1000 * i, None, SvType::Ins, Genotype::Heterozygous, None);
+            if let AlternateType::Symbolic(ref mut sv) = v.alternate {
+                sv.svlen = Some(200);
+            }
+            obs.push(v);
+        }
+        let m = SvModel::fit_from_observations(&obs, 100_000).expect("must produce a model");
+        assert!(m.type_probabilities.contains_key(&SvType::Ins));
+        let (mu, _) = m.length_log_normal.get(&SvType::Ins).unwrap();
+        // exp(mu) should be ~200. ln(200) ≈ 5.298
+        assert!((mu - 200.0f64.ln()).abs() < 1e-5);
+        assert!(m.per_base_rate > 0.0);
     }
 }

--- a/common/src/structs/variants.rs
+++ b/common/src/structs/variants.rs
@@ -234,6 +234,16 @@ impl SvData {
         }
         None
     }
+
+    /// Compute the total length of the variant event. For non-insertions, this
+    /// is identical to the reference span. For insertions, it is the length
+    /// of the inserted sequence (derived from `SVLEN`).
+    pub fn event_length(&self, location: usize) -> Option<usize> {
+        match self.sv_type {
+            SvType::Ins => self.svlen.map(|l| l.unsigned_abs() as usize),
+            _ => self.span(location),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -840,86 +840,211 @@ fn process_chimeric_variants(
     mut rng: NeatRng,
 ) -> Result<ContigResult, GenerateReadsError> {
     let mut all_reads = Vec::new();
-    let mut processed_bnds = HashSet::new();
+    let mut processed_ids = HashSet::new();
 
     for (contig_name, m_map) in ctx.mutated_maps.iter() {
         for sv_rec in &m_map.sv_records {
             let sv = match sv_rec.alternate.as_symbolic() {
-                Some(s) if s.sv_type == SvType::Bnd => s,
+                Some(s) => s,
                 _ => continue,
             };
 
-            let mate_contig = match &sv.mate_contig {
-                Some(c) => c,
-                None => continue,
-            };
-            let mate_pos = match sv.mate_pos {
-                Some(p) => p,
-                None => continue,
-            };
+            if sv.sv_type == SvType::Bnd {
+                let mate_contig = match &sv.mate_contig {
+                    Some(c) => c,
+                    None => continue,
+                };
+                let mate_pos = match sv.mate_pos {
+                    Some(p) => p,
+                    None => continue,
+                };
 
-            // BND records come in pairs — each side describes the same
-            // junction from its own contig+position. Canonicalize the
-            // (contig, pos) tuples so the "smaller" side comes first, then
-            // use that as the dedup key. Tuple ordering handles both the
-            // cross-contig case (compare contig names lexicographically)
-            // and the same-contig case (compare positions) uniformly.
-            let here = (contig_name.as_str(), sv_rec.location);
-            let mate = (mate_contig.as_str(), mate_pos);
-            let bnd_id = if here <= mate {
-                (contig_name.clone(), sv_rec.location, mate_contig.clone(), mate_pos)
-            } else {
-                (mate_contig.clone(), mate_pos, contig_name.clone(), sv_rec.location)
-            };
-            if !processed_bnds.insert(bnd_id) {
-                continue;
-            }
+                // BND records come in pairs — each side describes the same
+                // junction from its own contig+position. Canonicalize the
+                // (contig, pos) tuples so the "smaller" side comes first,
+                // then use that as the dedup key. Tuple ordering handles
+                // both the cross-contig case (compare contig names
+                // lexicographically) and the same-contig case (compare
+                // positions) uniformly. Stored in `processed_ids` keyed by
+                // type-prefixed string so BND and INV share one HashSet.
+                let here = (contig_name.as_str(), sv_rec.location);
+                let mate = (mate_contig.as_str(), mate_pos);
+                let bnd_id = if here <= mate {
+                    (contig_name.clone(), sv_rec.location, mate_contig.clone(), mate_pos)
+                } else {
+                    (mate_contig.clone(), mate_pos, contig_name.clone(), sv_rec.location)
+                };
+                if !processed_ids.insert(format!("BND_{:?}", bnd_id)) {
+                    continue;
+                }
 
-            // Coverage model for chimeric BND reads:
-            //   - Homozygous BND: every allele carries the junction, so every
-            //     read covering the breakpoint should be a junction read.
-            //     mult = 1.0 → num_frags = full configured coverage.
-            //   - Heterozygous: half the alleles carry the junction; the
-            //     other half are unbroken reference. mult = 1/ploidy.
-            //
-            // Important caveat: the *regular* per-contig pass also generates
-            // reads covering the breakpoint position (it just reads from the
-            // unbroken reference, oblivious to the BND). For a homozygous
-            // BND this means the breakpoint locus ends up with regular reads
-            // PLUS junction reads — roughly double the true biological
-            // coverage there. For a heterozygous BND it lands closer to
-            // correct (regular pass covers both alleles, chimeric pass adds
-            // 1/ploidy worth of junction reads). A proper fix would teach
-            // the regular pass to skip the broken-allele fraction of reads
-            // at BND positions; tracked as a v2 follow-up.
-            let mult = match sv_rec.genotype {
-                Genotype::Homozygous => 1.0,
-                Genotype::Heterozygous => 1.0 / (ctx.config.ploidy as f64),
-            };
+                // Coverage model for chimeric BND reads:
+                //   - Homozygous BND: every allele carries the junction, so
+                //     every read covering the breakpoint should be a
+                //     junction read. mult = 1.0 → num_frags = full coverage.
+                //   - Heterozygous: half the alleles carry the junction; the
+                //     other half are unbroken reference. mult = 1/ploidy.
+                //
+                // Important caveat: the *regular* per-contig pass also
+                // generates reads covering the breakpoint position (it just
+                // reads from the unbroken reference, oblivious to the BND).
+                // For a homozygous BND this means the breakpoint locus ends
+                // up with regular reads PLUS junction reads — roughly double
+                // the true biological coverage there. For a heterozygous
+                // BND it lands closer to correct (regular pass covers both
+                // alleles, chimeric pass adds 1/ploidy worth of junction
+                // reads). A proper fix would teach the regular pass to skip
+                // the broken-allele fraction of reads at BND positions;
+                // tracked as a v2 follow-up.
+                let mult = match sv_rec.genotype {
+                    Genotype::Homozygous => 1.0,
+                    Genotype::Heterozygous => 1.0 / (ctx.config.ploidy as f64),
+                };
 
-            let num_frags = scale_coverage(ctx.config.coverage, mult);
-            if num_frags == 0 {
-                continue;
-            }
+                let num_frags = scale_coverage(ctx.config.coverage, mult);
+                if num_frags == 0 {
+                    continue;
+                }
 
-            for frag_idx in 0..num_frags {
-                let rand_val = rng.random().map_err(GenerateReadsError::from)?;
-                let frag_len = ctx.fragment_length_model.generate_fragment(rand_val).map_err(GenerateReadsError::from)? as usize;
-                let offset = rng.range_i64(1, frag_len as i64).map_err(|e| GenerateReadsError::CliError(e))? as usize;
+                for frag_idx in 0..num_frags {
+                    // Fragment length picked the same way the main read-gen
+                    // path does it (paired-end: model-sampled with a
+                    // length-floor retry; single-end: read_len + a 32bp pad
+                    // so sequencing-error deletions don't truncate the read).
+                    let se_pad = if ctx.config.paired_ended { 0 } else { 32 };
+                    let frag_len = if ctx.config.paired_ended {
+                        let mut attempts = 0;
+                        let mut f = 0;
+                        while attempts < 100 {
+                            let rand_val = rng.random().map_err(GenerateReadsError::from)?;
+                            f = ctx.fragment_length_model.generate_fragment(rand_val).map_err(GenerateReadsError::from)? as usize;
+                            if ctx.config.long_reads || f >= ctx.config.read_len + 10 {
+                                break;
+                            }
+                            attempts += 1;
+                        }
+                        if f < ctx.config.read_len && !ctx.config.long_reads {
+                            f = ctx.config.read_len + 10;
+                        }
+                        f
+                    } else {
+                        ctx.config.read_len + se_pad
+                    };
 
-                let (read1, read2) = generate_chimeric_pair(
-                    ctx,
-                    contig_name,
-                    sv_rec.location,
-                    sv,
-                    frag_len,
-                    offset,
-                    frag_idx,
-                    &mut rng,
-                )?;
-                all_reads.push(read1);
-                if let Some(r2) = read2 {
-                    all_reads.push(r2);
+                    let offset = rng.range_i64(1, (frag_len - 1).min(ctx.config.read_len - 1).max(1) as i64).map_err(|e| GenerateReadsError::CliError(e))? as usize;
+
+                    let result = generate_chimeric_pair(
+                        ctx,
+                        contig_name,
+                        sv_rec.location,
+                        sv,
+                        frag_len,
+                        offset,
+                        frag_idx,
+                        &mut rng,
+                    );
+
+                    match result {
+                        Ok((read1, read2)) => {
+                            all_reads.push(read1);
+                            if let Some(r2) = read2 {
+                                all_reads.push(r2);
+                            }
+                        }
+                        Err(GenerateReadsError::FqToolsError(common::file_tools::fastq_tools::FastqToolsError::TruncatedRead(msg))) => {
+                            debug!("Skipping truncated chimeric read: {}", msg);
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+            } else if sv.sv_type == SvType::Inv {
+                let end = match sv.end {
+                    Some(e) => e,
+                    None => {
+                        if let Some(span) = sv.span(sv_rec.location) {
+                            sv_rec.location + span - 1
+                        } else {
+                            continue;
+                        }
+                    }
+                };
+
+                let inv_id = (contig_name.clone(), sv_rec.location, end);
+                if !processed_ids.insert(format!("INV_{:?}", inv_id)) {
+                    continue;
+                }
+
+                // Same coverage model as BND — full coverage for homozygous,
+                // 1/ploidy for heterozygous. The double-counting caveat from
+                // the BND branch applies here too: the regular per-contig
+                // pass still generates reads spanning the inversion's two
+                // breakpoints (it reads from the unbroken forward reference),
+                // so a homozygous inversion ends up with regular + junction
+                // coverage at each breakpoint.
+                let mult = match sv_rec.genotype {
+                    Genotype::Homozygous => 1.0,
+                    Genotype::Heterozygous => 1.0 / (ctx.config.ploidy as f64),
+                };
+
+                let num_frags = scale_coverage(ctx.config.coverage, mult);
+                if num_frags == 0 {
+                    continue;
+                }
+
+                for frag_idx in 0..num_frags {
+                    let se_pad = if ctx.config.paired_ended { 0 } else { 32 };
+                    let frag_len = if ctx.config.paired_ended {
+                        let mut attempts = 0;
+                        let mut f = 0;
+                        while attempts < 100 {
+                            let rand_val = rng.random().map_err(GenerateReadsError::from)?;
+                            f = ctx.fragment_length_model.generate_fragment(rand_val).map_err(GenerateReadsError::from)? as usize;
+                            if ctx.config.long_reads || f >= ctx.config.read_len + 10 {
+                                break;
+                            }
+                            attempts += 1;
+                        }
+                        if f < ctx.config.read_len && !ctx.config.long_reads {
+                            f = ctx.config.read_len + 10;
+                        }
+                        f
+                    } else {
+                        ctx.config.read_len + se_pad
+                    };
+
+                    // An inversion has two breakpoints (junction=1 at the
+                    // start, junction=2 at the end), and each one needs
+                    // its own junction-spanning reads. Both junctions share
+                    // the frag_idx (it's a per-INV-record counter) but the
+                    // junction number disambiguates the QNAMEs that
+                    // generate_inv_pair emits.
+                    for junction in 1..=2 {
+                        let offset = rng.range_i64(1, (frag_len - 1).min(ctx.config.read_len - 1).max(1) as i64).map_err(|e| GenerateReadsError::CliError(e))? as usize;
+                        let result = generate_inv_pair(
+                            ctx,
+                            contig_name,
+                            sv_rec.location,
+                            end,
+                            junction,
+                            frag_len,
+                            offset,
+                            frag_idx,
+                            &mut rng,
+                        );
+
+                        match result {
+                            Ok((read1, read2)) => {
+                                all_reads.push(read1);
+                                if let Some(r2) = read2 {
+                                    all_reads.push(r2);
+                                }
+                            }
+                            Err(GenerateReadsError::FqToolsError(common::file_tools::fastq_tools::FastqToolsError::TruncatedRead(msg))) => {
+                                debug!("Skipping truncated chimeric read: {}", msg);
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    }
                 }
             }
         }
@@ -1075,6 +1200,125 @@ fn generate_chimeric_pair(
     }
 
     Ok((r1, r2))
+}
+
+fn generate_inv_pair(
+    ctx: &ContigContext,
+    contig: &str,
+    location: usize, // 0-based
+    end: usize, // 1-based
+    junction: usize,
+    frag_len: usize,
+    offset: usize,
+    frag_idx: usize,
+    rng: &mut NeatRng,
+) -> Result<(ReadRecord, Option<ReadRecord>), GenerateReadsError> {
+    let ((c1, s1, e1, rev1), (c2, s2, e2, rev2)) =
+        get_inv_pieces(contig, location, end, junction, offset, frag_len - offset, ctx)?;
+
+    let seq1 = get_stitched_sequence(ctx, &c1, s1, e1, rev1, &c2, s2, e2, rev2, rng)?;
+
+    let read_len = ctx.config.read_len;
+    // The trailing 16-hex `frag_idx` matches the uniqueness-tag pattern that
+    // write_block_fastq + generate_chimeric_pair use (#210). The `junction`
+    // tag already disambiguates the two breakpoints of a single inversion;
+    // frag_idx disambiguates fragments at the same breakpoint when
+    // num_frags > 1.
+    let base_name = format!(
+        "RNEAT_chimeric_INV_{}_{}_{}_{}_{:016x}",
+        contig, location + 1, end, junction, frag_idx,
+    );
+
+    let quality_scores_1 = ctx.quality_score_model.generate_quality_scores(read_len, rng).map_err(GenerateReadsError::from)?;
+
+    // Inversion-junction reads contribute to junction signal, not point
+    // coverage — same rationale as generate_chimeric_pair. Use a throwaway
+    // AdCounter so generate_read's increment site has somewhere to write
+    // without leaking values into the per-contig counter used by write_vcf.
+    let mut throwaway_ad = AdCounter::new();
+
+    let r1 = generate_read(
+        &seq1,
+        &[],
+        &HashMap::new(),
+        read_len,
+        format!("{}/1", base_name),
+        Strand::Forward,
+        quality_scores_1,
+        ctx.seq_error_model,
+        rng,
+        c1.clone(),
+        s1,
+        c2.clone(),
+        s2,
+        frag_len as i32,
+        ctx.config.paired_ended,
+        &mut throwaway_ad,
+    ).map_err(GenerateReadsError::from)?;
+
+    let mut r2 = None;
+    if ctx.config.paired_ended {
+        let quality_scores_2 = ctx.quality_score_model.generate_quality_scores(read_len, rng).map_err(GenerateReadsError::from)?;
+        let r2_record = generate_read(
+            &reverse_complement(seq1),
+            &[],
+            &HashMap::new(),
+            read_len,
+            format!("{}/2", base_name),
+            Strand::Reverse,
+            quality_scores_2,
+            ctx.seq_error_model,
+            rng,
+            c2.clone(),
+            s2,
+            c1.clone(),
+            s1,
+            -(frag_len as i32),
+            true,
+            &mut throwaway_ad,
+        ).map_err(GenerateReadsError::from)?;
+        r2 = Some(r2_record);
+    }
+
+    Ok((r1, r2))
+}
+
+fn get_inv_pieces(
+    contig: &str,
+    location: usize, // 0-based location (POS-1)
+    end: usize, // 1-based END
+    junction: usize, // 1 or 2
+    len1: usize,
+    len2: usize,
+    ctx: &ContigContext,
+) -> Result<((String, usize, usize, bool), (String, usize, usize, bool)), GenerateReadsError> {
+    // Error rather than silently defaulting to zero-length sequences if the
+    // inversion's contig is missing from the reference — same defense-in-
+    // depth as get_bnd_pieces.
+    let c_len = ctx.reference.get(contig).map(|s| s.len()).ok_or_else(|| {
+        GenerateReadsError::CliError(format!(
+            "INV at {contig}:{location} references contig {contig} but that contig is not in the reference"
+        ))
+    })?;
+    Ok(if junction == 1 {
+        // Junction 1: REF[..POS-1] | RC(REF[POS..END])
+        // Left piece ends at index location-1. Right piece starts at RC(index end-1).
+        let e1 = location;
+        let s1 = e1.saturating_sub(len1);
+
+        let e2 = end.min(c_len);
+        let s2 = e2.saturating_sub(len2).max(location);
+        ((contig.to_string(), s1, e1, false), (contig.to_string(), s2, e2, true))
+    } else {
+        // Junction 2: RC(REF[POS..END]) | REF[END+1..]
+        // Left piece ends at RC(index location). Right piece starts at index end.
+        let s1 = location;
+        let e1 = (s1 + len1).min(end).min(c_len);
+
+        let s2 = end.min(c_len);
+        let e2 = (s2 + len2).min(c_len);
+        ((contig.to_string(), s1, e1, true), (contig.to_string(), s2, e2, false))
+    })
 }
 
 fn get_bnd_pieces(

--- a/rneat/tests/inv_fastq.rs
+++ b/rneat/tests/inv_fastq.rs
@@ -1,0 +1,61 @@
+mod common;
+use common::{
+    GenReadsConfig, fresh_workdir, h1n1_reference, rneat,
+};
+use std::io::Write as _;
+
+#[test]
+fn gen_reads_with_inv_variant_produces_chimeric_reads_in_fastq() {
+    let (_dir, work) = fresh_workdir();
+
+    let input_vcf = work.join("input_inv.vcf");
+    {
+        let mut f = std::fs::File::create(&input_vcf).unwrap();
+        writeln!(f, "##fileformat=VCFv4.2").unwrap();
+        writeln!(f, "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">").unwrap();
+        writeln!(f, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS").unwrap();
+        // INV variant: H1N1_HA:500 to 1000
+        writeln!(
+            f,
+            "H1N1_HA\t500\t.\tG\t<INV>\t60\tPASS\tEND=1000\tGT\t1/1"
+        )
+        .unwrap();
+    }
+
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.clone(), "inv_fastq");
+    config.coverage = 100; // High coverage to ensure we get some chimeric reads
+    config.produce_fastq = true;
+    config.input_vcf = Some(input_vcf);
+    let yaml = config.write_yaml();
+    rneat()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let out_fastq_1 = work.join("inv_fastq_r1.fastq.gz");
+    assert!(out_fastq_1.exists(), "output FASTQ 1 not produced at {:?}", out_fastq_1);
+    
+    // Check if any read name contains "chimeric_INV"
+    let fastq_lines: Vec<String> = {
+        use flate2::read::MultiGzDecoder;
+        use std::io::{BufRead, BufReader};
+        let r = BufReader::new(MultiGzDecoder::new(std::fs::File::open(&out_fastq_1).unwrap()));
+        r.lines().map(|l| l.unwrap()).collect()
+    };
+    
+    let has_chimeric = fastq_lines.iter().any(|l| l.contains("RNEAT_chimeric_INV"));
+    assert!(has_chimeric, "Expected to find chimeric INV reads in FASTQ output. Lines: {:?}", &fastq_lines[..fastq_lines.len().min(10)]);
+
+    // Check both junctions are represented. QNAMEs now end with
+    //   RNEAT_chimeric_INV_<contig>_<pos>_<end>_<junction>_<16-hex>/<mate>
+    // (the 16-hex frag_idx tag was added for QNAME-uniqueness per #210).
+    // The substring `_<junction>_0` is unambiguous for these synthetic
+    // H1N1 fixtures — the hex frag_idx values all start with `0` since
+    // num_frags is well under 2^60.
+    let has_junction_1 = fastq_lines.iter().any(|l| l.contains("_1_0"));
+    let has_junction_2 = fastq_lines.iter().any(|l| l.contains("_2_0"));
+
+    assert!(has_junction_1, "Expected to find Junction 1 chimeric reads");
+    assert!(has_junction_2, "Expected to find Junction 2 chimeric reads");
+}

--- a/tools/validate_with_gnomad.sh
+++ b/tools/validate_with_gnomad.sh
@@ -105,18 +105,18 @@ prep_input() {
         echo "Smoke mode: restricting to '$region' (detected naming from '$first_contig')"
     fi
     # Split multi-allelic records (so MCNV doesn't get silently dropped at
-    # the reader) and exclude SV types v1.10 can't generate so the trainer
+    # the reader) and exclude SV types v1.11 can't generate so the trainer
     # warn log stays readable. Pipe through bcftools view -r FIRST so the
     # region restriction is applied before any further filtering.
-    echo "Filtering: splitting multi-allelic, dropping INV/CPX/CTX/<INS:ME:*>"
+    echo "Filtering: splitting multi-allelic, dropping CPX/CTX"
     if [[ -n "$region" ]]; then
         bcftools view -r "$region" "$GNOMAD_VCF" \
             | bcftools norm -m - \
-            | bcftools view -e 'ALT~"^<INV>$" || ALT~"^<CPX>$" || ALT~"^<CTX>$" || ALT~"^<INS:ME"' \
+            | bcftools view -e 'ALT~"^<CPX>$" || ALT~"^<CTX>$"' \
                 -Oz -o "$out"
     else
         bcftools norm -m - "$GNOMAD_VCF" \
-            | bcftools view -e 'ALT~"^<INV>$" || ALT~"^<CPX>$" || ALT~"^<CTX>$" || ALT~"^<INS:ME"' \
+            | bcftools view -e 'ALT~"^<CPX>$" || ALT~"^<CTX>$"' \
                 -Oz -o "$out"
     fi
     bcftools index -t "$out"
@@ -177,16 +177,18 @@ inspect() {
     type_sum="$(echo "$sv_model" | jq '.type_probabilities | to_entries | map(.value) | add')"
     echo "type_probabilities sum: $type_sum (expect ~1.0)"
     # Compare against bundled defaults — fail soft on large deviations.
-    local del_p dup_p cnv_p bnd_p
+    local del_p dup_p cnv_p bnd_p inv_p ins_p
     del_p="$(echo "$sv_model" | jq '.type_probabilities.Del // 0')"
     dup_p="$(echo "$sv_model" | jq '.type_probabilities.Dup // 0')"
     cnv_p="$(echo "$sv_model" | jq '.type_probabilities.Cnv // 0')"
     bnd_p="$(echo "$sv_model" | jq '.type_probabilities.Bnd // 0')"
-    echo "Type breakdown:  DEL=$del_p     DUP=$dup_p     CNV=$cnv_p     BND=$bnd_p"
-    echo "Default expects: DEL=0.8171  DUP=0.1824  CNV=0.0005  BND=0.0 (v1.10.3)"
+    inv_p="$(echo "$sv_model" | jq '.type_probabilities.Inv // 0')"
+    ins_p="$(echo "$sv_model" | jq '.type_probabilities.Ins // 0')"
+    echo "Type breakdown:  DEL=$del_p     DUP=$dup_p     CNV=$cnv_p     BND=$bnd_p     INV=$inv_p     INS=$ins_p"
+    echo "Default expects: DEL=0.6433  DUP=0.1470  CNV=0.0004  BND=0.1943  INV=0.0050  INS=0.0100 (v1.11.1)"
     local per_base
     per_base="$(echo "$sv_model" | jq '.per_base_rate')"
-    echo "per_base_rate: $per_base (default 4.841e-4 from full gnomAD-SV v4.1)"
+    echo "per_base_rate: $per_base (default 6.009e-4 from full gnomAD-SV v4.1)"
     local hom
     hom="$(echo "$sv_model" | jq '.homozygous_frequency')"
     echo "homozygous_frequency: $hom (default 0.20 — literature; gnomAD-SV is sites-only)"
@@ -249,7 +251,7 @@ EOF
     local n_sv
     n_sv="$(zcat reads_out/validation.vcf.gz 2>/dev/null \
         | grep -v '^#' \
-        | grep -E '<DEL>|<DUP>|<CNV>|[[][^]]*:[^]]*[[|]][^]]*:[^]]*[]]' \
+        | grep -E '<DEL>|<DUP>|<CNV>|<INV>|[[][^]]*:[^]]*[[|]][^]]*:[^]]*[]]' \
         | wc -l)"
     echo "SVs in output golden VCF: $n_sv"
     if [[ "$n_sv" -eq 0 ]]; then


### PR DESCRIPTION
### Structural variant (SV) modeling improvements
- **Full support for symbolic `<INS>` (Insertions) in `SvModel`.** The statistical model now learns the rate and length distribution of symbolic insertions from training VCFs (gnomAD-SV, etc.). Sampled `<INS>` records now carry appropriate `SVLEN` and `END` tags in the output golden VCF.
- **Improved VCF output for structural variants.** De novo sampled SVs now include `SVLEN` in their INFO field (negative for deletions, positive for others).
- **VCF header completeness.** The output VCF header now includes missing `ALT` definitions for `<DUP>` and `<CNV>`, plus standard `INFO` definitions for `SVTYPE`, `SVLEN`, `END`, and `CN`.
- **Refined SV length statistics.** Introduced `SvData::event_length` to correctly distinguish between reference span (bases removed/replaced) and event length (bases inserted), ensuring more accurate log-normal fitting for insertions.
- **Bundled default SV model updated.** Updated `default_sv_model` with heuristic parameters for `<INS>` (median ~300bp, matching Alu MEIs) and `<INV>` (median ~4.9kb), and adjusted type probabilities to better reflect human genome diversity.
- **Fix:** `SvModel::affected_range_for_existing` now correctly handles `<INS>` and breakends as point events (1-bp reference span) rather than using their `SVLEN` as the span. This prevents point insertions from blocking nearby variants during de novo sampling.
