### PR TITLE
CHANGELOG: document sv_max_length_fraction (#229) under v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ design + decisions: `docs/cancer_simulator_native_plan.md`.
 `tools/cancer_simulate.sh` is retained as the reference implementation and for
 the Docker-based caller benchmarks, pending a same-seed parity test.
 
+### Configurable de novo SV length cap (#229)
+
+The de novo SV sampler rejected drawn lengths above a hardcoded `contig_len / 4`
+— a cap that keeps its overlap-rejection search tractable on chromosome-scale
+references. On small contigs (bacteria, viruses) that cap sits below the trained
+DEL median, starving DEL/DUP/INV draws and routing structural signal into BND;
+it also blocked any attempt to model large or aneuploid events.
+
+The cap is now a `gen-reads` config knob, **`sv_max_length_fraction`** (default
+`0.25`). The default reproduces the historical `contig_len / 4` behavior
+bit-for-bit, so existing configs are unaffected. Raise it toward `1.0` for small
+contigs or to admit large de novo events — the sampler scales its retry budget
+proportionally and its starvation warning now reports the active cap and
+fraction. Only de novo SVs are affected; `input_vcf` SVs are untouched. See the
+new structural-variants section in `template_config/gen_reads_template.yml` and
+the updated aneuploidy notes in `docs/cancer_simulator.md`.
+
 6/6/2026
 ========
 ## rneat v1.14.2


### PR DESCRIPTION
## Why

Found while reviewing the v1.15.0 release PR (#242, develop→main). #229 (`sv_max_length_fraction`, PR #241) merged into develop **after** the v1.15.0 release-prep commit, so its code is in this release but the CHANGELOG's v1.15.0 entry only documented the native `gen-cancer-reads` subcommand (#239). Shipping v1.15.0 as-is would tag the configurable SV length cap with no release note.

## What

Adds a "Configurable de novo SV length cap (#229)" subsection under the existing v1.15.0 entry. No code changes.

Merge this into develop before #242 goes to main so the v1.15.0 tag carries complete release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)