### PR TITLE
v1.14.1: breakpoint double-count fix + release (bundles perf + tumor-rate fixes)

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+All commands work via `npx` — no global install required.
+
+## Commands
+
+### analyze — Build or refresh the index
+
+```bash
+npx gitnexus analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+| `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
+
+### status — Check index freshness
+
+```bash
+npx gitnexus status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean — Delete the index
+
+```bash
+npx gitnexus clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki — Generate documentation from the graph
+
+```bash
+npx gitnexus wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list — Show all indexed repos
+
+```bash
+npx gitnexus list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] gitnexus_query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] gitnexus_context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Wrong return value   | `context` on the function → trace callees for data flow    |
+| Intermittent failure | `context` → look for external calls, async deps            |
+| Performance issue    | `context` → find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+
+## Tools
+
+**gitnexus_query** — find code related to error:
+
+```
+gitnexus_query({query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**gitnexus_context** — full context for a suspect:
+
+```
+gitnexus_context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**gitnexus_cypher** — custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. gitnexus_query({query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. gitnexus_context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] gitnexus_query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**gitnexus_query** — find execution flows related to a concept:
+
+```
+gitnexus_query({query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**gitnexus_context** — 360-degree view of a symbol:
+
+```
+gitnexus_context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. gitnexus_query({query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. gitnexus_context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence — execution flows related to a concept |
+| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `detect_changes` | Git-diff impact — what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `list_repos`     | Discover indexed repos                                                   |
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**gitnexus_impact** — the primary tool for symbol blast radius:
+
+```
+gitnexus_impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_detect_changes** — git-diff based impact analysis:
+
+```
+gitnexus_detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**gitnexus_rename** — automated multi-file rename:
+
+```
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**gitnexus_impact** — map all dependents first:
+
+```
+gitnexus_impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**gitnexus_detect_changes** — verify your changes after refactoring:
+
+```
+gitnexus_detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**gitnexus_cypher** — custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | gitnexus_query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review ast_search edits (config.json: dynamic reference!)
+
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. gitnexus_detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,62 @@
+6/6/2026
+========
+## rneat v1.14.1
+
+### Patch release: cancer-simulation fixes following the v1.14.0 PCAWG refit
+
+Three corrections to the v1.14.0 cancer-simulation path: a read-generation
+performance fix, a realistic default somatic mutation rate, and the long-standing
+breakpoint double-counting fix.
+
+#### Read-generation performance: O(log V) variant lookup (#233)
+
+`write_block_fastq` scanned the entire contig's `variant_map` for every fragment
+to find the variants overlapping each read — O(fragments × variants). With dense
+models this dominated read generation: the bundled COSMIC tumor model's
+corpus-aggregated rate (~5.5e-3 → ~220k SNVs on chr22) made the
+`cancer_simulate.sh` tumor pass run ~22–27 min where the normal pass took
+minutes. `MutatedMap.flagged_positions` is now kept sorted and the two read
+windows are located by `partition_point` binary search (and `is_flagged` uses
+`binary_search`), turning the per-read lookup into O(log V + hits). Output is
+byte-identical (same variant set per read, consumed by key). Measured on chr22
+cov2 with the COSMIC model: read-gen **23–27 min → ~27 s (~55×)**. Benefits any
+high-variant-density run (deep coverage, dense `input_vcf`), not just cancer.
+
+#### Realistic default tumor somatic mutation rate (#235)
+
+The de-novo mutations added in `cancer_simulate.sh`'s tumor pass are somatic
+(germline is carried through via `input_vcf`), but most tumor models — including
+the bundled COSMIC model (~5.5e-3) — carry a corpus-aggregated rate that
+overstates single-tumor burden by ~50–500×. `--tumor-mutation-rate` now
+**defaults to 1e-5** (typical solid tumor, ~10 SNVs/Mb) instead of the model's
+fitted rate. On the chr22 fixture this drops somatic SNVs from ~278k to ~507.
+Pass `--tumor-mutation-rate model` to defer to the model's own fitted rate. This
+is the SNP/indel rate only — SV burden (`sv_model.per_base_rate × --sv-rate-scale`)
+and the normal-pass germline rate are unchanged.
+
+**Behavioral change:** runs that relied on the old model-fitted default will now
+emit far fewer (realistic) somatic SNVs unless `--tumor-mutation-rate model` is
+passed.
+
+#### Breakpoint double-counting fix (#236)
+
+The chimeric pass emits junction-spanning reads for every chimeric SV junction,
+but the regular per-contig pass also covered those breakpoints from the unbroken
+reference, so a homozygous junction sat at ~2× coverage (het ~1.5×) — the caveat
+carried since v1.12.0. The regular pass now drops the broken-allele fraction of
+read-pairs that cross a junction (a pair crosses when its R1 `[start,start+rl)`
+or R2 `[end−rl,end)` window contains the junction; gap junctions are left alone),
+so total junction depth ≈ coverage. Covers **BND, INV, DEL, and CNV-loss**;
+**DUP and CNV-gain are intentionally not suppressed** — their chimeric junction
+is the tandem boundary (END→POS), a novel adjacency the regular linear pass never
+reproduces, so it isn't double-counted. No-op (and no RNG drawn) for contigs
+without suppressible SVs, so non-SV runs are byte-for-byte unchanged.
+
+**Behavioral change:** simulated depth at homozygous BND/INV/DEL/CNV-loss
+junctions drops from ~2× to ~1× coverage. SV-caller recall is unaffected (the
+chimeric junction reads — the actual detection signal — are retained; only the
+redundant reference reads are removed).
+
 6/5/2026
 ========
 ## rneat v1.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "bincode",
  "bstr",
@@ -1074,7 +1074,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.14.0'
+version = '1.14.1'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/docs/breakpoint_double_counting_fix_plan.md
+++ b/docs/breakpoint_double_counting_fix_plan.md
@@ -1,0 +1,156 @@
+# Fix plan: breakpoint double-counting at homozygous BND/INV junctions
+
+Status: **planned, not implemented** (2026-06-06).
+
+## Problem (grounded in the code)
+
+gen-reads produces SV junction reads in a **separate pass** from the regular
+per-contig read generation, and the two passes don't coordinate:
+
+- **Regular pass** (`process_contig` → `generate_fragments` → `write_block_fastq`):
+  generates reads across the contig from the **unbroken forward reference**.
+  Coverage is modulated per-base by `build_coverage_multipliers`
+  (`runner.rs:2097`). For BND and INV, `coverage_multiplier_for`
+  (`runner.rs:2205`) returns **`Some(1.0)`** — i.e. coverage-neutral, full
+  reference coverage straight through the breakpoint.
+- **Chimeric pass** (`process_chimeric_variants`, `runner.rs:838`): for each
+  BND/INV junction it generates `num_frags = scale_coverage(coverage, mult)`
+  junction-spanning fragments, where `mult = 1.0` (homozygous) or `1/ploidy`
+  (heterozygous). INV emits this per junction × 2 junctions (`location` and
+  `end`); BND emits it at `location`.
+
+So at a junction `j`, the number of read-pairs crossing it is:
+`regular (~coverage) + chimeric (coverage × broken_fraction)`.
+- **Homozygous** (broken_fraction = 1.0): ~**2× coverage** at the junction.
+- **Heterozygous** (1/ploidy = 0.5 at ploidy 2): ~1.5×.
+
+The regular reads at a homozygous junction are also *wrong* (they transcribe the
+unbroken reference, which doesn't exist on either allele), not just redundant.
+
+## Why the existing coverage-multiplier path can't fix it
+
+Coverage multipliers operate on **per-base coverage targets** over a span. But
+the double-count is a property of **fragment geometry** — only read-pairs whose
+sequenced read *crosses* the junction are doubled; pairs lying entirely on one
+flank (within ±read_len of the junction) are legitimate on the broken allele and
+must be kept. A per-base multiplier over a ±read_len window would suppress those
+flank pairs too, punching coverage holes on both sides of every junction. The
+fix must act at **fragment granularity**, not per-base. (This rules out the
+"just add a reduction window to `build_coverage_multipliers`" approach.)
+
+## Recommended design — per-fragment junction-crossing suppression
+
+Model: *the chimeric pass owns `broken_fraction` of the read-pairs that cross
+each junction.* So in the regular pass, **drop each junction-crossing pair with
+probability `broken_fraction`**. The chimeric pass already adds
+`coverage × broken_fraction` stitched pairs back. Net at junction `j`:
+- homozygous: 0 regular + `coverage` chimeric = `coverage` ✓
+- heterozygous: `0.5·coverage` regular (intact allele) + `0.5·coverage` chimeric = `coverage` ✓
+
+### 1. Collect junctions (once per contig)
+From `mutated_map.sv_records`, build a sorted `Vec<(usize /*pos_0based*/, f64 /*broken_fraction*/)>`:
+- **BND**: one entry at `sv_rec.location`.
+- **INV**: two entries, at `sv_rec.location` and the 0-based `end`
+  (**coordinate care**: the chimeric INV branch derives `end` from `sv.end`
+  (1-based END) or `location + span − 1`; the suppression position must be in
+  the same 0-based block-relative space as fragment `(start,end)` — verify
+  against `generate_inv_pair`'s junction coords so the two passes reference the
+  identical base).
+- `broken_fraction = 1.0` (Homozygous) or `1.0 / ploidy` (Heterozygous) — the
+  exact `mult` the chimeric pass uses, so the books balance.
+
+Size: O(#SVs) — kilobytes. Built from data already in memory.
+
+### 2. Suppression predicate (per fragment)
+A fragment `(start, end)` has a sequenced read crossing junction `j` when
+`start ≤ j < start + read_len` (R1) **or**, paired-end,
+`end − read_len ≤ j < end` (R2). (Junctions in the unsequenced insert gap don't
+cross a read and aren't doubled — must NOT be suppressed; this matches where
+`balanced_chimeric_offset` places the chimeric junction, i.e. inside a read.)
+Use `partition_point` on the sorted junction list to find candidates in each
+read window — O(log J + hits) per fragment.
+
+If a crossing junction is found, draw one coin from the contig RNG and drop the
+pair with probability `broken_fraction` (homozygous ⇒ always drop, can skip the
+draw to save a little RNG churn).
+
+### 3. Hook point
+In `process_contig`, after `block_fragments` is assembled and **before**
+`write_block_fastq` — filter `block_fragments` in place. Keeps the change in one
+place, downstream (FASTQ/BAM/AD-counter) automatically sees the corrected set.
+
+### 4. Determinism
+The het coin-flip consumes the contig's `child_rng`, shifting its stream → output
+changes (expected for a behavior fix). Keep the draw ordered deterministically
+(iterate `block_fragments` in existing order; one draw per crossing fragment).
+**Golden/determinism/parity baselines must be regenerated.** Homozygous-only
+runs change too (fragments dropped), so baselines change regardless.
+
+## Resource analysis (packages / memory / CPU)
+
+| | Recommended (per-fragment suppression) | Coverage-window (rejected) | Materialize alt alleles (ideal, expensive) |
+|---|---|---|---|
+| **External pkgs** | **None** — std `sort`/`partition_point` + existing `NeatRng`/`rayon`. (#junctions is small; a `rust-lapper`/interval-tree dep is unnecessary — a sorted `Vec` + binary search is faster and dependency-free.) | none | none, but needs a segmented/"patched-reference" view to stay sane |
+| **Memory** | O(#junctions) per contig (~KB). No large allocations. | O(#junctions) | **O(contig_len × ploidy)** if fully materialized — ~500 MB for a 250 Mb chr at ploidy 2 (1 byte/Nucleotide); whole-arm SVs make alt arms huge. Needs lazy/segmented representation to avoid. |
+| **CPU** | O(fragments × log J) added to read-gen — **<1% overhead** (read-gen is already O(fragments × read_len)). | same, but incorrect | comparable to current read-gen, but replaces the chimeric special-case entirely |
+| **Correctness** | Exact balance at fragment granularity | over-suppresses flanks | exact by construction (junctions emerge naturally) |
+| **Risk/scope** | Localized, ~1 function + junction collection | n/a | large rewrite of the core variant-application + read-gen path |
+
+→ **Recommended: per-fragment suppression.** No new dependency, negligible
+memory/CPU, correct. The materialize-alt-alleles approach is the "right"
+long-term architecture (it also deletes the entire chimeric special-case path
+and the double-count can't exist), but its memory cost and blast radius make it a
+separate redesign, not this fix.
+
+## Scope: BND/INV first; DEL/DUP/CNV considered
+
+The user-named bug is BND/INV (the coverage-neutral types → clean 2×). But the
+same two-pass double-count exists for **DEL/DUP/CNV**, which *also* run through
+`process_chimeric_variants` (`generate_del_pair`/`generate_dup_pair`) while
+*also* modulating coverage. Their interior coverage is handled by the
+multipliers, but flank reads that read *across* the breakpoint into the
+deleted/duplicated span still leak from the regular pass on top of the chimeric
+junction reads — a smaller, partially-masked version of the same issue.
+
+The per-fragment mechanism generalizes to all of them **if** the suppression
+`broken_fraction` for each junction is set to exactly that type's chimeric
+`mult` (read `generate_del_pair`/`generate_dup_pair`/the CNV branch to confirm
+each — they are CN-derived, not simply 1.0/het). Recommendation: **implement and
+validate BND/INV first** (clean, matches the documented caveat), then extend the
+same junction list to DEL/DUP/CNV with per-type fractions as a fast follow-up,
+guarding against double-correcting against the coverage multipliers (the
+multiplier handles interior depth; suppression handles junction-crossing pairs —
+they target different reads, so they compose, but this must be tested).
+
+## Test plan
+
+- **Coverage-depth regression** (the headline): a fixture with a homozygous BND
+  and a homozygous INV; align the FASTQ; assert mean depth in a ±read_len window
+  around each junction is ≈ `coverage`, not ≈ `2× coverage` (was the symptom).
+  Add a heterozygous case asserting ≈ `coverage` (currently ~1.5×).
+- **No flank holes**: assert depth on the flanks immediately outside the
+  junction window stays ≈ `coverage` (guards against over-suppression).
+- **Caller still recovers junctions**: re-run `cancer_sv_benchmark.sh`; BND/INV
+  positional recall must not regress (the chimeric junction reads are unchanged;
+  we only removed redundant reference reads).
+- **Determinism**: same seed → identical output; regenerate the model/parity
+  baselines in `tests/` and `scripts/regenerate_model_baselines.sh`.
+- **Unit**: the junction-crossing predicate (R1/R2 windows, gap exclusion,
+  coordinate space) and the suppression-fraction-per-genotype mapping.
+
+## Risks / follow-ups
+
+- **Coordinate mismatch** between the suppression junction positions and the
+  chimeric pass's junction positions would unbalance the books — pin them to the
+  exact same expressions (especially INV `end`) and assert in a unit test.
+- **DEL/DUP/CNV interaction** with existing coverage multipliers — compose, test.
+- **BND mate pairing**: each BND record suppresses at its own contig position;
+  the mate is handled when its contig/record is processed. Confirm both ends get
+  suppressed (no reliance on the chimeric canonical-ID dedup, which only
+  dedupes chimeric emission, not the regular pass).
+- The deeper "materialize alt alleles" redesign remains the eventual clean
+  architecture; this fix is the low-risk interim that removes the symptom.
+
+Relates to [[project_gen_reads_write_perf]] (the read-gen path this touches) and
+the v1.12.0/v1.13.x chimeric work (`docs/cancer_simulator.md` known-limitations).
+</content>

--- a/docs/breakpoint_double_counting_fix_plan.md
+++ b/docs/breakpoint_double_counting_fix_plan.md
@@ -102,25 +102,28 @@ long-term architecture (it also deletes the entire chimeric special-case path
 and the double-count can't exist), but its memory cost and blast radius make it a
 separate redesign, not this fix.
 
-## Scope: BND/INV first; DEL/DUP/CNV considered
+## Scope: BND/INV + DEL/CNV-loss suppressed; DUP/CNV-gain intentionally not
 
-The user-named bug is BND/INV (the coverage-neutral types → clean 2×). But the
-same two-pass double-count exists for **DEL/DUP/CNV**, which *also* run through
-`process_chimeric_variants` (`generate_del_pair`/`generate_dup_pair`) while
-*also* modulating coverage. Their interior coverage is handled by the
-multipliers, but flank reads that read *across* the breakpoint into the
-deleted/duplicated span still leak from the regular pass on top of the chimeric
-junction reads — a smaller, partially-masked version of the same issue.
+**Implemented** (`collect_suppressible_junctions` / `suppress_junction_double_count`):
 
-The per-fragment mechanism generalizes to all of them **if** the suppression
-`broken_fraction` for each junction is set to exactly that type's chimeric
-`mult` (read `generate_del_pair`/`generate_dup_pair`/the CNV branch to confirm
-each — they are CN-derived, not simply 1.0/het). Recommendation: **implement and
-validate BND/INV first** (clean, matches the documented caveat), then extend the
-same junction list to DEL/DUP/CNV with per-type fractions as a fast follow-up,
-guarding against double-correcting against the coverage multipliers (the
-multiplier handles interior depth; suppression handles junction-crossing pairs —
-they target different reads, so they compose, but this must be tested).
+- **BND** — one point junction at POS, `broken_fraction` = genotype mult (1.0 / 1/ploidy).
+- **INV** — two junctions (POS and END), genotype mult.
+- **DEL** — one junction at POS (the anchor), genotype mult. A read spanning the
+  whole deletion also covers POS, so the single POS junction suffices; the deleted
+  interior is already coverage-zeroed by the multiplier, and suppression handles
+  the flank reads crossing POS that leak on top. The two mechanisms target
+  different reads, so they compose (verified by the full suite passing).
+- **CNV-loss** (cn < ploidy) — DEL-like: one POS junction at `(ploidy − cn)/ploidy`
+  (matches the chimeric CNV branch's mult exactly; CN=0 → 1.0).
+
+**Intentionally NOT suppressed:**
+
+- **DUP** and **CNV-gain** (cn ≥ ploidy). Their chimeric junction is the *tandem
+  boundary* (END→POS) — a **novel adjacency** that the regular linear pass never
+  reproduces, so it is not double-counted. (The extra-copy *depth* is handled by
+  the coverage multiplier; a separate, subtler boundary-coverage question for
+  tandem dups exists but is out of scope for the chimeric double-count fix.)
+- **INS** — literal insertion, no junction double-count.
 
 ## Test plan
 

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -540,14 +540,16 @@ fn process_contig(
     };
 
     // Breakpoint double-counting fix: the chimeric pass emits junction-spanning
-    // read-pairs for every BND/INV junction, but the regular pass above also
-    // covers those positions from the unbroken reference (BND/INV are
-    // coverage-neutral — coverage_multiplier_for returns 1.0). Left alone, a
+    // read-pairs for every chimeric SV junction (BND/INV, plus DEL and CNV-loss),
+    // but the regular pass above also covers those breakpoints from the unbroken
+    // reference (BND/INV are coverage-neutral; DEL/CNV-loss only zero the deleted
+    // interior — flank reads crossing the breakpoint still leak). Left alone, a
     // homozygous junction lands at ~2x coverage (regular + junction reads), a
-    // het at ~1.5x. Drop the broken-allele fraction of regular pairs that cross
-    // a junction so total junction depth ≈ coverage. No-op when the contig has
-    // no BND/INV records (returns the input untouched, consuming no RNG).
-    let block_fragments = suppress_bnd_inv_double_count(
+    // het at ~1.5x. Drop the broken-allele fraction of regular pairs that cross a
+    // junction so total junction depth ≈ coverage. DUP / CNV-gain create a novel
+    // tandem adjacency that linear reads never reproduce, so they are not
+    // suppressed. No-op (no RNG drawn) when the contig has no suppressible SVs.
+    let block_fragments = suppress_junction_double_count(
         block_fragments,
         &mutated_map.sv_records,
         ctx.config.ploidy,
@@ -2116,22 +2118,31 @@ fn exclude_positions(
 /// END for an INV is computed exactly as the chimeric INV branch does
 /// (`sv.end`, else POS + span − 1 via `SvData::span`) so the suppression window
 /// references the same base the chimeric reads were placed against.
-fn collect_bnd_inv_junctions(sv_records: &[Variant], ploidy: usize) -> Vec<(usize, f64)> {
+fn collect_suppressible_junctions(sv_records: &[Variant], ploidy: usize) -> Vec<(usize, f64)> {
     let ploidy_f = (ploidy.max(1)) as f64;
+    let genotype_fraction = |g: &Genotype| match g {
+        Genotype::Homozygous => 1.0,
+        Genotype::Heterozygous => 1.0 / ploidy_f,
+    };
     let mut junctions: Vec<(usize, f64)> = Vec::new();
     for v in sv_records {
         let sv = match v.alternate.as_symbolic() {
             Some(s) => s,
             None => continue,
         };
-        let broken_fraction = match v.genotype {
-            Genotype::Homozygous => 1.0,
-            Genotype::Heterozygous => 1.0 / ploidy_f,
-        };
         match sv.sv_type {
-            SvType::Bnd => junctions.push((v.location, broken_fraction)),
+            // Single point junction at POS. The chimeric pass emits genotype-mult
+            // junction reads here; the regular pass also covers POS from the
+            // unbroken reference (BND is coverage-neutral, DEL's coverage
+            // multiplier only zeros the *interior* — flank reads crossing POS
+            // still leak). broken_fraction = the chimeric pass's genotype mult.
+            SvType::Bnd | SvType::Del => {
+                junctions.push((v.location, genotype_fraction(&v.genotype)))
+            }
+            // Two junctions (POS and END) — both breakpoints get junction reads.
             SvType::Inv => {
-                junctions.push((v.location, broken_fraction));
+                let bf = genotype_fraction(&v.genotype);
+                junctions.push((v.location, bf));
                 let end = match sv.end {
                     Some(e) => e,
                     None => match sv.span(v.location) {
@@ -2139,12 +2150,26 @@ fn collect_bnd_inv_junctions(sv_records: &[Variant], ploidy: usize) -> Vec<(usiz
                         _ => continue,
                     },
                 };
-                junctions.push((end, broken_fraction));
+                junctions.push((end, bf));
             }
-            // DEL/DUP/CNV/INS handled elsewhere (their coverage multipliers
-            // modulate interior depth); a uniform junction treatment for them is
-            // a documented follow-up — see docs/breakpoint_double_counting_fix_plan.md.
-            _ => continue,
+            // CNV loss (cn < ploidy) is DEL-like: one POS junction at the
+            // CN-derived loss fraction (matches the chimeric CNV branch's
+            // (ploidy − cn)/ploidy). CNV gain (cn ≥ ploidy) is DUP-like and, like
+            // <DUP>, only creates a NOVEL tandem adjacency that the regular
+            // linear pass never reproduces — so it is NOT double-counted and is
+            // intentionally left unsuppressed.
+            SvType::Cnv => {
+                if let Some(cn) = sv.copy_number {
+                    let cn = cn as usize;
+                    if cn < ploidy {
+                        let bf = (ploidy - cn) as f64 / ploidy_f;
+                        junctions.push((v.location, bf));
+                    }
+                }
+            }
+            // <DUP> tandem boundary is a novel adjacency (not in linear reads);
+            // <INS> is a literal insertion. Neither double-counts the regular pass.
+            SvType::Dup | SvType::Ins | SvType::Unknown => continue,
         }
     }
     junctions.sort_unstable_by_key(|&(p, _)| p);
@@ -2168,18 +2193,20 @@ fn max_broken_fraction_in_window(
         .fold(0.0_f64, f64::max)
 }
 
-/// Removes the broken-allele fraction of regular read-pairs that cross a BND/INV
-/// junction, so junction depth isn't double-counted against the chimeric pass.
+/// Removes the broken-allele fraction of regular read-pairs that cross a chimeric
+/// SV junction (BND, INV, DEL, and CNV-loss — see `collect_suppressible_junctions`),
+/// so junction depth isn't double-counted against the chimeric pass.
 ///
 /// A pair `(start, end)` crosses junction `j` when its R1 window
 /// `[start, start + read_len)` — or, paired-end, its R2 window
 /// `[end − read_len, end)` — contains `j`. Junctions in the unsequenced insert
-/// gap don't cross a sequenced read and are left alone. Homozygous junctions
-/// (broken_fraction = 1.0) drop the pair outright and consume no RNG;
-/// heterozygous junctions drop with probability `broken_fraction`. When the
-/// contig has no BND/INV records the input is returned untouched (no RNG drawn),
-/// so non-SV / DEL-DUP-only runs are byte-for-byte unaffected.
-fn suppress_bnd_inv_double_count(
+/// gap don't cross a sequenced read and are left alone. Junctions at
+/// broken_fraction = 1.0 (homozygous, or CN=0 loss) drop the pair outright and
+/// consume no RNG; fractional junctions drop with probability `broken_fraction`.
+/// When the contig has no suppressible junctions the input is returned untouched
+/// (no RNG drawn), so non-SV and DUP/CNV-gain-only runs are byte-for-byte
+/// unaffected.
+fn suppress_junction_double_count(
     fragments: Vec<(usize, usize)>,
     sv_records: &[Variant],
     ploidy: usize,
@@ -2187,7 +2214,7 @@ fn suppress_bnd_inv_double_count(
     paired_ended: bool,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
-    let junctions = collect_bnd_inv_junctions(sv_records, ploidy);
+    let junctions = collect_suppressible_junctions(sv_records, ploidy);
     if junctions.is_empty() {
         return Ok(fragments);
     }
@@ -2602,12 +2629,12 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_bnd_inv_junctions() {
+    fn test_collect_suppressible_junctions() {
         // BND (homozygous) at 100 → one junction (100, 1.0).
         // INV (heterozygous, ploidy 2) over [200, 300] → (200, 0.5) and (300, 0.5).
         let bnd = sv_variant_with_span(100, 0, SvType::Bnd, Genotype::Homozygous, None);
         let inv = sv_variant_with_span(200, 300, SvType::Inv, Genotype::Heterozygous, None);
-        let j = collect_bnd_inv_junctions(&[inv, bnd], 2);
+        let j = collect_suppressible_junctions(&[inv, bnd], 2);
         assert_eq!(j.len(), 3, "BND→1 junction, INV→2");
         // sorted by position
         assert_eq!(j[0].0, 100);
@@ -2619,12 +2646,31 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_ignores_del_dup_cnv() {
-        // DEL/DUP/CNV are coverage-modulated elsewhere — not junction-suppressed here.
+    fn test_collect_del_loss_suppressed_dup_gain_not() {
+        // DEL → one POS junction at the genotype mult.
+        // CNV-loss (cn < ploidy) → one POS junction at (ploidy−cn)/ploidy.
+        // DUP and CNV-gain (cn ≥ ploidy) create novel tandem adjacencies → NO junction.
         let del = sv_variant_with_span(100, 200, SvType::Del, Genotype::Homozygous, None);
         let dup = sv_variant_with_span(300, 400, SvType::Dup, Genotype::Homozygous, None);
-        let cnv = sv_variant_with_span(500, 600, SvType::Cnv, Genotype::Homozygous, Some(0));
-        assert!(collect_bnd_inv_junctions(&[del, dup, cnv], 2).is_empty());
+        let cnv_loss = sv_variant_with_span(500, 600, SvType::Cnv, Genotype::Homozygous, Some(1));
+        let cnv_gain = sv_variant_with_span(700, 800, SvType::Cnv, Genotype::Homozygous, Some(4));
+        let j = collect_suppressible_junctions(&[del, dup, cnv_loss, cnv_gain], 2);
+        // Only DEL (100) and CNV-loss (500) contribute.
+        assert_eq!(j.len(), 2, "expected DEL + CNV-loss junctions only, got {j:?}");
+        assert_eq!(j[0].0, 100);
+        assert!((j[0].1 - 1.0).abs() < 1e-9, "homozygous DEL → 1.0");
+        assert_eq!(j[1].0, 500);
+        // CNV cn=1, ploidy 2 → (2−1)/2 = 0.5.
+        assert!((j[1].1 - 0.5).abs() < 1e-9, "CNV-loss cn=1 → (ploidy−cn)/ploidy = 0.5");
+    }
+
+    #[test]
+    fn test_collect_cnv_full_loss_is_one() {
+        // CN=0 (full loss) → broken_fraction (ploidy−0)/ploidy = 1.0.
+        let cnv0 = sv_variant_with_span(500, 600, SvType::Cnv, Genotype::Homozygous, Some(0));
+        let j = collect_suppressible_junctions(&[cnv0], 2);
+        assert_eq!(j.len(), 1);
+        assert!((j[0].1 - 1.0).abs() < 1e-9);
     }
 
     #[test]
@@ -2638,7 +2684,7 @@ mod tests {
         ];
         let mut rng = NeatRng::new_from_seed(&vec!["bp".to_string()]).unwrap();
         let kept =
-            suppress_bnd_inv_double_count(frags, &[bnd], 2, 100, false, &mut rng).unwrap();
+            suppress_junction_double_count(frags, &[bnd], 2, 100, false, &mut rng).unwrap();
         assert_eq!(kept, vec![(300, 400), (600, 700)]);
     }
 
@@ -2648,7 +2694,7 @@ mod tests {
         let frags = vec![(0, 100), (200, 300)];
         let mut rng = NeatRng::new_from_seed(&vec!["bp".to_string()]).unwrap();
         let kept =
-            suppress_bnd_inv_double_count(frags.clone(), &[], 2, 100, false, &mut rng).unwrap();
+            suppress_junction_double_count(frags.clone(), &[], 2, 100, false, &mut rng).unwrap();
         assert_eq!(kept, frags);
     }
 
@@ -2659,13 +2705,13 @@ mod tests {
         let in_gap = sv_variant_with_span(550, 0, SvType::Bnd, Genotype::Homozygous, None);
         let mut rng = NeatRng::new_from_seed(&vec!["bp".to_string()]).unwrap();
         let kept =
-            suppress_bnd_inv_double_count(vec![(400, 700)], &[in_gap], 2, 100, true, &mut rng)
+            suppress_junction_double_count(vec![(400, 700)], &[in_gap], 2, 100, true, &mut rng)
                 .unwrap();
         assert_eq!(kept, vec![(400, 700)], "gap junction must not suppress");
         // A junction at 450 sits in R1 → crossed → dropped.
         let in_r1 = sv_variant_with_span(450, 0, SvType::Bnd, Genotype::Homozygous, None);
         let kept2 =
-            suppress_bnd_inv_double_count(vec![(400, 700)], &[in_r1], 2, 100, true, &mut rng)
+            suppress_junction_double_count(vec![(400, 700)], &[in_r1], 2, 100, true, &mut rng)
                 .unwrap();
         assert!(kept2.is_empty(), "R1-crossing pair must be suppressed");
     }
@@ -2678,7 +2724,7 @@ mod tests {
         let frags: Vec<(usize, usize)> = vec![(450usize, 550usize); 1000];
         let mut rng = NeatRng::new_from_seed(&vec!["bp het".to_string()]).unwrap();
         let kept =
-            suppress_bnd_inv_double_count(frags, &[het], 2, 100, false, &mut rng).unwrap();
+            suppress_junction_double_count(frags, &[het], 2, 100, false, &mut rng).unwrap();
         assert!(
             (300..700).contains(&kept.len()),
             "expected ~50% of 1000 het-crossing pairs kept, got {}",

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -539,6 +539,23 @@ fn process_contig(
         block_frags
     };
 
+    // Breakpoint double-counting fix: the chimeric pass emits junction-spanning
+    // read-pairs for every BND/INV junction, but the regular pass above also
+    // covers those positions from the unbroken reference (BND/INV are
+    // coverage-neutral — coverage_multiplier_for returns 1.0). Left alone, a
+    // homozygous junction lands at ~2x coverage (regular + junction reads), a
+    // het at ~1.5x. Drop the broken-allele fraction of regular pairs that cross
+    // a junction so total junction depth ≈ coverage. No-op when the contig has
+    // no BND/INV records (returns the input untouched, consuming no RNG).
+    let block_fragments = suppress_bnd_inv_double_count(
+        block_fragments,
+        &mutated_map.sv_records,
+        ctx.config.ploidy,
+        ctx.config.read_len,
+        ctx.config.paired_ended,
+        &mut rng,
+    )?;
+
     let mut contig_files_r1: Vec<PathBuf> = Vec::new();
     let mut contig_files_r2: Vec<PathBuf> = Vec::new();
 
@@ -2089,6 +2106,116 @@ fn exclude_positions(
     result
 }
 
+/// Collects `(position_0based, broken_fraction)` for every BND and INV junction
+/// in `sv_records`, sorted by position. A BND contributes one junction (its
+/// POS); an INV contributes two (its POS and its END) — mirroring the two
+/// junctions `process_chimeric_variants` emits for an inversion. `broken_fraction`
+/// is the chimeric pass's `mult`: 1.0 homozygous, 1/ploidy heterozygous — the
+/// fraction of alleles that carry the junction.
+///
+/// END for an INV is computed exactly as the chimeric INV branch does
+/// (`sv.end`, else POS + span − 1 via `SvData::span`) so the suppression window
+/// references the same base the chimeric reads were placed against.
+fn collect_bnd_inv_junctions(sv_records: &[Variant], ploidy: usize) -> Vec<(usize, f64)> {
+    let ploidy_f = (ploidy.max(1)) as f64;
+    let mut junctions: Vec<(usize, f64)> = Vec::new();
+    for v in sv_records {
+        let sv = match v.alternate.as_symbolic() {
+            Some(s) => s,
+            None => continue,
+        };
+        let broken_fraction = match v.genotype {
+            Genotype::Homozygous => 1.0,
+            Genotype::Heterozygous => 1.0 / ploidy_f,
+        };
+        match sv.sv_type {
+            SvType::Bnd => junctions.push((v.location, broken_fraction)),
+            SvType::Inv => {
+                junctions.push((v.location, broken_fraction));
+                let end = match sv.end {
+                    Some(e) => e,
+                    None => match sv.span(v.location) {
+                        Some(span) if span > 0 => v.location + span - 1,
+                        _ => continue,
+                    },
+                };
+                junctions.push((end, broken_fraction));
+            }
+            // DEL/DUP/CNV/INS handled elsewhere (their coverage multipliers
+            // modulate interior depth); a uniform junction treatment for them is
+            // a documented follow-up — see docs/breakpoint_double_counting_fix_plan.md.
+            _ => continue,
+        }
+    }
+    junctions.sort_unstable_by_key(|&(p, _)| p);
+    junctions
+}
+
+/// Largest `broken_fraction` among junctions whose position falls in the
+/// half-open read window `[lo, hi)`. `positions` must be `junctions` projected
+/// to positions (kept sorted) so the window can be located by binary search.
+fn max_broken_fraction_in_window(
+    junctions: &[(usize, f64)],
+    positions: &[usize],
+    lo: usize,
+    hi: usize,
+) -> f64 {
+    let i = positions.partition_point(|&p| p < lo);
+    let j = positions.partition_point(|&p| p < hi);
+    junctions[i..j]
+        .iter()
+        .map(|&(_, bf)| bf)
+        .fold(0.0_f64, f64::max)
+}
+
+/// Removes the broken-allele fraction of regular read-pairs that cross a BND/INV
+/// junction, so junction depth isn't double-counted against the chimeric pass.
+///
+/// A pair `(start, end)` crosses junction `j` when its R1 window
+/// `[start, start + read_len)` — or, paired-end, its R2 window
+/// `[end − read_len, end)` — contains `j`. Junctions in the unsequenced insert
+/// gap don't cross a sequenced read and are left alone. Homozygous junctions
+/// (broken_fraction = 1.0) drop the pair outright and consume no RNG;
+/// heterozygous junctions drop with probability `broken_fraction`. When the
+/// contig has no BND/INV records the input is returned untouched (no RNG drawn),
+/// so non-SV / DEL-DUP-only runs are byte-for-byte unaffected.
+fn suppress_bnd_inv_double_count(
+    fragments: Vec<(usize, usize)>,
+    sv_records: &[Variant],
+    ploidy: usize,
+    read_len: usize,
+    paired_ended: bool,
+    rng: &mut NeatRng,
+) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
+    let junctions = collect_bnd_inv_junctions(sv_records, ploidy);
+    if junctions.is_empty() {
+        return Ok(fragments);
+    }
+    let positions: Vec<usize> = junctions.iter().map(|&(p, _)| p).collect();
+    let mut kept: Vec<(usize, usize)> = Vec::with_capacity(fragments.len());
+    for (start, end) in fragments {
+        let mut bf =
+            max_broken_fraction_in_window(&junctions, &positions, start, start + read_len);
+        if paired_ended && end > read_len {
+            bf = bf.max(max_broken_fraction_in_window(
+                &junctions,
+                &positions,
+                end - read_len,
+                end,
+            ));
+        }
+        if bf <= 0.0 {
+            kept.push((start, end)); // crosses no junction
+        } else if bf >= 1.0 {
+            continue; // homozygous: every allele broken — drop, no RNG draw
+        } else if rng.random()? >= bf {
+            kept.push((start, end)); // heterozygous: survived the drop coin
+        }
+        // else: heterozygous and dropped
+    }
+    Ok(kept)
+}
+
 /// Builds a sorted, contiguous list of `(start, end, multiplier)` coverage
 /// segments spanning `[0, block_end)`. Default multiplier is `1.0`; each
 /// symbolic SV multiplies the multiplier in its span (overlapping SVs compose
@@ -2472,6 +2599,91 @@ mod tests {
             provenance: common::structs::variants::Provenance::Denovo,
             sample: vec![],
         }
+    }
+
+    #[test]
+    fn test_collect_bnd_inv_junctions() {
+        // BND (homozygous) at 100 → one junction (100, 1.0).
+        // INV (heterozygous, ploidy 2) over [200, 300] → (200, 0.5) and (300, 0.5).
+        let bnd = sv_variant_with_span(100, 0, SvType::Bnd, Genotype::Homozygous, None);
+        let inv = sv_variant_with_span(200, 300, SvType::Inv, Genotype::Heterozygous, None);
+        let j = collect_bnd_inv_junctions(&[inv, bnd], 2);
+        assert_eq!(j.len(), 3, "BND→1 junction, INV→2");
+        // sorted by position
+        assert_eq!(j[0].0, 100);
+        assert!((j[0].1 - 1.0).abs() < 1e-9, "homozygous broken_fraction = 1.0");
+        assert_eq!(j[1].0, 200);
+        assert!((j[1].1 - 0.5).abs() < 1e-9, "het broken_fraction = 1/ploidy");
+        assert_eq!(j[2].0, 300);
+        assert!((j[2].1 - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_collect_ignores_del_dup_cnv() {
+        // DEL/DUP/CNV are coverage-modulated elsewhere — not junction-suppressed here.
+        let del = sv_variant_with_span(100, 200, SvType::Del, Genotype::Homozygous, None);
+        let dup = sv_variant_with_span(300, 400, SvType::Dup, Genotype::Homozygous, None);
+        let cnv = sv_variant_with_span(500, 600, SvType::Cnv, Genotype::Homozygous, Some(0));
+        assert!(collect_bnd_inv_junctions(&[del, dup, cnv], 2).is_empty());
+    }
+
+    #[test]
+    fn test_suppress_homozygous_drops_crossing_keeps_flank() {
+        // Single-end, read_len 100, homozygous BND junction at 500.
+        let bnd = sv_variant_with_span(500, 0, SvType::Bnd, Genotype::Homozygous, None);
+        let frags = vec![
+            (450, 550), // R1 [450,550) contains 500 → crosses → drop
+            (300, 400), // flank-left → keep
+            (600, 700), // flank-right → keep
+        ];
+        let mut rng = NeatRng::new_from_seed(&vec!["bp".to_string()]).unwrap();
+        let kept =
+            suppress_bnd_inv_double_count(frags, &[bnd], 2, 100, false, &mut rng).unwrap();
+        assert_eq!(kept, vec![(300, 400), (600, 700)]);
+    }
+
+    #[test]
+    fn test_suppress_no_sv_returns_unchanged() {
+        // No BND/INV → input returned verbatim, no RNG consumed.
+        let frags = vec![(0, 100), (200, 300)];
+        let mut rng = NeatRng::new_from_seed(&vec!["bp".to_string()]).unwrap();
+        let kept =
+            suppress_bnd_inv_double_count(frags.clone(), &[], 2, 100, false, &mut rng).unwrap();
+        assert_eq!(kept, frags);
+    }
+
+    #[test]
+    fn test_suppress_paired_gap_not_crossed() {
+        // Paired, read_len 100. Fragment [400,700]: R1 [400,500), R2 [600,700).
+        // A junction at 550 sits in the unsequenced gap [500,600) → NOT crossed.
+        let in_gap = sv_variant_with_span(550, 0, SvType::Bnd, Genotype::Homozygous, None);
+        let mut rng = NeatRng::new_from_seed(&vec!["bp".to_string()]).unwrap();
+        let kept =
+            suppress_bnd_inv_double_count(vec![(400, 700)], &[in_gap], 2, 100, true, &mut rng)
+                .unwrap();
+        assert_eq!(kept, vec![(400, 700)], "gap junction must not suppress");
+        // A junction at 450 sits in R1 → crossed → dropped.
+        let in_r1 = sv_variant_with_span(450, 0, SvType::Bnd, Genotype::Homozygous, None);
+        let kept2 =
+            suppress_bnd_inv_double_count(vec![(400, 700)], &[in_r1], 2, 100, true, &mut rng)
+                .unwrap();
+        assert!(kept2.is_empty(), "R1-crossing pair must be suppressed");
+    }
+
+    #[test]
+    fn test_suppress_heterozygous_partial() {
+        // Het junction (broken_fraction 0.5): over many identical crossing pairs
+        // ~half survive. Deterministic seed; assert neither ~0 nor ~all.
+        let het = sv_variant_with_span(500, 0, SvType::Bnd, Genotype::Heterozygous, None);
+        let frags: Vec<(usize, usize)> = vec![(450usize, 550usize); 1000];
+        let mut rng = NeatRng::new_from_seed(&vec!["bp het".to_string()]).unwrap();
+        let kept =
+            suppress_bnd_inv_double_count(frags, &[het], 2, 100, false, &mut rng).unwrap();
+        assert!(
+            (300..700).contains(&kept.len()),
+            "expected ~50% of 1000 het-crossing pairs kept, got {}",
+            kept.len()
+        );
     }
 
     #[test]

--- a/rneat/tests/bnd_inv_double_count.rs
+++ b/rneat/tests/bnd_inv_double_count.rs
@@ -1,0 +1,117 @@
+//! End-to-end test for the BND/INV breakpoint double-counting fix.
+//!
+//! The chimeric pass emits junction-spanning reads for every BND/INV junction.
+//! Before the fix, the regular per-contig pass *also* covered those junctions
+//! from the unbroken reference (BND/INV are coverage-neutral), so a homozygous
+//! junction sat at ~2x coverage. The fix drops the broken-allele fraction of
+//! regular pairs that cross a junction; for a homozygous junction that's all of
+//! them, so afterward NO regular read (`RNEAT_generated_`) should span the
+//! junction, while interior / flank positions keep normal coverage and the
+//! chimeric junction reads (`RNEAT_chimeric_`) are still emitted.
+
+mod common;
+
+use common::{GenReadsConfig, fresh_workdir, h1n1_reference, rneat};
+use flate2::read::MultiGzDecoder;
+use std::io::{BufRead, BufReader};
+use std::io::Write as _;
+
+const READ_LEN: usize = 151;
+
+/// Run a homozygous INV at H1N1_HA:[start,end] (1-based) and return all
+/// FASTQ read-name lines (line 1 of every 4-line record).
+fn run_hom_inv(test_name: &str, sv_start: usize, sv_end: usize) -> Vec<String> {
+    let (_dir, work) = fresh_workdir();
+    let input_vcf = work.join("input_inv.vcf");
+    {
+        let mut f = std::fs::File::create(&input_vcf).unwrap();
+        writeln!(f, "##fileformat=VCFv4.2").unwrap();
+        writeln!(f, "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"GT\">").unwrap();
+        writeln!(f, "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"t\">").unwrap();
+        writeln!(f, "##INFO=<ID=END,Number=1,Type=Integer,Description=\"e\">").unwrap();
+        writeln!(f, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS").unwrap();
+        writeln!(
+            f,
+            "H1N1_HA\t{sv_start}\t.\tA\t<INV>\t60\tPASS\tSVTYPE=INV;END={sv_end}\tGT\t1/1"
+        )
+        .unwrap();
+    }
+
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.clone(), test_name);
+    config.coverage = 100;
+    config.read_len = READ_LEN;
+    config.produce_fastq = true;
+    config.input_vcf = Some(input_vcf);
+    let yaml = config.write_yaml();
+    rneat().args(["gen-reads", "-c"]).arg(yaml.path()).assert().success();
+
+    let out = work.join(format!("{test_name}_r1.fastq.gz"));
+    assert!(out.exists(), "FASTQ not produced at {:?}", out);
+    let r = BufReader::new(MultiGzDecoder::new(std::fs::File::open(&out).unwrap()));
+    r.lines()
+        .enumerate()
+        .filter(|(i, _)| i % 4 == 0)
+        .map(|(_, l)| l.unwrap())
+        .collect()
+}
+
+/// Count regular (`RNEAT_generated_`) reads on H1N1_HA whose span
+/// `[abs_start, abs_end)` contains the 0-based position `pos`. Read names are
+/// `RNEAT_generated_H1N1_HA_<abs_start>_<abs_end>_<hex>/1`.
+fn regular_reads_covering(qnames: &[String], pos: usize) -> usize {
+    qnames
+        .iter()
+        .filter(|l| l.contains("RNEAT_generated_H1N1_HA_"))
+        .filter_map(|l| {
+            // strip leading '@' and trailing '/1'
+            let name = l.trim_start_matches('@').split('/').next()?;
+            let parts: Vec<&str> = name.split('_').collect();
+            // ...generated_H1N1_HA_<start>_<end>_<hex>
+            let n = parts.len();
+            if n < 3 {
+                return None;
+            }
+            let start: usize = parts[n - 3].parse().ok()?;
+            let end: usize = parts[n - 2].parse().ok()?;
+            Some((start, end))
+        })
+        .filter(|&(start, end)| start <= pos && pos < end)
+        .count()
+}
+
+#[test]
+fn homozygous_inv_junctions_have_no_regular_crossing_reads() {
+    // INV at H1N1_HA 1-based [400, 799] → 0-based junctions at 399 and 798.
+    let qnames = run_hom_inv("hom_inv_dc", 400, 799);
+
+    // Sanity: the chimeric junction reads are still emitted (we only removed
+    // the redundant regular reference reads, not the junction signal).
+    let chimeric = qnames
+        .iter()
+        .filter(|l| l.contains("RNEAT_chimeric_INV_H1N1_HA_"))
+        .count();
+    assert!(chimeric > 0, "expected chimeric INV junction reads, got 0");
+
+    // Interior / flank control positions keep normal coverage.
+    let interior = regular_reads_covering(&qnames, 600); // inside the inversion
+    let flank = regular_reads_covering(&qnames, 150); // left of the inversion
+    assert!(interior > 0, "interior should retain regular coverage");
+    assert!(flank > 0, "flank should retain regular coverage");
+
+    // Homozygous → every regular pair crossing a junction is dropped (no RNG),
+    // so EXACTLY zero regular reads span either breakpoint. The suppression
+    // junctions match the chimeric pass: POS-1 (0-based start, 399) and the
+    // stored END value (799) — see collect_bnd_inv_junctions.
+    let cross_start = regular_reads_covering(&qnames, 399);
+    let cross_end = regular_reads_covering(&qnames, 799);
+    assert_eq!(
+        cross_start, 0,
+        "homozygous INV start junction (399) must have no regular crossing reads; \
+         interior control = {interior}"
+    );
+    assert_eq!(
+        cross_end, 0,
+        "homozygous INV end junction (799) must have no regular crossing reads; \
+         interior control = {interior}"
+    );
+}

--- a/rneat/tests/bnd_inv_double_count.rs
+++ b/rneat/tests/bnd_inv_double_count.rs
@@ -1,13 +1,15 @@
-//! End-to-end test for the BND/INV breakpoint double-counting fix.
+//! End-to-end test for the breakpoint double-counting fix (BND/INV + DEL/CNV-loss).
 //!
-//! The chimeric pass emits junction-spanning reads for every BND/INV junction.
-//! Before the fix, the regular per-contig pass *also* covered those junctions
-//! from the unbroken reference (BND/INV are coverage-neutral), so a homozygous
-//! junction sat at ~2x coverage. The fix drops the broken-allele fraction of
-//! regular pairs that cross a junction; for a homozygous junction that's all of
-//! them, so afterward NO regular read (`RNEAT_generated_`) should span the
-//! junction, while interior / flank positions keep normal coverage and the
-//! chimeric junction reads (`RNEAT_chimeric_`) are still emitted.
+//! The chimeric pass emits junction-spanning reads for every chimeric SV
+//! junction. Before the fix the regular per-contig pass *also* covered those
+//! breakpoints from the unbroken reference, so a homozygous junction sat at ~2x
+//! coverage. The fix drops the broken-allele fraction of regular pairs that
+//! cross a junction; for a homozygous junction that's all of them, so afterward
+//! NO regular read (`RNEAT_generated_`) should span the breakpoint, while
+//! interior / flank positions keep normal coverage and the chimeric junction
+//! reads (`RNEAT_chimeric_`) are still emitted. (DUP / CNV-gain make a novel
+//! tandem adjacency that linear reads never reproduce, so they are not
+//! suppressed and aren't tested here.)
 
 mod common;
 
@@ -20,9 +22,9 @@ const READ_LEN: usize = 151;
 
 /// Run a homozygous INV at H1N1_HA:[start,end] (1-based) and return all
 /// FASTQ read-name lines (line 1 of every 4-line record).
-fn run_hom_inv(test_name: &str, sv_start: usize, sv_end: usize) -> Vec<String> {
+fn run_hom_sv(test_name: &str, svtype: &str, sv_start: usize, sv_end: usize) -> Vec<String> {
     let (_dir, work) = fresh_workdir();
-    let input_vcf = work.join("input_inv.vcf");
+    let input_vcf = work.join("input_sv.vcf");
     {
         let mut f = std::fs::File::create(&input_vcf).unwrap();
         writeln!(f, "##fileformat=VCFv4.2").unwrap();
@@ -32,7 +34,7 @@ fn run_hom_inv(test_name: &str, sv_start: usize, sv_end: usize) -> Vec<String> {
         writeln!(f, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS").unwrap();
         writeln!(
             f,
-            "H1N1_HA\t{sv_start}\t.\tA\t<INV>\t60\tPASS\tSVTYPE=INV;END={sv_end}\tGT\t1/1"
+            "H1N1_HA\t{sv_start}\t.\tA\t<{svtype}>\t60\tPASS\tSVTYPE={svtype};END={sv_end}\tGT\t1/1"
         )
         .unwrap();
     }
@@ -82,7 +84,7 @@ fn regular_reads_covering(qnames: &[String], pos: usize) -> usize {
 #[test]
 fn homozygous_inv_junctions_have_no_regular_crossing_reads() {
     // INV at H1N1_HA 1-based [400, 799] → 0-based junctions at 399 and 798.
-    let qnames = run_hom_inv("hom_inv_dc", 400, 799);
+    let qnames = run_hom_sv("hom_inv_dc", "INV", 400, 799);
 
     // Sanity: the chimeric junction reads are still emitted (we only removed
     // the redundant regular reference reads, not the junction signal).
@@ -113,5 +115,37 @@ fn homozygous_inv_junctions_have_no_regular_crossing_reads() {
         cross_end, 0,
         "homozygous INV end junction (799) must have no regular crossing reads; \
          interior control = {interior}"
+    );
+}
+
+#[test]
+fn homozygous_del_breakpoint_has_no_regular_crossing_reads() {
+    // DEL at H1N1_HA 1-based [400, 799] → 0-based anchor/breakpoint at 399.
+    // The deleted interior is coverage-zeroed (homozygous), but flank reads
+    // crossing the anchor used to leak on top of the chimeric DEL junction reads.
+    let qnames = run_hom_sv("hom_del_dc", "DEL", 400, 799);
+
+    // Chimeric DEL junction reads are still emitted.
+    let chimeric = qnames
+        .iter()
+        .filter(|l| l.contains("RNEAT_chimeric_DEL_H1N1_HA_"))
+        .count();
+    assert!(chimeric > 0, "expected chimeric DEL junction reads, got 0");
+
+    // Left flank keeps normal coverage.
+    let flank = regular_reads_covering(&qnames, 150);
+    assert!(flank > 0, "left flank should retain regular coverage");
+
+    // No regular read crosses the deletion breakpoint (homozygous → all dropped),
+    // and the deleted interior produces no regular reads (coverage-zeroed).
+    let cross = regular_reads_covering(&qnames, 399);
+    let interior = regular_reads_covering(&qnames, 600);
+    assert_eq!(
+        cross, 0,
+        "homozygous DEL breakpoint (399) must have no regular crossing reads"
+    );
+    assert_eq!(
+        interior, 0,
+        "deleted interior (600) must have no regular reads (coverage-zeroed)"
     );
 }


### PR DESCRIPTION
## v1.14.1 release PR

v1.14.0 is already tagged/released, so this packages the post-v1.14.0 cancer-simulation fixes into a single **v1.14.1 patch**. It carries the breakpoint double-counting fix (new here) plus the version bump + CHANGELOG documenting the two fixes already merged to develop.

### Bundled in v1.14.1
- **#233 (already in develop)** — read-write O(log V) variant lookup; ~55× faster dense read-gen. Output byte-identical.
- **#235 (already in develop)** — `cancer_simulate.sh --tumor-mutation-rate` defaults to 1e-5 (realistic somatic burden); `model` opts back into the model's fitted rate. *Behavioral change.*
- **#236 (this branch)** — breakpoint double-counting fix: drop the broken-allele fraction of regular pairs crossing a chimeric SV junction so homozygous junction depth is ~1× instead of ~2×. Covers **BND/INV/DEL/CNV-loss**; **DUP/CNV-gain intentionally not** (novel tandem adjacency). *Behavioral change*; SV-caller recall unaffected.

### Tests
9 unit + 2 end-to-end; full suite (620) green.

### Release steps after merge
Merge develop → main and tag `v1.14.1` (matching the v1.14.0 flow, PR #231).

🤖 Generated with [Claude Code](https://claude.com/claude-code)