### PR TITLE
cancer_simulate.sh: fix cross-pass duplicate read names in merged FASTQ

### DIFF
--- a/tools/cancer_simulate.sh
+++ b/tools/cancer_simulate.sh
@@ -253,19 +253,45 @@ write_config "$TUMOR_CONFIG" "$TUMOR_PREFIX" "$TUMOR_COVERAGE" \
 "$RNEAT_BIN" gen-reads -c "$TUMOR_CONFIG"
 
 # ── Merge FASTQs ─────────────────────────────────────────────────────────
-# Gzipped FASTQ files are concatenable as-is — multi-stream gzip is part
-# of the spec and every standard reader (fastp, samtools, MultiGzDecoder,
-# bgzf-aware tools) handles it. cat is the right tool here, not a re-gzip.
+# gen-reads names reads by genomic position (`RNEAT_generated_<contig>_
+# <start>_<end>/<mate>`), so if the normal and tumor passes happen to
+# sample reads at the same start coordinate they get IDENTICAL names. On
+# chr22 at 30× combined coverage we observed ~456k collisions out of
+# ~9.6M reads, which Mutect2 warns about and which Picard MarkDuplicates
+# would silently drop (halving effective coverage at those loci).
+#
+# Fix: stream each per-pass FASTQ through awk and prefix the read name
+# (line 1 of every 4-line record) with `N_` or `T_` before re-bgzipping.
+# Quality lines (line 4) can start with `@` too — that's why we filter
+# by line position within each record, not by leading character.
+prefix_reads() {
+    local in_fq="$1" out_fq="$2" tag="$3"
+    zcat "$in_fq" | awk -v tag="$tag" '
+        NR % 4 == 1 { sub(/^@/, "@" tag "_") }
+        { print }
+    ' | gzip -c > "$out_fq"
+}
+
 NORMAL_R1="${OUTPUT_DIR}/${NORMAL_PREFIX}_r1.fastq.gz"
 TUMOR_R1="${OUTPUT_DIR}/${TUMOR_PREFIX}_r1.fastq.gz"
 MERGED_R1="${OUTPUT_DIR}/${MERGED_PREFIX}_r1.fastq.gz"
-cat "$NORMAL_R1" "$TUMOR_R1" > "$MERGED_R1"
+NORMAL_R1_TAGGED="${OUTPUT_DIR}/${NORMAL_PREFIX}_r1.tagged.fastq.gz"
+TUMOR_R1_TAGGED="${OUTPUT_DIR}/${TUMOR_PREFIX}_r1.tagged.fastq.gz"
+prefix_reads "$NORMAL_R1" "$NORMAL_R1_TAGGED" "N"
+prefix_reads "$TUMOR_R1"  "$TUMOR_R1_TAGGED"  "T"
+cat "$NORMAL_R1_TAGGED" "$TUMOR_R1_TAGGED" > "$MERGED_R1"
+rm -f "$NORMAL_R1_TAGGED" "$TUMOR_R1_TAGGED"
 
 if [[ "$PAIRED_END" == "true" ]]; then
     NORMAL_R2="${OUTPUT_DIR}/${NORMAL_PREFIX}_r2.fastq.gz"
     TUMOR_R2="${OUTPUT_DIR}/${TUMOR_PREFIX}_r2.fastq.gz"
     MERGED_R2="${OUTPUT_DIR}/${MERGED_PREFIX}_r2.fastq.gz"
-    cat "$NORMAL_R2" "$TUMOR_R2" > "$MERGED_R2"
+    NORMAL_R2_TAGGED="${OUTPUT_DIR}/${NORMAL_PREFIX}_r2.tagged.fastq.gz"
+    TUMOR_R2_TAGGED="${OUTPUT_DIR}/${TUMOR_PREFIX}_r2.tagged.fastq.gz"
+    prefix_reads "$NORMAL_R2" "$NORMAL_R2_TAGGED" "N"
+    prefix_reads "$TUMOR_R2"  "$TUMOR_R2_TAGGED"  "T"
+    cat "$NORMAL_R2_TAGGED" "$TUMOR_R2_TAGGED" > "$MERGED_R2"
+    rm -f "$NORMAL_R2_TAGGED" "$TUMOR_R2_TAGGED"
 fi
 
 # ── Merge golden VCFs into a single origin-tagged truth set ─────────────


### PR DESCRIPTION
## Summary
gen-reads names reads by genomic position (`RNEAT_generated_<contig>_<start>_<end>/<mate>`). When `cancer_simulate.sh`'s merge step concatenates the normal + tumor per-pass FASTQs with `cat`, any pair of reads that happen to sample the same start coordinate across the two passes ends up sharing a literal name in the merged FASTQ. That's a real bug — Mutect2 warns about it loudly, Picard MarkDuplicates would silently drop the duplicates and halve effective coverage at those loci, and tools that parse FASTQ pairing from QNAME suffixes can misinterpret them.

## Scale (chr22 30× smoke test)
- ~456,223 names appear in both the normal and tumor pass FASTQs
- After `cat` merge: ~912k reads share names with another read

## Fix
Stream each per-pass FASTQ through `awk` and prefix the read name (line 1 of every 4-line record) with `N_` or `T_` before re-gzipping. Quality lines can also start with `@` (valid PHRED character), so we filter by position-within-record rather than leading char.

End-to-end verified on the existing chr22 smoke-test FASTQs: zero cross-pass collisions in the tagged merge output.

## Partial fix — gen-reads side still has intra-pass collisions
On the same chr22 smoke test:
- Normal pass: 5,048,193 raw reads, 4,819,574 unique names → ~228k duplicates *within* the normal pass
- Tumor pass:  5,048,193 raw reads, 4,819,851 unique names → ~228k duplicates *within* the tumor pass

This is expected by birthday paradox at 5M reads on a 50Mb contig — but it's still a bug, and this PR doesn't fix it. Filing as a follow-up since the fix requires a tie-breaker in `gen-reads`' read-name construction (rust-side change), not the shell wrapper.

## Recovery for existing chr22 smoke-test data
You don't have to re-run cancer_simulate.sh end-to-end (1.5 hours). Just re-do the merge step:

```bash
cd ~/code/cancer_test
prefix_reads() {
    zcat "$1" | awk -v tag="$3" 'NR%4==1 {sub(/^@/, "@" tag "_")} {print}' | gzip -c > "$2"
}
prefix_reads smoketest_normal_r1.fastq.gz /tmp/n.fq.gz N
prefix_reads smoketest_tumor_r1.fastq.gz  /tmp/t.fq.gz T
cat /tmp/n.fq.gz /tmp/t.fq.gz > smoketest_merged_r1.fastq.gz
rm /tmp/n.fq.gz /tmp/t.fq.gz
```

Then re-run `cancer_benchmark.sh` against the de-duplicated merged FASTQ.

## Test plan
- [ ] `cancer_simulate.sh` produces a merged FASTQ where every read name appears at most as many times as its intra-pass collision count (i.e., zero cross-pass overhead).
- [ ] Mutect2 warns substantially less (down by ~50% on the chr22 test).
- [ ] Eventually, with the gen-reads intra-pass fix, both warning counts drop to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)