### PR TITLE
perf: O(log V) read-write variant lookup (fix slow tumor-pass read-gen)

### DIFF
--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -116,18 +116,30 @@ pub fn write_block_fastq<T: Write, W: Write>(
         let mut reads1_flagged: Vec<usize> = Vec::new();
         let mut read2_variants: HashMap<usize, &Variant> = HashMap::new();
         let mut reads2_flagged: Vec<usize> = Vec::new();
-        for (pos, variant) in &block_map.variant_map {
-            if (start..(start + effective_read_len)).contains(pos) {
-                let var_pos = pos - start;
-                read1_variants.insert(var_pos, variant);
-                reads1_flagged.push(var_pos);
-            }
-            if end > effective_read_len
-                && paired_ended
-                && ((end - effective_read_len)..end).contains(pos)
-            {
+        // Only the variants overlapping this fragment's two read windows matter.
+        // block_map.flagged_positions is sorted (from_interval), so binary-search
+        // each window instead of scanning every variant on the contig. The old
+        // full-map scan made this O(fragments × variants) — pathological with
+        // dense models (~220k SNVs on chr22 from the COSMIC tumor rate).
+        let flagged = &block_map.flagged_positions;
+        // R1 window: [start, start + effective_read_len); var offset = pos - start.
+        let r1_lo = flagged.partition_point(|&p| p < start);
+        let r1_hi = flagged.partition_point(|&p| p < start + effective_read_len);
+        for &pos in &flagged[r1_lo..r1_hi] {
+            let var_pos = pos - start;
+            read1_variants.insert(var_pos, &block_map.variant_map[&pos]);
+            reads1_flagged.push(var_pos);
+        }
+        // R2 window: [end - effective_read_len, end); R2 is reverse-stranded so
+        // var offset = (end - 1) - pos. Guard end > effective_read_len so the
+        // window start doesn't underflow (matches the original condition).
+        if paired_ended && end > effective_read_len {
+            let w_lo = end - effective_read_len;
+            let r2_lo = flagged.partition_point(|&p| p < w_lo);
+            let r2_hi = flagged.partition_point(|&p| p < end);
+            for &pos in &flagged[r2_lo..r2_hi] {
                 let var_pos = (end - 1) - pos;
-                read2_variants.insert(var_pos, variant);
+                read2_variants.insert(var_pos, &block_map.variant_map[&pos]);
                 reads2_flagged.push(var_pos);
             }
         }

--- a/common/src/structs/mutated_map.rs
+++ b/common/src/structs/mutated_map.rs
@@ -64,6 +64,13 @@ impl MutatedMap {
             variant_map.insert(location, variant);
             flagged_positions.push(location);
         }
+        // Keep sorted so `is_flagged` and the read-window overlap query in
+        // `write_block_fastq` can binary-search instead of scanning every
+        // variant. With dense models (e.g. the corpus-aggregated COSMIC tumor
+        // rate at ~5.5e-3 → ~220k SNVs on chr22) the old linear scans made
+        // read writing O(fragments × variants); sorting once here makes the
+        // per-read lookup O(log V + hits).
+        flagged_positions.sort_unstable();
         Ok(MutatedMap {
             flagged_positions,
             block_interval: (start, end),
@@ -73,7 +80,9 @@ impl MutatedMap {
     }
 
     pub fn is_flagged(&self, position: &usize) -> bool {
-        self.flagged_positions.contains(position)
+        // flagged_positions is kept sorted by from_interval, so binary-search
+        // rather than a linear scan (called per-base in the chimeric subseq path).
+        self.flagged_positions.binary_search(position).is_ok()
     }
 
     pub fn contains(&self, (x, y): (usize, usize)) -> bool {


### PR DESCRIPTION
## Problem
`write_block_fastq` scanned the **entire contig `variant_map` for every fragment**
to find variants overlapping each read's two windows — O(fragments × variants).
With dense mutation models this dominates read generation. Concretely, the
bundled COSMIC tumor model carries the corpus-aggregated rate (~5.5e-3 → ~220k
SNVs on chr22), so `cancer_simulate.sh`'s tumor pass ran **~22–27 min** where the
normal pass took minutes. Confirmed single-threaded CPU-bound (not contention,
not logging, not the SVs — full investigation in commit message / issue notes).

## Fix
- Keep `MutatedMap.flagged_positions` **sorted** (in `from_interval`).
- Replace the per-fragment full scan with `partition_point` binary-search of each
  read window, looking variants up by key.
- Switch `is_flagged` from linear `contains()` to `binary_search` (it's called
  per-base in the chimeric subseq path).

Turns the per-read lookup into O(log V + hits). Benefits **any** high-variant
run (deep coverage, dense `input_vcf`), not just cancer.

## Correctness
Output is **byte-identical** — the same variant set is collected per read and
consumed by key (not order). `common` unit tests (330), `determinism`,
`model_parity`, and `fastq_validation` all pass; read counts unchanged.

## Measured (chr22 cov2, COSMIC tumor model)
| config | before | after |
|--------|--------|-------|
| cosmic model + sv_rate_scale 5 | ~23 min | **26 s** |
| input_vcf + cosmic + sv_rate_scale 50 | ~27 min | **27 s** |

~55× faster, identical read counts.

## Follow-up (not in this PR)
The COSMIC model's 5.5e-3 rate is also biologically wrong per-tumor (~220k SNVs
is corpus-aggregated, not single-tumor); `cancer_simulate.sh` should default
`--tumor-mutation-rate` to a realistic ~1e-5–1e-4. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)