### PR TITLE
v1.15.1: cancer wrap-up — parity test, output-dir fix, how-to guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 6/6/2026
 ========
+## rneat v1.15.1
+
+### Cancer wrap-up: parity test, output-dir fix, how-to guide
+
+Tying off the native `gen-cancer-reads` work (#239):
+
+- **`gen-cancer-reads` now creates `output_dir` if it doesn't exist** (via
+  `create_dir_all`), matching `gen-reads`. Previously the cancer path built its
+  per-pass configs directly and skipped the YAML parser's dir-creation step, so a
+  non-existent `output_dir` failed mid-run with a bare `NotFound`.
+- **Parity test** (`rneat/tests/cancer_parity.rs`): runs the native subcommand and
+  `tools/cancer_simulate.sh` over the same reference/seed/purity and asserts they
+  produce identical merged-FASTQ record multisets, per-pass golden VCF bodies, and
+  origin-tagged truth-VCF `(chrom,pos,ref,alt,NEAT_ORIGIN)` sets. This is the proof
+  gating eventual retirement of the shell script.
+- **`fastq_merge` unit test** covering read-name tagging, including the case where
+  a quality line begins with `@` (must not be tagged).
+- **New copy-paste guide** `docs/cancer_howto.md` with worked examples
+  (WGS tumor/normal, per-tissue SV models, purity sweeps, low-purity samples),
+  output reference, benchmarking, and model training. The README cancer section is
+  trimmed to a short intro pointing at it.
+
+6/6/2026
+========
 ## rneat v1.15.0
 
 ### Native `rneat gen-cancer-reads` subcommand (#239)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "bincode",
  "bstr",
@@ -1074,7 +1074,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.15.0'
+version = '1.15.1'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/README.md
+++ b/README.md
@@ -3,11 +3,23 @@ Welcome to `rneat`, a Rust port of NEAT (https://github.com/ncsa/neat), a geneti
 
 The most recent version of `rneat` includes adding in the utilities to allow users to generate their own models for running `rneat`. It also now outputs a golden BAM file with ideal alignments, accepts a BED file for filtering the genome down to target regions for read creation, a more accurate coverage tool, and the ability to read in custom variants from a VCF file and insert them into the code. We swapped out the temp file writing method for a file streaming method that seems to work even faster and does not take up as much space on disk, avoiding expensive disk I/O of previous versions. We've done numerous benchmarks and tests on the data, but we look forward to user feedback on how well the output reproduces their data on a statistical level,
 
-## Cancer simulation (new in v1.11.0)
+## Cancer simulation
 
-`rneat` can now simulate tumor / normal sequencing data end-to-end. The native `rneat gen-cancer-reads -c <config.yml>` subcommand (see `template_config/gen_cancer_reads_template.yml`) runs two `gen-reads` passes — one normal-genotype, one tumor — over the same reference and merges them at a configurable purity into a single FASTQ that downstream somatic callers (Mutect2, Strelka, etc.) consume as a "tumor biopsy" sample, with no `bcftools`/`awk` dependency. (The original `tools/cancer_simulate.sh` shell orchestration remains as the reference implementation and for the Docker-based caller benchmarks.) Alongside the merged FASTQ it emits a single origin-tagged truth VCF where every record carries `INFO/NEAT_ORIGIN ∈ {germline, somatic, shared}` and `FORMAT/GT:AD:DP:AF`, so the truth set is directly consumable by `hap.py` / `som.py` / `vcfeval` for VAF-stratified TP/FP/FN benchmarking without any preprocessing. A pre-trained pan-cancer mutation model fit from COSMIC v104 is bundled at `tools/cosmic_v104_pancancer_model.json.gz`; users wanting their own can train from MC3 (`tools/fetch_tumor_corpus.sh`) or COSMIC (`tools/fetch_cosmic_corpus.sh`). A companion script `tools/cancer_benchmark.sh` runs the full BWA-MEM → Mutect2 → som.py pipeline in pinned Docker containers and scores a caller against the truth in one command. See `docs/cancer_simulator.md` for the design rationale, mutation-rate calibration caveats, and the staged SV-gap roadmap.
+`rneat` simulates tumor / normal sequencing data end-to-end. The
+`rneat gen-cancer-reads -c <config.yml>` subcommand runs two `gen-reads` passes —
+one normal-genotype, one tumor — over the same reference and merges them at a
+configurable purity into a single "tumor biopsy" FASTQ that downstream somatic
+callers (Mutect2, Strelka, Manta, …) consume directly, plus an origin-tagged truth
+VCF (`INFO/NEAT_ORIGIN ∈ {germline, somatic, shared}`) for scoring. It also
+generates the foundational structural-variant types cancer SVs depend on — `<BND>`
+translocations, `<INV>` inversions, and de novo `<INS>` — and ships bundled
+pan-cancer and per-tissue (BRCA / skin / lung) models plus Docker-based benchmark
+pipelines.
 
-**As of v1.12.0**, the simulator also generates the three foundational structural-variant types most clinically-recognizable cancer SVs depend on: `<BND>` translocations with chimeric junction reads (BCR-ABL, PML-RARA, EWSR1-FLI1, MYC-IGH, …), `<INV>` inversions with read-strand flipping (inv(16) AML, inv(3) MDS, …), and de novo `<INS>` mobile-element insertions with novel sequence (L1 retrotransposition, Alu / SVA). Enable via `--sv-rate-scale 1.0` (or higher to stress-test SV callers). A companion `tools/cancer_sv_benchmark.sh` runs BWA-MEM → Manta → truvari to score an SV caller against the same origin-tagged truth.
+**See [`docs/cancer_howto.md`](docs/cancer_howto.md) for a copy-paste guide** with
+worked examples, output reference, benchmarking, and model training. Design
+rationale and calibration caveats live in
+[`docs/cancer_simulator.md`](docs/cancer_simulator.md).
 
 # How to use `rneat`
 

--- a/docs/cancer_howto.md
+++ b/docs/cancer_howto.md
@@ -1,0 +1,246 @@
+# Cancer simulation how-to
+
+A practical, copy-paste guide to simulating tumor/normal sequencing data with
+`rneat gen-cancer-reads`. For the design rationale, mutation-rate calibration
+math, and the SV roadmap, see [`cancer_simulator.md`](cancer_simulator.md).
+
+## What it does
+
+A real tumor biopsy is a **mixture**: some fraction of cells are tumor (carrying
+germline + somatic variants), the rest are normal-tissue contamination (germline
+only). `rneat gen-cancer-reads` reproduces this in one command by running two
+`gen-reads` passes over the same reference and merging them:
+
+```
+                      coverage          variants
+  normal pass   →   (1 − purity)·C   →  germline only
+  tumor  pass   →     purity·C       →  germline (shared) + somatic (de novo)
+                                         │
+            merge: tag reads N_/T_, concatenate, and
+            combine the two truth VCFs with origin tags
+                                         ▼
+   <prefix>_merged_r1.fastq.gz   ← feed this to your aligner + somatic caller
+   <prefix>_merged_truth.vcf.gz  ← score the caller against this
+```
+
+The tumor pass consumes the normal pass's golden VCF as its germline, so both
+populations share the same patient germline — biologically correct, and what lets
+a somatic caller separate germline from somatic. No `bcftools`/`awk` needed; the
+merge is native Rust.
+
+## Quick start
+
+Smoke test on the bundled ~14 kb H1N1 reference — finishes in seconds and proves
+your build works end-to-end:
+
+```bash
+cat > cancer.yml <<'YAML'
+reference: rneat/test_data/references/H1N1.fa
+output_dir: ./cancer_out
+output_prefix: smoketest
+total_coverage: 30
+purity: 0.6
+read_len: 70
+paired_ended: true
+fragment_mean: 250
+fragment_st_dev: 30
+rng_seed: demo
+overwrite_output: true
+YAML
+
+rneat gen-cancer-reads -c cancer.yml
+ls cancer_out/
+# smoketest_normal.vcf.gz   smoketest_tumor.vcf.gz
+# smoketest_normal_r1.fastq.gz  ...  smoketest_merged_r1.fastq.gz  smoketest_merged_r2.fastq.gz
+# smoketest_merged_truth.vcf.gz
+```
+
+Copy `template_config/gen_cancer_reads_template.yml` as a fully-commented starting
+point for your own config.
+
+## Output files
+
+| File | What it is |
+|---|---|
+| `<prefix>_merged_r1.fastq.gz` (+ `_r2`) | **The deliverable.** `N_`/`T_`-tagged, concatenated reads — the simulated tumor biopsy. Feed this to your aligner. |
+| `<prefix>_merged_truth.vcf.gz` | Origin-tagged truth set. Every record carries `INFO/NEAT_ORIGIN ∈ {germline, somatic, shared}`. Score your caller against this. |
+| `<prefix>_normal.vcf.gz` | Germline-only truth (the patient's genome). |
+| `<prefix>_tumor.vcf.gz` | Germline + somatic truth. |
+| `<prefix>_normal_r1.fastq.gz`, `<prefix>_tumor_r1.fastq.gz` | Per-pass reads (set `keep_per_pass: false` to delete after merge). |
+
+The `N_`/`T_` read-name tags matter: without them a normal and a tumor read
+sampled at the same coordinate get identical QNAMEs, which Picard MarkDuplicates
+silently drops — halving effective coverage at those loci.
+
+## Worked examples
+
+All examples assume `rneat` is on your `PATH` and a reference at
+`~/code/data/chr22.fa` (any `.fa`/`.fa.gz` works).
+
+### 1. Realistic WGS tumor/normal with the bundled COSMIC model
+
+70% purity, 60× combined coverage, somatic SNVs/indels from the pan-cancer COSMIC
+model at a realistic per-tumor rate (the `1e-5` default):
+
+```bash
+cat > brca_wgs.yml <<'YAML'
+reference: ~/code/data/chr22.fa
+output_dir: ./brca_out
+output_prefix: tumor70
+total_coverage: 60
+purity: 0.7
+read_len: 151
+paired_ended: true
+fragment_mean: 350
+fragment_st_dev: 50
+tumor_model: tools/cosmic_v104_pancancer_model.json.gz
+tumor_mutation_rate: 1e-5
+rng_seed: brca-demo
+overwrite_output: true
+YAML
+
+rneat gen-cancer-reads -c brca_wgs.yml
+```
+
+### 2. Tissue-specific SVs (breast) with structural variants enabled
+
+Bundled per-tissue SV models stratify the SV catalog by primary site
+(`tools/cosmic_pancancer_sv_{BRCA,skin,lung}.json.gz` — BRCA is DUP-dominant, skin
+BND-enriched, lung DEL-dominant). Turn on de novo SV generation with
+`sv_rate_scale`:
+
+```bash
+cat > brca_sv.yml <<'YAML'
+reference: ~/code/data/chr22.fa
+output_dir: ./brca_sv_out
+output_prefix: brca_sv
+total_coverage: 60
+purity: 0.7
+read_len: 151
+paired_ended: true
+fragment_mean: 350
+fragment_st_dev: 50
+tumor_model: tools/cosmic_pancancer_sv_BRCA.json.gz
+sv_rate_scale: 1.0          # 1.0 = the model's nominal rate; higher stress-tests SV callers
+rng_seed: brca-sv-demo
+overwrite_output: true
+YAML
+
+rneat gen-cancer-reads -c brca_sv.yml
+```
+
+### 3. One germline, many tumor scenarios
+
+To compare callers across purities while holding the patient germline fixed,
+generate the germline once, then point each run at it via `germline_vcf:`. Any
+normal-pass golden VCF (or a real germline VCF) works:
+
+```bash
+# Reuse an existing germline truth as the shared germline:
+for p in 0.3 0.5 0.8; do
+  cat > scenario_$p.yml <<YAML
+reference: ~/code/data/chr22.fa
+output_dir: ./purity_sweep
+output_prefix: purity_$p
+total_coverage: 60
+purity: $p
+read_len: 151
+paired_ended: true
+fragment_mean: 350
+fragment_st_dev: 50
+germline_vcf: ./brca_out/tumor70_normal.vcf.gz
+tumor_model: tools/cosmic_v104_pancancer_model.json.gz
+rng_seed: sweep-$p
+overwrite_output: true
+YAML
+  rneat gen-cancer-reads -c scenario_$p.yml
+done
+```
+
+### 4. Low-purity sample
+
+Poor-yield biopsies can be <30% tumor. Just lower `purity` — but keep
+`total_coverage` high enough that the tumor pass (`purity·C`) doesn't round to a
+useless depth:
+
+```bash
+# purity 0.2 at 100x → 80x normal / 20x tumor
+rneat gen-cancer-reads -c <(sed 's/^purity:.*/purity: 0.2/; s/^total_coverage:.*/total_coverage: 100/' brca_wgs.yml)
+```
+
+> **Small / viral references:** the de novo SV sampler caps SV length at
+> `contig_len/4` by default. On bacterial or viral contigs that starves the larger
+> SV types. Raise it per the structural-variants section of
+> `template_config/gen_reads_template.yml` (`sv_max_length_fraction`) — though note
+> that knob lives on `gen-reads`; for cancer SV work on small contigs, supply the
+> events through a `germline_vcf:`/input VCF instead.
+
+## Benchmarking a somatic caller
+
+The repo ships Docker-based scoring pipelines so you can go from simulated reads
+to a scored caller in one command.
+
+**SNV/indel** — BWA-MEM → Mutect2 → `som.py`:
+
+```bash
+tools/cancer_benchmark.sh \
+    --reference   ~/code/data/chr22.fa \
+    --normal-fastq ./brca_out/tumor70_normal_r1.fastq.gz \
+    --tumor-fastq  ./brca_out/tumor70_merged_r1.fastq.gz \
+    --truth-vcf    ./brca_out/tumor70_merged_truth.vcf.gz \
+    --output-dir   ./benchmark_out
+```
+
+**Structural variants** — BWA-MEM → Manta → `truvari`:
+
+```bash
+tools/cancer_sv_benchmark.sh \
+    --reference   ~/code/data/chr22.fa \
+    --normal-fastq ./brca_sv_out/brca_sv_normal_r1.fastq.gz \
+    --tumor-fastq  ./brca_sv_out/brca_sv_merged_r1.fastq.gz \
+    --truth-vcf    ./brca_sv_out/brca_sv_merged_truth.vcf.gz \
+    --output-dir   ./sv_benchmark_out
+```
+
+Because the truth VCF carries `INFO/NEAT_ORIGIN`, you can filter to somatic-only
+records before scoring (the benchmark scripts expose `--truth-filter`), giving
+clean somatic TP/FP/FN without germline contaminating the numbers.
+
+## Training your own tumor model
+
+The bundled COSMIC pan-cancer model is a convenience. To fit a model from a corpus
+you control, the two shipped adapters chain into `rneat gen-mut-model`:
+
+```bash
+# Open-tier TCGA MC3 (no registration; SNPs only):
+tools/fetch_tumor_corpus.sh   # → writes a normalized VCF
+# Or COSMIC GenomeScreensMutant (academic registration; SNV + indel):
+tools/fetch_cosmic_corpus.sh
+
+# then train:
+rneat gen-mut-model -c your_gen_mut_model_config.yml
+```
+
+Point `tumor_model:` at the resulting `.json.gz`.
+
+## Calibration notes
+
+- **Somatic rate.** `tumor_mutation_rate` defaults to `1e-5` (typical solid
+  tumor; `~1e-4` for high-burden/MSI). Corpus-aggregated model rates (e.g. the
+  COSMIC model's ~5.5e-3) measure "fraction of bp mutated *anywhere across the
+  catalog*" and overstate per-tumor burden by 50–500×, so the de novo somatic rate
+  is set here, not taken from the model. Pass `tumor_mutation_rate: model` only if
+  you deliberately want the model's fitted rate.
+- **Purity drives VAF.** Somatic variant allele fractions scale with `purity`;
+  sweep it (example 3) to test a caller's low-VAF sensitivity.
+- **Reproducibility.** `rng_seed` seeds both passes (suffixed `-normal`/`-tumor`).
+  The same seed + config reproduces a run; the seed used is printed to the log.
+
+## Relationship to `tools/cancer_simulate.sh`
+
+The native subcommand is a drop-in replacement for the original shell
+orchestrator. They are verified to produce equivalent output by the parity test
+`rneat/tests/cancer_parity.rs` (identical merged-FASTQ record multisets, per-pass
+golden VCFs, and origin classifications). The shell script is retained for now as
+the reference implementation and for the Docker benchmark wiring; prefer the
+native subcommand for new work.

--- a/rneat/src/gen_cancer_reads/utils/config.rs
+++ b/rneat/src/gen_cancer_reads/utils/config.rs
@@ -139,6 +139,10 @@ impl CancerConfig {
         }
 
         cfg.validate()?;
+        // Create the output directory up front (unlike gen-reads, the cancer path
+        // builds its per-pass RunConfigurations directly and bypasses the YAML
+        // parser's dir-creation arm). create_dir_all is a no-op if it exists.
+        std::fs::create_dir_all(&cfg.output_dir).map_err(GenCancerReadsError::Io)?;
         Ok(cfg)
     }
 
@@ -309,6 +313,21 @@ mod tests {
             CancerConfig::from_scrape(s),
             Err(GenCancerReadsError::PerPassCoverageZero { .. })
         ));
+    }
+
+    #[test]
+    fn from_scrape_creates_missing_output_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("a/b/cancer_out");
+        assert!(!nested.exists());
+        let mut s = base_scrape();
+        s.insert(
+            "output_dir".into(),
+            Value::String(nested.to_string_lossy().into()),
+        );
+        let cfg = CancerConfig::from_scrape(s).unwrap();
+        assert!(nested.is_dir(), "output_dir should be created (create_dir_all)");
+        assert_eq!(cfg.output_dir, nested);
     }
 
     #[test]

--- a/rneat/src/gen_cancer_reads/utils/fastq_merge.rs
+++ b/rneat/src/gen_cancer_reads/utils/fastq_merge.rs
@@ -41,3 +41,70 @@ pub fn tag_and_concat(inputs: &[(&Path, &str)], out: &Path) -> Result<(), GenCan
     w.finish()?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    fn write_gz(path: &Path, body: &str) {
+        let f = File::create(path).unwrap();
+        let mut w = GzEncoder::new(f, Compression::default());
+        w.write_all(body.as_bytes()).unwrap();
+        w.finish().unwrap();
+    }
+
+    fn read_gz(path: &Path) -> String {
+        let mut s = String::new();
+        MultiGzDecoder::new(File::open(path).unwrap())
+            .read_to_string(&mut s)
+            .unwrap();
+        s
+    }
+
+    #[test]
+    fn tag_and_concat_prefixes_headers_and_preserves_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let n = dir.path().join("n.fastq.gz");
+        let t = dir.path().join("t.fastq.gz");
+        let out = dir.path().join("merged.fastq.gz");
+
+        // Note the second record's QUALITY line is "@@@@" (Phred '@' = Q31).
+        // A naive "prefix every line starting with '@'" would corrupt it — the
+        // function must key on record position (line 1 of every 4), not the
+        // leading character.
+        write_gz(
+            &n,
+            "@RNEAT_generated_chr1_100_170/1\nACGT\n+\nIIII\n\
+             @RNEAT_generated_chr1_200_270/1\nTTTT\n+\n@@@@\n",
+        );
+        write_gz(
+            &t,
+            "@RNEAT_generated_chr1_100_170/1\nGGGG\n+\nIIII\n",
+        );
+
+        tag_and_concat(&[(&n as &Path, "N"), (&t as &Path, "T")], &out).unwrap();
+        let merged = read_gz(&out);
+        let lines: Vec<&str> = merged.lines().collect();
+
+        // 2 normal records + 1 tumor record = 12 lines.
+        assert_eq!(lines.len(), 12, "merged record count");
+
+        // Headers (line 1 of each record) are tag-prefixed, normal block first.
+        assert_eq!(lines[0], "@N_RNEAT_generated_chr1_100_170/1");
+        assert_eq!(lines[4], "@N_RNEAT_generated_chr1_200_270/1");
+        assert_eq!(lines[8], "@T_RNEAT_generated_chr1_100_170/1");
+
+        // Sequence / separator / quality lines pass through untouched — crucially
+        // the "@@@@" quality line is NOT prefixed.
+        assert_eq!(lines[1], "ACGT");
+        assert_eq!(lines[6], "+");
+        assert_eq!(lines[7], "@@@@", "quality line starting with '@' must not be tagged");
+        assert_eq!(lines[9], "GGGG");
+
+        // The same coordinate (chr1_100_170) appears under both N_ and T_ — which
+        // is the whole point: tagging prevents the QNAME collision.
+        assert!(merged.contains("@N_RNEAT_generated_chr1_100_170/1"));
+        assert!(merged.contains("@T_RNEAT_generated_chr1_100_170/1"));
+    }
+}

--- a/rneat/tests/cancer_parity.rs
+++ b/rneat/tests/cancer_parity.rs
@@ -1,0 +1,216 @@
+//! Parity test: native `rneat gen-cancer-reads` vs the legacy
+//! `tools/cancer_simulate.sh`.
+//!
+//! The native subcommand (#239) is a port of the shell orchestrator. Before the
+//! script can be retired we need proof the two produce equivalent output. This
+//! test runs both over the same H1N1 reference, with identical purity / coverage
+//! / seed, and asserts:
+//!
+//!   1. The merged FASTQs carry the same record **multiset** (both tag `N_`/`T_`
+//!      and concatenate normal→tumor; gen-reads output *order* is not stable —
+//!      see `determinism.rs` — so we compare sorted records, not lines).
+//!   2. The per-pass golden VCF bodies match (same gen-reads driven identically).
+//!   3. The origin-tagged truth VCF carries the same
+//!      `(chrom, pos, ref, alt, NEAT_ORIGIN)` set — i.e. the native Rust merge
+//!      classifies germline / somatic / shared exactly as the bcftools+awk merge.
+//!
+//! The bash path needs `bash` (+ `awk`/`gzip`, universally present on the dev/CI
+//! Linux image). The truth-VCF merge additionally needs `bcftools`/`bgzip`; if
+//! those are absent the script skips that step, and so do we (with a note).
+//! When `bash` itself is missing the whole test skips rather than fails, so a
+//! minimal environment doesn't break the suite.
+
+mod common;
+
+use common::{fresh_workdir, h1n1_reference, read_gzip_fastq_lines, rneat};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// `true` if `name` resolves on PATH.
+fn tool_available(name: &str) -> bool {
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!("command -v {name}"))
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Group FASTQ lines into 4-line records and sort — turns output order (which is
+/// not deterministic across runs) into a stable multiset comparison.
+fn sorted_records(lines: Vec<String>) -> Vec<[String; 4]> {
+    assert!(
+        lines.len().is_multiple_of(4),
+        "FASTQ line count must be a multiple of 4"
+    );
+    let mut records: Vec<[String; 4]> = lines
+        .chunks(4)
+        .map(|c| [c[0].clone(), c[1].clone(), c[2].clone(), c[3].clone()])
+        .collect();
+    records.sort();
+    records
+}
+
+/// Sorted multiset of a gzipped VCF's body (non-`#`) lines.
+fn vcf_body_sorted(path: &Path) -> Vec<String> {
+    let mut body: Vec<String> = read_gzip_fastq_lines(path)
+        .into_iter()
+        .filter(|l| !l.starts_with('#'))
+        .collect();
+    body.sort();
+    body
+}
+
+/// Set of `(chrom, pos, ref, alt, origin)` for every body record. `origin` is the
+/// `NEAT_ORIGIN=` value parsed out of the INFO column (col 8).
+fn vcf_origin_set(path: &Path) -> BTreeSet<(String, String, String, String, String)> {
+    read_gzip_fastq_lines(path)
+        .into_iter()
+        .filter(|l| !l.starts_with('#'))
+        .filter_map(|l| {
+            let c: Vec<&str> = l.split('\t').collect();
+            if c.len() < 8 {
+                return None;
+            }
+            let origin = c[7]
+                .split(';')
+                .find_map(|f| f.strip_prefix("NEAT_ORIGIN="))
+                .unwrap_or("?")
+                .to_string();
+            Some((c[0].into(), c[1].into(), c[3].into(), c[4].into(), origin))
+        })
+        .collect()
+}
+
+#[test]
+fn native_gen_cancer_reads_matches_cancer_simulate_sh() {
+    if !tool_available("bash") {
+        eprintln!("skipping cancer parity test: `bash` not available");
+        return;
+    }
+
+    let script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("tools")
+        .join("cancer_simulate.sh");
+    assert!(script.is_file(), "cancer_simulate.sh not found at {script:?}");
+
+    // The same rneat binary drives both paths (bash shells out to it via --rneat-bin).
+    let bin = assert_cmd::cargo::cargo_bin("rneat");
+
+    let (_d, work) = fresh_workdir();
+    let native_dir = work.join("native");
+    let bash_dir = work.join("bash");
+    std::fs::create_dir_all(&native_dir).unwrap();
+    std::fs::create_dir_all(&bash_dir).unwrap();
+
+    // Shared parameters. purity 0.6 → normal 12x / tumor 18x (asymmetric, so a
+    // swapped-pass bug in either path would surface). Defaults match across the
+    // two: tumor_mutation_rate 1e-5, sv_rate_scale 0.0, model-fitted normal rate.
+    const TOTAL_COV: &str = "30";
+    const PURITY: &str = "0.6";
+    const READ_LEN: &str = "70";
+    const FRAG_MEAN: &str = "250";
+    const FRAG_SD: &str = "30";
+    const SEED: &str = "parity-seed";
+
+    // ── native ──────────────────────────────────────────────────────────────
+    let yaml = native_dir.join("cancer.yml");
+    std::fs::write(
+        &yaml,
+        format!(
+            "reference: {ref}\n\
+             output_dir: {out}\n\
+             output_prefix: sample\n\
+             total_coverage: {TOTAL_COV}\n\
+             purity: {PURITY}\n\
+             read_len: {READ_LEN}\n\
+             paired_ended: true\n\
+             fragment_mean: {FRAG_MEAN}\n\
+             fragment_st_dev: {FRAG_SD}\n\
+             rng_seed: {SEED}\n\
+             overwrite_output: true\n",
+            ref = h1n1_reference().display(),
+            out = native_dir.display(),
+        ),
+    )
+    .unwrap();
+    rneat()
+        .args(["gen-cancer-reads", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    // ── bash ────────────────────────────────────────────────────────────────
+    let status = Command::new("bash")
+        .arg(&script)
+        .arg("--reference")
+        .arg(h1n1_reference())
+        .arg("--output-prefix")
+        .arg(bash_dir.join("sample"))
+        .args([
+            "--total-coverage",
+            TOTAL_COV,
+            "--purity",
+            PURITY,
+            "--read-len",
+            READ_LEN,
+            "--paired-ended",
+            "--fragment-mean",
+            FRAG_MEAN,
+            "--fragment-st-dev",
+            FRAG_SD,
+            "--rng-seed",
+            SEED,
+            "--rneat-bin",
+        ])
+        .arg(&bin)
+        .status()
+        .expect("failed to spawn cancer_simulate.sh");
+    assert!(status.success(), "cancer_simulate.sh exited non-zero");
+
+    // ── 1. merged FASTQs: same record multiset ───────────────────────────────
+    for r in ["r1", "r2"] {
+        let nat = sorted_records(read_gzip_fastq_lines(
+            &native_dir.join(format!("sample_merged_{r}.fastq.gz")),
+        ));
+        let bash = sorted_records(read_gzip_fastq_lines(
+            &bash_dir.join(format!("sample_merged_{r}.fastq.gz")),
+        ));
+        assert!(!nat.is_empty(), "native produced no {r} reads");
+        assert_eq!(
+            nat, bash,
+            "merged {r} FASTQ record multiset differs between native and bash"
+        );
+    }
+
+    // ── 2. per-pass golden VCF bodies match ──────────────────────────────────
+    for pass in ["normal", "tumor"] {
+        let nat = vcf_body_sorted(&native_dir.join(format!("sample_{pass}.vcf.gz")));
+        let bash = vcf_body_sorted(&bash_dir.join(format!("sample_{pass}.vcf.gz")));
+        assert!(!nat.is_empty(), "native {pass} golden VCF has no records");
+        assert_eq!(nat, bash, "{pass} golden VCF body differs native vs bash");
+    }
+
+    // ── 3. origin-tagged truth VCF: same classification set ──────────────────
+    // The bash truth merge is gated on bcftools+bgzip; skip the comparison if the
+    // script couldn't produce it (it warns and leaves the per-pass VCFs only).
+    let bash_truth = bash_dir.join("sample_merged_truth.vcf.gz");
+    let native_truth = native_dir.join("sample_merged_truth.vcf.gz");
+    if bash_truth.is_file() {
+        let nat = vcf_origin_set(&native_truth);
+        let bash = vcf_origin_set(&bash_truth);
+        assert!(!nat.is_empty(), "native truth VCF has no records");
+        assert_eq!(
+            nat, bash,
+            "origin-tagged truth VCF (chrom,pos,ref,alt,NEAT_ORIGIN) set differs \
+             between the native merge and bcftools+awk"
+        );
+    } else {
+        eprintln!(
+            "note: cancer_simulate.sh produced no truth VCF (bcftools/bgzip absent) \
+             — skipping truth-VCF parity check"
+        );
+    }
+}

--- a/rneat/tests/cancer_reads_e2e.rs
+++ b/rneat/tests/cancer_reads_e2e.rs
@@ -9,7 +9,6 @@ mod common;
 use common::{fresh_workdir, h1n1_reference, rneat};
 use flate2::read::MultiGzDecoder;
 use std::io::{BufRead, BufReader};
-use std::io::Write as _;
 
 fn read_gz_lines(path: &std::path::Path) -> Vec<String> {
     let r = BufReader::new(MultiGzDecoder::new(std::fs::File::open(path).unwrap()));


### PR DESCRIPTION
Wraps up the native `gen-cancer-reads` track (#239).

## Changes

**Bug fix — `output_dir` auto-creation.** `gen-cancer-reads` builds its per-pass `RunConfiguration`s directly and bypassed the YAML parser's dir-creation step, so pointing `output_dir` at a path that didn't exist yet failed mid-run with a bare `NotFound`. Now creates it via `create_dir_all` (matching `gen-reads`).

**Parity test** (`rneat/tests/cancer_parity.rs`). Runs the native subcommand *and* `tools/cancer_simulate.sh` over the same H1N1 reference, seed, purity, and coverage, then asserts they produce:
- identical merged-FASTQ **record multisets** (both tag `N_`/`T_` and concat normal→tumor; gen-reads output *order* isn't stable, so we compare sorted records — see `determinism.rs`),
- identical per-pass golden VCF bodies,
- identical origin-tagged truth-VCF `(chrom, pos, ref, alt, NEAT_ORIGIN)` sets — i.e. the native Rust merge classifies germline/somatic/shared exactly as the bcftools+awk merge.

This is the proof gating eventual retirement of the shell script. The test skips gracefully if `bash` is absent, and skips just the truth-VCF comparison if `bcftools`/`bgzip` are absent.

**`fastq_merge` unit test** covering read-name tagging, including the case where a quality line begins with `@` (must not be tagged) — the bug the position-based keying guards against.

**New how-to guide** `docs/cancer_howto.md`: copy-paste worked examples (WGS tumor/normal with the COSMIC model, per-tissue SV models, one-germline/many-tumor purity sweeps, low-purity samples), output-file reference, SNV + SV benchmarking, and model training. README cancer section trimmed from two dense paragraphs to a short intro pointing at the guide.

## Version

Bumps `1.15.0 → 1.15.1`. develop was sitting on the already-released `1.15.0`; this is a patch (bug fix + tests + docs, no new user-facing feature).

## Tests

`cargo test --workspace` green (incl. the new parity + fastq_merge + output-dir tests). No new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)