### PR TITLE
Deterministic FASTQ output, opt-in sub-contig chunking, and honest NEAT comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,9 @@ seqkit shuffle -2 sample_R1.fastq.gz sample_R2.fastq.gz \
 
 Parallel Processing
 ===================
-`rneat gen-reads` processes contigs in parallel by default using rayon's work-stealing thread pool. Each contig is an independent unit of work — variant generation, fragment sampling, and FASTQ writing all happen concurrently across contigs — so multi-core machines see roughly linear speedup up to the number of contigs in the reference.
+`rneat gen-reads` processes the reference in parallel by default using rayon's work-stealing thread pool. The unit of work is a **sub-contig chunk**: each contig is split into fixed-size chunks (variant generation, fragment sampling, and FASTQ/BAM writing all happen concurrently across chunks), so multi-core machines see speedup even on references with one or a few large chromosomes — not just references with many contigs.
+
+The chunk size is derived from the **genome size**, not the thread count, so output is byte-identical regardless of `num_threads`. See **Chunk size** below to tune or disable it.
 
 **Thread count:**
 
@@ -336,6 +338,24 @@ num_threads: 1
 ```
 
 Omit `num_threads` (or set it to `.`) to restore the default all-cores behaviour.
+
+**Chunk size:**
+
+Contigs are split into chunks so a single large chromosome can be worked by many
+cores at once. The default size scales with the genome (≈ genome / 256, clamped
+to 1–25 Mbp) and is independent of the thread count, so the same seed yields
+byte-identical FASTQ regardless of how many threads you run.
+
+```yaml
+# auto (recommended) — omit or set to .
+chunk_size: .
+
+# fixed chunk size in base pairs (e.g. smaller chunks for finer load-balancing)
+chunk_size: 5000000
+
+# disable chunking entirely — one chunk per whole contig (legacy per-contig behaviour)
+chunk_size: 0
+```
 
 **BAM output is fully parallel:**
 

--- a/README.md
+++ b/README.md
@@ -374,6 +374,24 @@ chunk_size: 0
 chunk_size: 5000000
 ```
 
+*When might it help?* Only when read generation is **CPU-bound** rather than
+memory-bandwidth bound — the opposite of what we measured on a typical desktop.
+Consider trying it when **both** are true:
+
+1. Your reference is dominated by **one or a few large contigs**, so the default
+   per-contig parallelism leaves most cores idle (e.g. a single-chromosome
+   assembly, or a genome where one chromosome dwarfs the rest).
+2. You have **memory bandwidth to spare relative to cores** — a multi-socket or
+   many-memory-channel HPC node rather than a commodity desktop — and/or you run
+   compute-heavier settings (GC-bias-weighted coverage, long-read mode, very high
+   coverage) where per-read CPU work dominates memory traffic.
+
+It is **not** worth enabling on a typical workstation, or on references with many
+contigs (those already parallelize per contig). Always benchmark on your own
+hardware: start with `chunk_size ≈ longest_contig_bp / (4 × cores)` (a few chunks
+per core), compare wall time against the default, and keep it only if it is
+actually faster.
+
 **BAM output is fully parallel:**
 
 `rneat` uses a per-contig temp-file strategy: each contig worker writes its alignment records to a private temporary BAM body file, then a single concatenation pass assembles them in reference order into the final coordinate-sorted BAM.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ rationale and calibration caveats live in
 ## How `rneat` compares to NEAT
 
 `rneat` is a Rust port of NEAT that tracks the NEAT feature set while adding a
-native cancer workflow and a focus on speed and low memory use. The table below
-compares the original Python 2 NEAT (the 2.x "genReads" line), the current
-Python 3 NEAT 4.x, and `rneat`.
+native cancer workflow, a low and flat memory footprint, and reproducible
+output. The table below compares the original Python 2 NEAT (the 2.x "genReads"
+line), the current Python 3 NEAT 4.x, and `rneat`.
 
 |                                            | **NEAT 2.x** (genReads)        | **NEAT 4.x**                              | **`rneat`**                                              |
 | ------------------------------------------ | ------------------------------ | ----------------------------------------- | -------------------------------------------------------- |
@@ -57,6 +57,21 @@ Python 3 NEAT 4.x, and `rneat`.
 and Allen et al. (2026), *Journal of Open Source Software* 11(121):9056,
 [doi:10.21105/joss.09056](https://doi.org/10.21105/joss.09056). `rneat`:
 [doi:10.5281/zenodo.20100558](https://doi.org/10.5281/zenodo.20100558).
+
+**Where `rneat` fits.** NEAT 4.x is a capable, actively developed simulator, and
+the two tools share most of their core feature set. `rneat` is the right choice
+when you want:
+
+- **Cancer simulation** — a native tumor/normal workflow (`gen-cancer-reads`)
+  with configurable purity and an origin-tagged truth VCF, plus CNVs and
+  per-tissue cancer models. This is `rneat`-only.
+- **Low, flat memory** — streaming FASTQ writes keep peak RSS small and roughly
+  constant across genome size and thread count, which matters on shared HPC
+  allocations.
+- **Reproducibility** — the same seed yields byte-identical FASTQ regardless of
+  the thread count.
+- **Easy deployment** — a single self-contained binary with no Python
+  environment to manage (and a Bioconda package in review).
 
 # How to use `rneat`
 
@@ -319,9 +334,11 @@ seqkit shuffle -2 sample_R1.fastq.gz sample_R2.fastq.gz \
 
 Parallel Processing
 ===================
-`rneat gen-reads` processes the reference in parallel by default using rayon's work-stealing thread pool. The unit of work is a **sub-contig chunk**: each contig is split into fixed-size chunks (variant generation, fragment sampling, and FASTQ/BAM writing all happen concurrently across chunks), so multi-core machines see speedup even on references with one or a few large chromosomes — not just references with many contigs.
+`rneat gen-reads` processes contigs in parallel by default using rayon's work-stealing thread pool. Each contig is an independent unit of work — variant generation, fragment sampling, and FASTQ/BAM writing all happen concurrently across contigs — so references with many contigs scale well across cores.
 
-The chunk size is derived from the **genome size**, not the thread count, so output is byte-identical regardless of `num_threads`. See **Chunk size** below to tune or disable it.
+Output is **byte-identical regardless of `num_threads`** (the same seed always produces the same reads in the same order), so you can change the thread count freely without affecting results.
+
+A note on scaling: read generation is largely **memory-bandwidth bound**, so on references dominated by one or a few large chromosomes the wall-time gain from extra cores is limited — the bottleneck is memory throughput, not CPU. An experimental sub-contig **chunk size** knob (below) can split a single chromosome across cores, but it is **disabled by default** because in our benchmarks it did not improve wall time and occasionally regressed it.
 
 **Thread count:**
 
@@ -339,22 +356,22 @@ num_threads: 1
 
 Omit `num_threads` (or set it to `.`) to restore the default all-cores behaviour.
 
-**Chunk size:**
+**Chunk size (experimental, opt-in):**
 
-Contigs are split into chunks so a single large chromosome can be worked by many
-cores at once. The default size scales with the genome (≈ genome / 256, clamped
-to 1–25 Mbp) and is independent of the thread count, so the same seed yields
-byte-identical FASTQ regardless of how many threads you run.
+By default each contig is one unit of work. Setting `chunk_size` splits contigs
+into sub-contig chunks so a single large chromosome can be worked by several
+cores at once. It is **off by default**: read generation is memory-bandwidth
+bound, so chunking did not improve wall time in our benchmarks (and added a
+little overhead). It is kept for CPU-bound or very-many-core scenarios where it
+may help. The size is in base pairs and independent of the thread count, so
+output stays byte-identical regardless of `num_threads`.
 
 ```yaml
-# auto (recommended) — omit or set to .
-chunk_size: .
-
-# fixed chunk size in base pairs (e.g. smaller chunks for finer load-balancing)
-chunk_size: 5000000
-
-# disable chunking entirely — one chunk per whole contig (legacy per-contig behaviour)
+# default — disabled (one chunk per whole contig); omit or set to . or 0
 chunk_size: 0
+
+# opt in: fixed chunk size in base pairs
+chunk_size: 5000000
 ```
 
 **BAM output is fully parallel:**

--- a/docs/subcontig_chunking_plan.md
+++ b/docs/subcontig_chunking_plan.md
@@ -1,0 +1,57 @@
+# Sub-contig chunking for multicore read generation (prototype)
+
+## Motivation
+`gen-reads` parallelizes per **contig** (one rayon task = one contig). On
+few-contig genomes the longest chromosome pins a single core. Benchmark
+(NEAT 4.5.3 vs rneat, 8 cores, c_elegans 97 MB, paired-end 10×):
+
+| | 1 thread | 8 threads | speedup |
+|---|---|---|---|
+| NEAT 4 | 1162 s | 331 s | 3.5× |
+| rneat (per-contig) | 379 s | 380 s | **~1.0× (none)** |
+
+rneat is 3× faster single-threaded but gets **no multicore scaling** on
+c_elegans (7 chromosomes, dominated by chr V) and ecoli (1 contig). NEAT wins
+the default multicore case by splitting each contig into chunks.
+
+## Approach (prototype)
+Make a fixed-size **sub-contig chunk** the unit of parallel work instead of a
+whole contig.
+
+- **Work-list:** flatten every contig into `(contig_idx, chunk_idx, start, end)`
+  items with a target size of `CHUNK_TARGET = 10 Mbp`, evenly split per contig.
+  `par_bridge` over the flat list so both big-contig splitting *and*
+  many-small-contig parallelism work.
+- **Chunk size independent of `num_threads`** → output stays byte-identical
+  across thread counts (NEAT ties chunking to thread count, so its output
+  changes with `--threads`; rneat keeps its determinism guarantee — a
+  differentiator).
+- **Boundary fragments:** each chunk owns fragments whose **anchor (left
+  coordinate)** falls in `[start, end)`, and may read past `end` into the full
+  contig sequence (no read-content stitching). Disjoint anchor ranges ⇒ read
+  names stay globally unique even though `frag_idx` resets per chunk.
+- **Shared sequence:** an `Arc<SequenceBlock>` per contig, built lazily and
+  shared by all its chunks (one sequence copy per contig — memory ≈ today, not
+  multiplied by chunk count). `SequenceBlock` keeps `ref_start = 0` and the full
+  sequence so `get_subseq` (absolute indexing) is unchanged.
+- **Deterministic seeding:** per-chunk RNG = `base_rng.derive_child(contig_idx)
+  .derive_child(chunk_idx)`.
+- **Merge:** FASTQ temp files concatenated (order-independent, names already
+  carry `ref_start`/`ref_end`); BAM bodies ordered by `(contig_idx, chunk_start)`
+  = coordinate order; `AdCounter` (`HashMap<usize,(u32,u32)>`) summed per contig;
+  `MutatedMap` read from the shared `Arc` for VCF (no per-chunk clone).
+
+## Known prototype limitations (follow-ups)
+- **Memory at hg38 scale:** the shared-sequence cache holds each built contig's
+  sequence until end of run. Fine for ≤ few-hundred-MB genomes (benchmark);
+  for hg38 use `Weak`-based eviction or Tier-2 sliced buffers (fix `get_subseq`
+  to honor `ref_start != 0` so a chunk holds only `[start, end)` + overhang).
+- **Junction double-count at chunk boundaries:** `suppress_junction_double_count`
+  runs per chunk; an SV junction sitting exactly on a chunk boundary may have its
+  crossing read-pairs split across two chunks, slightly perturbing suppression.
+  Interior junctions (the vast majority) are unaffected.
+
+## Target
+c_elegans 8-core: **380 s → ~150–200 s**, memory no worse than the current
+~520 MB. Validate determinism (same seed ⇒ identical FASTQ regardless of
+`num_threads`) and full test suite green.

--- a/docs/subcontig_chunking_plan.md
+++ b/docs/subcontig_chunking_plan.md
@@ -104,9 +104,25 @@ single thread (~365 s). rneat starts near the hardware bandwidth ceiling, so it
 has little to gain.
 
 **Decision:** keep the chunking machinery (correct, tested, deterministic) but
-default it **off** behind `chunk_size`, for the niche where it might help
-(CPU-bound configs, or genomes dominated by one chromosome on a machine with
-spare bandwidth). Do not advertise multicore speed.
+default it **off** behind `chunk_size`. Do not advertise multicore speed.
+
+**When chunking might still help (the niche it's kept for).** Both conditions
+should hold, otherwise leave it off:
+
+1. **Few/one large contig** — the reference is dominated by one or a few big
+   chromosomes, so per-contig parallelism leaves cores idle (single-chromosome
+   assemblies; one chromosome dwarfing the rest). With many contigs, per-contig
+   parallelism already fills the cores and chunking only adds overhead.
+2. **Spare memory bandwidth relative to cores** — a multi-socket / many-channel
+   HPC node (far higher aggregate bandwidth than the commodity desktop these
+   benchmarks ran on), and/or compute-heavier settings (GC-bias-weighted
+   coverage, long-read mode, very high coverage) where per-read CPU work
+   dominates memory traffic, shifting the workload from bandwidth-bound toward
+   CPU-bound.
+
+Recommended starting point: `chunk_size ≈ longest_contig_bp / (4 × cores)`
+(~4 chunks/core on the dominant contig). Always A/B against the default on the
+target hardware and keep it only if wall time actually improves.
 
 **The only real lever for more throughput** would be cutting per-read memory
 traffic in the generation hot loop (reuse fragment buffers instead of allocating

--- a/docs/subcontig_chunking_plan.md
+++ b/docs/subcontig_chunking_plan.md
@@ -1,5 +1,15 @@
 # Sub-contig chunking for multicore read generation (prototype)
 
+> **Status (implemented):** done on `feature/subcontig-chunking`. Two deviations
+> from the original plan below: (1) chunk size is **adaptive to genome size**
+> (≈ genome/256, clamped to [1 Mbp, 25 Mbp]) rather than a fixed 10 Mbp, with a
+> `chunk_size` config override (`0` disables); still independent of thread count.
+> (2) A real bug was caught by determinism testing: the R2 temp file was named
+> with whole-contig coords, so chunks of a multi-chunk contig shared one R2 file
+> and duplicated/raced R2 reads — fixed to use chunk coords. Output is now
+> verified byte-identical across thread counts (unit + e2e regression tests).
+
+
 ## Motivation
 `gen-reads` parallelizes per **contig** (one rayon task = one contig). On
 few-contig genomes the longest chromosome pins a single core. Benchmark

--- a/docs/subcontig_chunking_plan.md
+++ b/docs/subcontig_chunking_plan.md
@@ -1,13 +1,15 @@
 # Sub-contig chunking for multicore read generation (prototype)
 
-> **Status (implemented):** done on `feature/subcontig-chunking`. Two deviations
-> from the original plan below: (1) chunk size is **adaptive to genome size**
-> (≈ genome/256, clamped to [1 Mbp, 25 Mbp]) rather than a fixed 10 Mbp, with a
-> `chunk_size` config override (`0` disables); still independent of thread count.
-> (2) A real bug was caught by determinism testing: the R2 temp file was named
-> with whole-contig coords, so chunks of a multi-chunk contig shared one R2 file
-> and duplicated/raced R2 reads — fixed to use chunk coords. Output is now
-> verified byte-identical across thread counts (unit + e2e regression tests).
+> **Status: implemented, then DISABLED BY DEFAULT.** The machinery works and is
+> correct, but benchmarking showed it does not help (read generation is
+> memory-bandwidth bound — see **Conclusion** at the end). It ships behind an
+> opt-in `chunk_size: <n>` config key, off by default. Notable findings along
+> the way: (1) a real determinism bug was caught by testing — the R2 temp file
+> was named with whole-contig coords, so chunks of a multi-chunk contig shared
+> one R2 file and duplicated/raced R2 reads (fixed to use chunk coords); output
+> is now verified byte-identical across thread counts. (2) Chunk-0 uses the
+> plain per-contig RNG derivation, so with chunking off the read stream is
+> identical to the pre-chunking (develop) behaviour.
 
 
 ## Motivation
@@ -61,7 +63,54 @@ whole contig.
   crossing read-pairs split across two chunks, slightly perturbing suppression.
   Interior junctions (the vast majority) are unaffected.
 
-## Target
+## Target (hypothesis going in)
 c_elegans 8-core: **380 s → ~150–200 s**, memory no worse than the current
 ~520 MB. Validate determinism (same seed ⇒ identical FASTQ regardless of
 `num_threads`) and full test suite green.
+
+## Conclusion (outcome — chunking does NOT help; disabled by default)
+
+The hypothesis was wrong. Chunking delivered no multicore speedup, and the
+investigation revealed why: **read generation is memory-bandwidth bound, not
+CPU/parallelism-granularity bound.**
+
+Benchmark (NEAT 4.5.3 vs rneat, 8-core desktop, c_elegans 97 Mbp, paired-end
+10×, 3-rep medians; rneat timings cross-checked with a same-session develop-vs-
+branch A/B):
+
+| config | c_elegans 1-thread | c_elegans 8-thread |
+| --- | --- | --- |
+| rneat, chunking off (= develop) | ~365 s | ~400 s |
+| rneat, chunking on (auto ~1 Mbp) | — | ~440 s |
+| NEAT 4 | 1162 s | 331 s |
+
+Evidence the bottleneck is bandwidth, not parallelism granularity:
+
+1. **rneat 8-thread is *slower* than 1-thread regardless of chunking** (~400 s vs
+   ~365 s), and develop shows the same — adding cores cannot help when there is
+   no spare memory throughput. This is inherent, not a chunking artifact.
+2. **Finer chunking monotonically worsened wall time** (25 Mbp → 396 s, 5 Mbp →
+   431 s, 1 Mbp → 441 s): more, smaller work-items add overhead with no headroom
+   to exploit.
+3. **Swapping the global allocator to mimalloc changed nothing** (8-thread ~392 s
+   vs ~400 s), ruling out allocator contention. The remaining cost is raw memory
+   traffic — per-fragment `get_subseq().to_owned()` + `reverse_complement()`
+   copies plus gzip, all bandwidth-heavy.
+
+Why NEAT 4 "wins" multicore (1162 → 331 s, 3.5×) while rneat is flat: NEAT is
+CPU-bound (Python interpreter overhead) and has abundant headroom to parallelize
+into — but it only parallelizes far enough to *catch up* to rneat's already-fast
+single thread (~365 s). rneat starts near the hardware bandwidth ceiling, so it
+has little to gain.
+
+**Decision:** keep the chunking machinery (correct, tested, deterministic) but
+default it **off** behind `chunk_size`, for the niche where it might help
+(CPU-bound configs, or genomes dominated by one chromosome on a machine with
+spare bandwidth). Do not advertise multicore speed.
+
+**The only real lever for more throughput** would be cutting per-read memory
+traffic in the generation hot loop (reuse fragment buffers instead of allocating
++ copying per read; avoid the `reverse_complement` allocation). That reduces
+bandwidth demand and would help *single-threaded* performance too — but it is a
+substantial hot-loop rewrite with uncertain payoff, and single-thread is already
+~3× faster than NEAT 4. Not pursued here.

--- a/rneat/src/gen_reads/utils/config.rs
+++ b/rneat/src/gen_reads/utils/config.rs
@@ -76,6 +76,11 @@ pub struct RunConfiguration {
     pub(crate) gc_bias_normalize_coverage: bool,
     // maximum threads for parallel contig processing (None = rayon default = all cores)
     pub num_threads: Option<usize>,
+    // Target size (bp) of a parallel sub-contig chunk. None = auto (scaled to the
+    // genome size); Some(0) = disable chunking (one chunk per whole contig);
+    // Some(n) = fixed n bp. Independent of num_threads, so output is identical
+    // across thread counts.
+    pub chunk_size: Option<usize>,
     // when true, fragments shorter than read_len are kept and produce truncated reads
     // (long-read platforms); when false, such fragments are discarded (short-read default)
     pub long_reads: bool,
@@ -126,6 +131,7 @@ impl Default for RunConfiguration {
             gc_bias_model: None,
             gc_bias_normalize_coverage: true,
             num_threads: None,
+            chunk_size: None,
             long_reads: false,
             sv_rate_scale: 0.0,
             sv_max_length_fraction: 0.25,
@@ -454,6 +460,14 @@ impl RunConfiguration {
                             )
                         })? as usize);
                     }
+                    "chunk_size" => {
+                        config.chunk_size = Some(value.as_u64().ok_or_else(|| {
+                            GenerateReadsError::ConfigReadError(
+                                "chunk_size".to_string(),
+                                "integer".to_string(),
+                            )
+                        })? as usize);
+                    }
                     "long_reads" => {
                         config.long_reads = value.as_bool().ok_or_else(|| {
                             GenerateReadsError::ConfigReadError(
@@ -672,6 +686,7 @@ mod tests {
             gc_bias_model: None,
             gc_bias_normalize_coverage: true,
             num_threads: None,
+            chunk_size: None,
             long_reads: false,
             sv_rate_scale: 0.0,
             sv_max_length_fraction: 0.25,

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -236,13 +236,24 @@ pub fn run_neat(
     // *within* a large chromosome, not just across contigs. Chunk size is
     // independent of num_threads, so output is identical regardless of thread
     // count. Each contig's sequence is shared across its chunks via the cache.
+    let total_genome_len: usize = ctx.reference.values().map(|s| s.len()).sum();
+    let chunk_size = resolve_chunk_size(config, total_genome_len);
+    info!(
+        "\t>Sub-contig chunk size: {} bp{}",
+        chunk_size,
+        match config.chunk_size {
+            None => " (auto)",
+            Some(0) => " (chunking disabled — one chunk per contig)",
+            Some(_) => " (configured)",
+        }
+    );
     let seq_cache = SeqBlockCache::new(&ctx.reference, &contig_order_in_file);
     let chunk_work: Vec<ChunkWork> = contig_order_in_file
         .iter()
         .enumerate()
         .flat_map(|(contig_idx, name)| {
             let contig_len = ctx.reference.get(name).map(|s| s.len()).unwrap_or(0);
-            split_contig_into_chunks(contig_len)
+            split_contig_into_chunks(contig_len, chunk_size)
                 .into_iter()
                 .enumerate()
                 .map(move |(chunk_idx, (chunk_start, chunk_end))| ChunkWork {
@@ -431,9 +442,30 @@ pub fn run_neat(
     Ok(files_written.clone())
 }
 
-/// Target size (bp) of a parallel sub-contig chunk. Fixed and independent of
-/// `num_threads`, so generated output is byte-identical across thread counts.
-const CHUNK_TARGET: usize = 10_000_000;
+/// Auto chunk-sizing bounds. The chunk size is derived from the *genome* size
+/// (not the thread count) so output stays byte-identical across thread counts,
+/// while still scaling: small genomes get small chunks (so a single contig
+/// still parallelizes), large genomes get larger chunks (so the chunk — and
+/// temp-file — count stays bounded instead of exploding into millions).
+const CHUNK_AUTO_TARGET_CHUNKS: usize = 256;
+const CHUNK_AUTO_MIN: usize = 1_000_000; // 1 Mbp floor — below this, boundary overhead dominates
+const CHUNK_AUTO_MAX: usize = 25_000_000; // 25 Mbp cap — keeps chunk count bounded on huge genomes
+
+/// Pick a sub-contig chunk size (bp) from the total genome length, aiming for
+/// ~`CHUNK_AUTO_TARGET_CHUNKS` chunks genome-wide, clamped to [MIN, MAX].
+fn auto_chunk_size(total_genome_len: usize) -> usize {
+    (total_genome_len / CHUNK_AUTO_TARGET_CHUNKS).clamp(CHUNK_AUTO_MIN, CHUNK_AUTO_MAX)
+}
+
+/// Resolve the effective chunk size from config: `None` → auto (genome-scaled);
+/// `Some(0)` → disable chunking (one chunk per whole contig); `Some(n)` → fixed.
+fn resolve_chunk_size(config: &RunConfiguration, total_genome_len: usize) -> usize {
+    match config.chunk_size {
+        None => auto_chunk_size(total_genome_len),
+        Some(0) => usize::MAX, // one chunk spans the whole contig
+        Some(n) => n,
+    }
+}
 
 /// One unit of parallel read-generation work: a sub-range of a contig.
 struct ChunkWork {
@@ -460,13 +492,14 @@ struct ChunkData {
     ad_counter: AdCounter,
 }
 
-/// Split a contig of `len` bp into evenly-sized chunks of ~`CHUNK_TARGET` bp.
+/// Split a contig of `len` bp into evenly-sized chunks of ~`chunk_size` bp.
 /// An empty contig yields a single `[0, 0)` chunk so it still produces a result.
-fn split_contig_into_chunks(len: usize) -> Vec<(usize, usize)> {
+fn split_contig_into_chunks(len: usize, chunk_size: usize) -> Vec<(usize, usize)> {
     if len == 0 {
         return vec![(0, 0)];
     }
-    let n = len.div_ceil(CHUNK_TARGET).max(1);
+    let chunk_size = chunk_size.max(1);
+    let n = len.div_ceil(chunk_size).max(1);
     let base = len / n;
     let rem = len % n;
     let mut out = Vec::with_capacity(n);
@@ -738,7 +771,7 @@ fn process_chunk(
             let mut file_to_write_2 = PathBuf::from(ctx.working_dir);
             file_to_write_2.push(format!(
                 "temp_{}_{:010}_{:010}_r2_tmp.fastq.gz",
-                contig_name, current_block.ref_start, current_block.ref_end,
+                contig_name, chunk_start, chunk_end,
             ));
             let file2 = append_to_file(&file_to_write_2)?;
             let writer2 = BufWriter::new(&file2);

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -2681,6 +2681,57 @@ mod tests {
     use common::structs::variants::AlternateType;
 
     #[test]
+    fn test_split_contig_into_chunks_covers_contig_without_gaps_or_overlap() {
+        // 1 Mbp chunks over a 2.5 Mbp contig → 3 even chunks, contiguous, covering [0, len).
+        let chunks = split_contig_into_chunks(2_500_000, 1_000_000);
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks.first().unwrap().0, 0);
+        assert_eq!(chunks.last().unwrap().1, 2_500_000);
+        for w in chunks.windows(2) {
+            assert_eq!(w[0].1, w[1].0, "chunks must be contiguous (no gap/overlap)");
+        }
+        // Even split: sizes differ by at most 1.
+        let sizes: Vec<usize> = chunks.iter().map(|(s, e)| e - s).collect();
+        assert!(sizes.iter().max().unwrap() - sizes.iter().min().unwrap() <= 1);
+    }
+
+    #[test]
+    fn test_split_contig_into_chunks_edge_cases() {
+        // Contig smaller than the chunk size → a single whole-contig chunk.
+        assert_eq!(split_contig_into_chunks(500, 1_000_000), vec![(0, 500)]);
+        // Empty contig → one [0,0) chunk so it still yields a result.
+        assert_eq!(split_contig_into_chunks(0, 1_000_000), vec![(0, 0)]);
+        // chunk_size 0 is treated as 1 (guarded) and must not divide-by-zero.
+        assert!(!split_contig_into_chunks(10, 0).is_empty());
+    }
+
+    #[test]
+    fn test_auto_chunk_size_scales_and_clamps() {
+        // Small genome clamps to the floor so a single contig still parallelizes.
+        assert_eq!(auto_chunk_size(4_600_000), CHUNK_AUTO_MIN);
+        // Huge genome clamps to the cap so chunk count stays bounded.
+        assert_eq!(auto_chunk_size(10_000_000_000), CHUNK_AUTO_MAX);
+        // Mid-range scales linearly (≈ total / target chunks).
+        let mid = auto_chunk_size(1_000_000_000);
+        assert!(mid > CHUNK_AUTO_MIN && mid < CHUNK_AUTO_MAX);
+        assert_eq!(mid, 1_000_000_000 / CHUNK_AUTO_TARGET_CHUNKS);
+    }
+
+    #[test]
+    fn test_resolve_chunk_size_config_modes() {
+        let mut cfg = RunConfiguration::default();
+        // None → auto.
+        cfg.chunk_size = None;
+        assert_eq!(resolve_chunk_size(&cfg, 100_000_000), auto_chunk_size(100_000_000));
+        // Some(0) → disabled (one chunk spans the whole contig).
+        cfg.chunk_size = Some(0);
+        assert_eq!(resolve_chunk_size(&cfg, 100_000_000), usize::MAX);
+        // Some(n) → fixed.
+        cfg.chunk_size = Some(5_000_000);
+        assert_eq!(resolve_chunk_size(&cfg, 100_000_000), 5_000_000);
+    }
+
+    #[test]
     fn test_intersect_with_bed() {
         let r1 = SequenceMap::from(RegionType::NonNRegion, 100, 200);
         let r2 = SequenceMap::from(RegionType::NonNRegion, 300, 400);

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -63,24 +63,6 @@ struct ContigContext<'a> {
     max_del_lens: HashMap<String, usize>,
 }
 
-struct ContigResult {
-    idx: usize,
-    name: String,
-    len: usize,
-    data: Option<ProcessedContigData>,
-}
-
-struct ProcessedContigData {
-    mutated_map: MutatedMap,
-    r1_files: Vec<PathBuf>,
-    r2_files: Vec<PathBuf>,
-    bam_body_file: Option<PathBuf>,
-    // Per-contig allelic-depth accumulator populated by write_block_fastq.
-    // Keyed by per-contig position (matches Variant::location). Passed to
-    // write_vcf so the golden VCF can carry FORMAT/AD, FORMAT/DP, FORMAT/AF.
-    ad_counter: AdCounter,
-}
-
 pub fn run_neat(
     config: &RunConfiguration,
     rng: &mut NeatRng,
@@ -244,19 +226,56 @@ pub fn run_neat(
     let mut all_fastq_files: HashMap<String, (Vec<PathBuf>, Vec<PathBuf>)> = HashMap::new();
     let mut contig_order: Vec<String> = Vec::new();
     let mut fasta_lengths: HashMap<String, usize> = HashMap::new();
-    let mut bam_body_files: HashMap<String, PathBuf> = HashMap::new();
+    // Multiple BAM body files per contig (one per chunk); value is (chunk_start, path).
+    let mut bam_body_files: HashMap<String, Vec<(usize, PathBuf)>> = HashMap::new();
     let mut ad_counters: HashMap<String, AdCounter> = HashMap::new();
 
     info!("Generating simulated dataset");
 
-    // All contigs processed in parallel; BAM workers each write a temp body file.
-    let parallel_iter = contig_order_in_file.into_iter().enumerate().par_bridge().map(
-        |(idx, name)| -> Result<ContigResult, GenerateReadsError> {
-            let child_rng = ctx.base_rng.derive_child(idx as u64);
-            process_contig(idx, name, &ctx, child_rng)
-        },
-    );
-    let collected: Result<Vec<ContigResult>, _> = match config.num_threads {
+    // Flatten contigs into fixed-size sub-contig chunks so work parallelizes
+    // *within* a large chromosome, not just across contigs. Chunk size is
+    // independent of num_threads, so output is identical regardless of thread
+    // count. Each contig's sequence is shared across its chunks via the cache.
+    let seq_cache = SeqBlockCache::new(&ctx.reference, &contig_order_in_file);
+    let chunk_work: Vec<ChunkWork> = contig_order_in_file
+        .iter()
+        .enumerate()
+        .flat_map(|(contig_idx, name)| {
+            let contig_len = ctx.reference.get(name).map(|s| s.len()).unwrap_or(0);
+            split_contig_into_chunks(contig_len)
+                .into_iter()
+                .enumerate()
+                .map(move |(chunk_idx, (chunk_start, chunk_end))| ChunkWork {
+                    contig_idx,
+                    chunk_idx,
+                    name: name.clone(),
+                    chunk_start,
+                    chunk_end,
+                })
+        })
+        .collect();
+
+    let parallel_iter = chunk_work
+        .into_par_iter()
+        .map(|w| -> Result<ChunkResult, GenerateReadsError> {
+            // Deterministic per-chunk seed: contig index then chunk index.
+            let child_rng = ctx
+                .base_rng
+                .derive_child(w.contig_idx as u64)
+                .derive_child(w.chunk_idx as u64);
+            let block = seq_cache.get(&w.name);
+            process_chunk(
+                w.contig_idx,
+                w.chunk_idx,
+                w.name,
+                w.chunk_start,
+                w.chunk_end,
+                block,
+                &ctx,
+                child_rng,
+            )
+        });
+    let collected: Result<Vec<ChunkResult>, _> = match config.num_threads {
         Some(n) => rayon::ThreadPoolBuilder::new()
             .num_threads(n)
             .build()
@@ -266,9 +285,9 @@ pub fn run_neat(
             .install(|| parallel_iter.collect()),
         None => parallel_iter.collect(),
     };
-    // par_bridge does not preserve order — restore contig order by idx.
     let mut results = collected?;
-    results.sort_unstable_by_key(|r| r.idx);
+    // Order by (contig, chunk_start) so BAM bodies concatenate coordinate-sorted.
+    results.sort_unstable_by_key(|r| (r.contig_idx, r.chunk_start));
 
     // Phase 3: Generate chimeric reads for BND junctions
     if config.produce_fastq || config.produce_bam {
@@ -278,15 +297,22 @@ pub fn run_neat(
     }
 
     for cr in results {
-        collect_contig_result(
+        collect_chunk_result(
             cr,
             &mut contig_order,
             &mut fasta_lengths,
-            &mut mutated_maps,
             &mut all_fastq_files,
             &mut bam_body_files,
             &mut ad_counters,
         );
+    }
+
+    // The golden VCF reads per-contig MutatedMaps from the shared Arc (chunks no
+    // longer carry their own clone).
+    for name in &contig_order {
+        if let Some(m) = ctx.mutated_maps.get(name) {
+            mutated_maps.insert(name.clone(), vec![m.clone()]);
+        }
     }
 
     info!("Read generation complete, producing output files");
@@ -294,8 +320,22 @@ pub fn run_neat(
     if config.produce_fastq {
         info!("Producing final fastq(s) file(s)");
 
+        // Concatenate in contig order (each contig's chunk files are already in
+        // chunk_start order), then the chimeric reads, so the FASTQ is
+        // byte-identical regardless of thread count — not just the same read set.
         let mut all_r1: Vec<PathBuf> = Vec::new();
         let mut all_r2: Vec<PathBuf> = Vec::new();
+        for name in &contig_order {
+            if let Some((r1_files, r2_files)) = all_fastq_files.remove(name) {
+                all_r1.extend(r1_files);
+                all_r2.extend(r2_files);
+            }
+        }
+        if let Some((r1_files, r2_files)) = all_fastq_files.remove("chimeric") {
+            all_r1.extend(r1_files);
+            all_r2.extend(r2_files);
+        }
+        // Safety net for any unexpected leftover keys.
         for (r1_files, r2_files) in all_fastq_files.into_values() {
             all_r1.extend(r1_files);
             all_r2.extend(r2_files);
@@ -352,10 +392,15 @@ pub fn run_neat(
             "Assembling BAM from {} temp body file(s)",
             bam_body_files.len()
         );
-        let ordered_bodies: Vec<PathBuf> = contig_order
-            .iter()
-            .filter_map(|name| bam_body_files.remove(name))
-            .collect();
+        // Concatenate bodies in (contig order, chunk_start) order so the
+        // assembled BAM stays coordinate-sorted across sub-contig chunks.
+        let mut ordered_bodies: Vec<PathBuf> = Vec::new();
+        for name in &contig_order {
+            if let Some(mut bodies) = bam_body_files.remove(name) {
+                bodies.sort_by_key(|(start, _)| *start);
+                ordered_bodies.extend(bodies.into_iter().map(|(_, path)| path));
+            }
+        }
         concat_temp_bams(bam_ctx, &ordered_bodies, bam_path)?;
         info!("Successfully wrote BAM file: {:?}", bam_path);
         files_written.push(bam_path.clone());
@@ -386,67 +431,166 @@ pub fn run_neat(
     Ok(files_written.clone())
 }
 
-fn process_contig(
-    idx: usize,
+/// Target size (bp) of a parallel sub-contig chunk. Fixed and independent of
+/// `num_threads`, so generated output is byte-identical across thread counts.
+const CHUNK_TARGET: usize = 10_000_000;
+
+/// One unit of parallel read-generation work: a sub-range of a contig.
+struct ChunkWork {
+    contig_idx: usize,
+    chunk_idx: usize,
+    name: String,
+    chunk_start: usize,
+    chunk_end: usize,
+}
+
+/// Result of generating reads for one chunk.
+struct ChunkResult {
+    contig_idx: usize,
+    chunk_start: usize,
+    name: String,
+    len: usize, // full contig length (not chunk length)
+    data: Option<ChunkData>,
+}
+
+struct ChunkData {
+    r1_files: Vec<PathBuf>,
+    r2_files: Vec<PathBuf>,
+    bam_body_file: Option<PathBuf>,
+    ad_counter: AdCounter,
+}
+
+/// Split a contig of `len` bp into evenly-sized chunks of ~`CHUNK_TARGET` bp.
+/// An empty contig yields a single `[0, 0)` chunk so it still produces a result.
+fn split_contig_into_chunks(len: usize) -> Vec<(usize, usize)> {
+    if len == 0 {
+        return vec![(0, 0)];
+    }
+    let n = len.div_ceil(CHUNK_TARGET).max(1);
+    let base = len / n;
+    let rem = len % n;
+    let mut out = Vec::with_capacity(n);
+    let mut start = 0;
+    for i in 0..n {
+        let this = base + usize::from(i < rem);
+        out.push((start, start + this));
+        start += this;
+    }
+    out
+}
+
+/// Lazily-built cache of full-contig `SequenceBlock`s shared across a contig's
+/// chunks. Each contig's sequence is cloned at most once (the `OnceLock`
+/// serializes the first build); all chunks of that contig share the `Arc`, so
+/// memory is one sequence copy per *built* contig — not per chunk.
+struct SeqBlockCache<'a> {
+    reference: &'a HashMap<String, Vec<Nucleotide>>,
+    cells: HashMap<String, std::sync::OnceLock<Arc<SequenceBlock>>>,
+}
+
+impl<'a> SeqBlockCache<'a> {
+    fn new(reference: &'a HashMap<String, Vec<Nucleotide>>, names: &[String]) -> Self {
+        let cells = names
+            .iter()
+            .map(|n| (n.clone(), std::sync::OnceLock::new()))
+            .collect();
+        Self { reference, cells }
+    }
+
+    /// Contigs are pre-validated (names come from the reference), so the build
+    /// closure is infallible.
+    fn get(&self, name: &str) -> Arc<SequenceBlock> {
+        let cell = self
+            .cells
+            .get(name)
+            .expect("chunk contig must be present in the sequence-block cache");
+        Arc::clone(cell.get_or_init(|| {
+            let sequence = self
+                .reference
+                .get(name)
+                .expect("chunk contig must exist in reference")
+                .clone();
+            let sequence_map = map_buffer(&sequence);
+            let ref_end = sequence.len();
+            Arc::new(SequenceBlock {
+                contig: name.to_string(),
+                ref_start: 0,
+                ref_end,
+                sequence,
+                sequence_map,
+            })
+        }))
+    }
+}
+
+fn process_chunk(
+    contig_idx: usize,
+    chunk_idx: usize,
     contig_name: String,
+    chunk_start: usize,
+    chunk_end: usize,
+    block: Arc<SequenceBlock>,
     ctx: &ContigContext,
     mut rng: NeatRng,
-) -> Result<ContigResult, GenerateReadsError> {
-    let sequence = ctx
-        .reference
-        .get(&contig_name)
-        .ok_or_else(|| {
-            GenerateReadsError::IoError(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("Contig {} not found in reference", contig_name),
-            ))
-        })?
-        .clone();
-    let contig_len = sequence.len();
-    debug!("Processing {}", contig_name);
+) -> Result<ChunkResult, GenerateReadsError> {
+    let _ = chunk_idx; // reserved for diagnostics
+    let contig_len = block.ref_end;
+    debug!(
+        "Processing {} chunk [{}, {})",
+        contig_name, chunk_start, chunk_end
+    );
 
     if let Some(bed) = ctx.target_bed
         && !bed.contains_key(&contig_name)
     {
         debug!("Skipping {} — not in target BED", contig_name);
-        return Ok(ContigResult {
-            idx,
+        return Ok(ChunkResult {
+            contig_idx,
+            chunk_start,
             name: contig_name,
             len: contig_len,
             data: None,
         });
     }
 
-    if sequence.is_empty() {
+    if block.sequence.is_empty() {
         warn!("Contig {} has empty sequence, skipping", contig_name);
-        return Ok(ContigResult {
-            idx,
+        return Ok(ChunkResult {
+            contig_idx,
+            chunk_start,
             name: contig_name,
             len: contig_len,
             data: None,
         });
     }
 
-    let sequence_map = map_buffer(&sequence);
-    let current_block = SequenceBlock {
-        contig: contig_name.clone(),
-        ref_start: 0,
-        ref_end: contig_len,
-        sequence,
-        sequence_map,
-    };
+    // The full-contig SequenceBlock is shared across this contig's chunks.
+    let current_block = &*block;
 
     debug!("    > Generating bias map.");
     let raw_regions = current_block.get_non_n_regions();
-    let regions_of_interest: Vec<SequenceMap> = if let Some(bed) = ctx.target_bed {
+    let bed_regions: Vec<SequenceMap> = if let Some(bed) = ctx.target_bed {
         let contig_beds = bed.get(&contig_name).map(|v| v.as_slice()).unwrap_or(&[]);
         intersect_with_bed(&raw_regions, contig_beds, 0)
     } else {
         raw_regions.into_iter().cloned().collect()
     };
+    // Restrict this chunk to fragments ANCHORED in [chunk_start, chunk_end).
+    // Reads may still extend past chunk_end into the full shared sequence, so
+    // no read-content stitching is needed and coverage stays uniform: every
+    // fragment is owned by exactly one chunk (the one containing its anchor).
+    let regions_of_interest: Vec<SequenceMap> = bed_regions
+        .into_iter()
+        .filter_map(|r| {
+            let s = r.start.max(chunk_start);
+            let e = r.end.min(chunk_end);
+            (s < e).then(|| SequenceMap::from(r.region_type, s, e))
+        })
+        .collect();
     if regions_of_interest.is_empty() {
-        return Ok(ContigResult {
-            idx,
+        return Ok(ChunkResult {
+            contig_idx,
+            chunk_start,
             name: contig_name,
             len: contig_len,
             data: None,
@@ -471,16 +615,14 @@ fn process_contig(
         }
     }
 
-    let mutated_map = ctx
-        .mutated_maps
-        .get(&contig_name)
-        .ok_or_else(|| {
-            GenerateReadsError::IoError(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("MutatedMap for {} not found", contig_name),
-            ))
-        })?
-        .clone();
+    // Borrow the shared per-contig MutatedMap (no per-chunk clone). The golden
+    // VCF reads it back from the shared Arc after the parallel phase.
+    let mutated_map = ctx.mutated_maps.get(&contig_name).ok_or_else(|| {
+        GenerateReadsError::IoError(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("MutatedMap for {} not found", contig_name),
+        ))
+    })?;
     let max_del_len = *ctx.max_del_lens.get(&contig_name).unwrap_or(&0);
 
     let block_fragments: Vec<(usize, usize)> = {
@@ -517,7 +659,7 @@ fn process_contig(
                     )?
                 } else {
                     generate_weighted_fragments(
-                        &current_block,
+                        current_block,
                         sub_start,
                         sub_end,
                         ctx.config.read_len,
@@ -569,8 +711,10 @@ fn process_contig(
 
     // Create a per-contig BAM body writer if BAM output is requested.
     let mut bam_body_writer: Option<BamBodyWriter> = if let Some(bam_ctx) = &ctx.bam_context {
-        let bam_temp_path =
-            PathBuf::from(ctx.working_dir).join(format!("temp_bam_{:06}_{}.bam", idx, contig_name));
+        let bam_temp_path = PathBuf::from(ctx.working_dir).join(format!(
+            "temp_bam_{:06}_{:010}_{}.bam",
+            contig_idx, chunk_start, contig_name
+        ));
         Some(BamBodyWriter::new(bam_temp_path, Arc::clone(bam_ctx))?)
     } else {
         None
@@ -582,7 +726,7 @@ fn process_contig(
         let mut file_to_write_1 = PathBuf::from(ctx.working_dir);
         file_to_write_1.push(format!(
             "temp_{}_{:010}_{:010}_r1_tmp.fastq.gz",
-            contig_name, current_block.ref_start, current_block.ref_end,
+            contig_name, chunk_start, chunk_end,
         ));
         let file1 = append_to_file(&file_to_write_1)?;
         let writer1 = BufWriter::new(&file1);
@@ -602,8 +746,8 @@ fn process_contig(
             debug!("Writing paired-ended contig fastq files");
             write_block_fastq(
                 block_fragments,
-                &mutated_map,
-                &current_block,
+                mutated_map,
+                current_block,
                 true,
                 &mut buffer1,
                 &mut buffer2,
@@ -624,8 +768,8 @@ fn process_contig(
             let mut buffer2 = GzEncoder::new(dummy_data, Compression::default());
             write_block_fastq(
                 block_fragments,
-                &mutated_map,
-                &current_block,
+                mutated_map,
+                current_block,
                 false,
                 &mut buffer1,
                 &mut buffer2,
@@ -653,8 +797,8 @@ fn process_contig(
         debug!("BAM-only: generating reads for {}", contig_name);
         write_block_fastq(
             block_fragments,
-            &mutated_map,
-            &current_block,
+            mutated_map,
+            current_block,
             ctx.config.paired_ended,
             &mut buf1,
             &mut buf2,
@@ -677,12 +821,12 @@ fn process_contig(
         None
     };
 
-    Ok(ContigResult {
-        idx,
+    Ok(ChunkResult {
+        contig_idx,
+        chunk_start,
         name: contig_name,
         len: contig_len,
-        data: Some(ProcessedContigData {
-            mutated_map,
+        data: Some(ChunkData {
             r1_files: contig_files_r1,
             r2_files: contig_files_r2,
             bam_body_file,
@@ -858,7 +1002,7 @@ fn generate_mutated_map(
 fn process_chimeric_variants(
     ctx: &ContigContext,
     mut rng: NeatRng,
-) -> Result<ContigResult, GenerateReadsError> {
+) -> Result<ChunkResult, GenerateReadsError> {
     let mut all_reads = Vec::new();
     let mut processed_ids = HashSet::new();
 
@@ -1420,12 +1564,12 @@ fn process_chimeric_variants(
         }
     }
 
-    Ok(ContigResult {
-        idx,
+    Ok(ChunkResult {
+        contig_idx: idx,
+        chunk_start: 0,
         name: contig_name,
         len: 0,
-        data: Some(ProcessedContigData {
-            mutated_map: MutatedMap::from_interval(0, 0, vec![]).map_err(GenerateReadsError::from)?,
+        data: Some(ChunkData {
             r1_files: contig_files_r1,
             r2_files: contig_files_r2,
             bam_body_file,
@@ -1974,16 +2118,15 @@ fn get_mutated_subseq(
     Ok(seq)
 }
 
-fn collect_contig_result(
-    cr: ContigResult,
+fn collect_chunk_result(
+    cr: ChunkResult,
     contig_order: &mut Vec<String>,
     fasta_lengths: &mut HashMap<String, usize>,
-    mutated_maps: &mut HashMap<String, Vec<MutatedMap>>,
     all_fastq_files: &mut HashMap<String, (Vec<PathBuf>, Vec<PathBuf>)>,
-    bam_body_files: &mut HashMap<String, PathBuf>,
+    bam_body_files: &mut HashMap<String, Vec<(usize, PathBuf)>>,
     ad_counters: &mut HashMap<String, AdCounter>,
 ) {
-    // `process_chimeric_variants` returns a pseudo ContigResult named
+    // `process_chimeric_variants` returns a pseudo ChunkResult named
     // "chimeric" with len=0 — a control-flow tag for organizing the
     // junction-spanning FASTQ/BAM outputs, NOT a real reference contig.
     // Its reads' positions are already keyed to real contigs (the BND
@@ -1992,22 +2135,35 @@ fn collect_contig_result(
     // into VCF-relevant accumulators. Leaving it in `contig_order` /
     // `fasta_lengths` produces a malformed `##contig=<ID=chimeric,length=0>`
     // header line that breaks strict downstream parsers like truvari.
+    //
+    // Results arrive sorted by (contig_idx, chunk_start), so the first chunk of
+    // each contig records its order/length; later chunks of the same contig
+    // accumulate their reads, AD counts, and BAM bodies.
     let is_chimeric_pseudo = cr.name == "chimeric" && cr.len == 0;
-    if !is_chimeric_pseudo {
+    if !is_chimeric_pseudo && !fasta_lengths.contains_key(&cr.name) {
         contig_order.push(cr.name.clone());
         fasta_lengths.insert(cr.name.clone(), cr.len);
     }
     if let Some(data) = cr.data {
         if !is_chimeric_pseudo {
-            mutated_maps.insert(cr.name.clone(), vec![data.mutated_map]);
-            ad_counters.insert(cr.name.clone(), data.ad_counter);
+            // Merge per-variant allelic depth across this contig's chunks.
+            let acc = ad_counters.entry(cr.name.clone()).or_default();
+            for (key, (ref_n, alt_n)) in data.ad_counter {
+                let slot = acc.entry(key).or_insert((0, 0));
+                slot.0 += ref_n;
+                slot.1 += alt_n;
+            }
         }
-        // FASTQ + BAM outputs from chimeric reads still need to flow into
-        // the final merge — they carry real per-real-contig records that
-        // just happened to be synthesized through the chimeric path.
-        all_fastq_files.insert(cr.name.clone(), (data.r1_files, data.r2_files));
+        // FASTQ outputs (order-independent) accumulate per contig; chimeric
+        // reads carry real per-real-contig records and still flow into the merge.
+        let entry = all_fastq_files.entry(cr.name.clone()).or_default();
+        entry.0.extend(data.r1_files);
+        entry.1.extend(data.r2_files);
         if let Some(bam_path) = data.bam_body_file {
-            bam_body_files.insert(cr.name, bam_path);
+            bam_body_files
+                .entry(cr.name)
+                .or_default()
+                .push((cr.chunk_start, bam_path));
         }
     }
 }

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -236,17 +236,11 @@ pub fn run_neat(
     // *within* a large chromosome, not just across contigs. Chunk size is
     // independent of num_threads, so output is identical regardless of thread
     // count. Each contig's sequence is shared across its chunks via the cache.
-    let total_genome_len: usize = ctx.reference.values().map(|s| s.len()).sum();
-    let chunk_size = resolve_chunk_size(config, total_genome_len);
-    info!(
-        "\t>Sub-contig chunk size: {} bp{}",
-        chunk_size,
-        match config.chunk_size {
-            None => " (auto)",
-            Some(0) => " (chunking disabled — one chunk per contig)",
-            Some(_) => " (configured)",
-        }
-    );
+    let chunk_size = resolve_chunk_size(config);
+    match config.chunk_size {
+        None | Some(0) => info!("\t>Sub-contig chunking: disabled (one chunk per contig)"),
+        Some(n) => info!("\t>Sub-contig chunking: enabled, chunk size {} bp", n),
+    }
     let seq_cache = SeqBlockCache::new(&ctx.reference, &contig_order_in_file);
     let chunk_work: Vec<ChunkWork> = contig_order_in_file
         .iter()
@@ -269,11 +263,17 @@ pub fn run_neat(
     let parallel_iter = chunk_work
         .into_par_iter()
         .map(|w| -> Result<ChunkResult, GenerateReadsError> {
-            // Deterministic per-chunk seed: contig index then chunk index.
-            let child_rng = ctx
-                .base_rng
-                .derive_child(w.contig_idx as u64)
-                .derive_child(w.chunk_idx as u64);
+            // Deterministic per-chunk seed. Chunk 0 (the only chunk when
+            // chunking is disabled) uses the plain per-contig derivation so its
+            // RNG stream — and therefore its reads — matches the pre-chunking
+            // behaviour exactly. Later chunks derive a sub-seed from it.
+            let child_rng = if w.chunk_idx == 0 {
+                ctx.base_rng.derive_child(w.contig_idx as u64)
+            } else {
+                ctx.base_rng
+                    .derive_child(w.contig_idx as u64)
+                    .derive_child(w.chunk_idx as u64)
+            };
             let block = seq_cache.get(&w.name);
             process_chunk(
                 w.contig_idx,
@@ -442,27 +442,19 @@ pub fn run_neat(
     Ok(files_written.clone())
 }
 
-/// Auto chunk-sizing bounds. The chunk size is derived from the *genome* size
-/// (not the thread count) so output stays byte-identical across thread counts,
-/// while still scaling: small genomes get small chunks (so a single contig
-/// still parallelizes), large genomes get larger chunks (so the chunk — and
-/// temp-file — count stays bounded instead of exploding into millions).
-const CHUNK_AUTO_TARGET_CHUNKS: usize = 256;
-const CHUNK_AUTO_MIN: usize = 1_000_000; // 1 Mbp floor — below this, boundary overhead dominates
-const CHUNK_AUTO_MAX: usize = 25_000_000; // 25 Mbp cap — keeps chunk count bounded on huge genomes
-
-/// Pick a sub-contig chunk size (bp) from the total genome length, aiming for
-/// ~`CHUNK_AUTO_TARGET_CHUNKS` chunks genome-wide, clamped to [MIN, MAX].
-fn auto_chunk_size(total_genome_len: usize) -> usize {
-    (total_genome_len / CHUNK_AUTO_TARGET_CHUNKS).clamp(CHUNK_AUTO_MIN, CHUNK_AUTO_MAX)
-}
-
-/// Resolve the effective chunk size from config: `None` → auto (genome-scaled);
-/// `Some(0)` → disable chunking (one chunk per whole contig); `Some(n)` → fixed.
-fn resolve_chunk_size(config: &RunConfiguration, total_genome_len: usize) -> usize {
+/// Resolve the effective chunk size (bp) from config.
+///
+/// Sub-contig chunking is **disabled by default**: benchmarking showed rneat's
+/// read-generation loop is memory-bandwidth bound, so splitting a contig across
+/// cores does not improve wall time (and can mildly regress it). The machinery
+/// is kept behind an opt-in for CPU-bound or very-many-core scenarios.
+///
+/// - `None` (omitted)  → disabled: one chunk spans the whole contig (default).
+/// - `Some(0)`         → disabled (explicit).
+/// - `Some(n)` (n > 0) → fixed chunk size of `n` bp (opt-in).
+fn resolve_chunk_size(config: &RunConfiguration) -> usize {
     match config.chunk_size {
-        None => auto_chunk_size(total_genome_len),
-        Some(0) => usize::MAX, // one chunk spans the whole contig
+        None | Some(0) => usize::MAX, // one chunk spans the whole contig
         Some(n) => n,
     }
 }
@@ -2706,29 +2698,17 @@ mod tests {
     }
 
     #[test]
-    fn test_auto_chunk_size_scales_and_clamps() {
-        // Small genome clamps to the floor so a single contig still parallelizes.
-        assert_eq!(auto_chunk_size(4_600_000), CHUNK_AUTO_MIN);
-        // Huge genome clamps to the cap so chunk count stays bounded.
-        assert_eq!(auto_chunk_size(10_000_000_000), CHUNK_AUTO_MAX);
-        // Mid-range scales linearly (≈ total / target chunks).
-        let mid = auto_chunk_size(1_000_000_000);
-        assert!(mid > CHUNK_AUTO_MIN && mid < CHUNK_AUTO_MAX);
-        assert_eq!(mid, 1_000_000_000 / CHUNK_AUTO_TARGET_CHUNKS);
-    }
-
-    #[test]
     fn test_resolve_chunk_size_config_modes() {
         let mut cfg = RunConfiguration::default();
-        // None → auto.
+        // None (default) → disabled: one chunk spans the whole contig.
         cfg.chunk_size = None;
-        assert_eq!(resolve_chunk_size(&cfg, 100_000_000), auto_chunk_size(100_000_000));
-        // Some(0) → disabled (one chunk spans the whole contig).
+        assert_eq!(resolve_chunk_size(&cfg), usize::MAX);
+        // Some(0) → disabled (explicit).
         cfg.chunk_size = Some(0);
-        assert_eq!(resolve_chunk_size(&cfg, 100_000_000), usize::MAX);
-        // Some(n) → fixed.
+        assert_eq!(resolve_chunk_size(&cfg), usize::MAX);
+        // Some(n) → fixed opt-in chunk size.
         cfg.chunk_size = Some(5_000_000);
-        assert_eq!(resolve_chunk_size(&cfg, 100_000_000), 5_000_000);
+        assert_eq!(resolve_chunk_size(&cfg), 5_000_000);
     }
 
     #[test]

--- a/rneat/tests/common/mod.rs
+++ b/rneat/tests/common/mod.rs
@@ -82,6 +82,7 @@ pub struct GenReadsConfig {
     pub rng_seed: String,
     pub sequence_error_model: Option<PathBuf>,
     pub num_threads: Option<usize>,
+    pub chunk_size: Option<usize>,
     pub input_vcf: Option<PathBuf>,
     pub mutation_rate: Option<f64>,
     pub mutation_model: Option<PathBuf>,
@@ -103,6 +104,7 @@ impl GenReadsConfig {
             rng_seed: "integration phase two".to_string(),
             sequence_error_model: None,
             num_threads: None,
+            chunk_size: None,
             input_vcf: None,
             mutation_rate: None,
             mutation_model: None,
@@ -125,6 +127,10 @@ impl GenReadsConfig {
         };
         let threads_section = match self.num_threads {
             Some(n) => format!("num_threads: {n}\n"),
+            None => String::new(),
+        };
+        let chunk_size_section = match self.chunk_size {
+            Some(n) => format!("chunk_size: {n}\n"),
             None => String::new(),
         };
         let input_vcf_section = match &self.input_vcf {
@@ -155,7 +161,7 @@ impl GenReadsConfig {
              output_filename: {name}\n\
              overwrite_output: true\n\
              rng_seed: {seed}\n\
-             {pair}{model}{threads}{ivcf}{mrate}{mmodel}{svscale}",
+             {pair}{model}{threads}{chunksz}{ivcf}{mrate}{mmodel}{svscale}",
             ref_ = self.reference.display(),
             rl = self.read_len,
             cov = self.coverage,
@@ -168,6 +174,7 @@ impl GenReadsConfig {
             pair = pair_section,
             model = model_section,
             threads = threads_section,
+            chunksz = chunk_size_section,
             ivcf = input_vcf_section,
             mrate = mutation_rate_section,
             mmodel = mutation_model_section,

--- a/rneat/tests/pipeline_e2e.rs
+++ b/rneat/tests/pipeline_e2e.rs
@@ -33,6 +33,58 @@ fn quality_lines(fastq_path: &std::path::Path) -> Vec<String> {
 }
 
 #[test]
+fn gen_reads_output_is_byte_identical_across_thread_counts() {
+    // Regression guard for the sub-contig chunking path: with a small chunk_size
+    // the multi-segment H1N1 reference splits into several chunks per contig.
+    // Output (R1 AND R2) must be byte-identical regardless of num_threads, and
+    // free of duplicate read names. This catches the class of bug where a chunk
+    // wrote to a shared temp file / a path was merged once per chunk, which
+    // duplicated reads and raced under parallelism.
+    let run = |threads: usize, prefix: &str| -> (std::path::PathBuf, std::path::PathBuf) {
+        let (dir, out) = fresh_workdir();
+        std::mem::forget(dir); // keep the temp dir alive for the duration of the test
+        let mut config = GenReadsConfig::new(h1n1_reference(), out.clone(), prefix);
+        config.paired_ended = true;
+        config.coverage = 20;
+        config.read_len = 50;
+        config.rng_seed = "chunk determinism seed".to_string();
+        config.num_threads = Some(threads);
+        config.chunk_size = Some(500); // force several chunks per ~1.7 kb segment
+        let yaml = config.write_yaml();
+        rneat()
+            .args(["gen-reads", "-c"])
+            .arg(yaml.path())
+            .assert()
+            .success();
+        (
+            out.join(format!("{prefix}_r1.fastq.gz")),
+            out.join(format!("{prefix}_r2.fastq.gz")),
+        )
+    };
+
+    let (r1_t1, r2_t1) = run(1, "t1");
+    let (r1_t4, r2_t4) = run(4, "t4");
+
+    for (a, b, which) in [(&r1_t1, &r1_t4, "R1"), (&r2_t1, &r2_t4, "R2")] {
+        let la = read_gzip_fastq_lines(a);
+        let lb = read_gzip_fastq_lines(b);
+        assert!(!la.is_empty(), "{which}: no reads produced");
+        assert_eq!(
+            la, lb,
+            "{which} differs between 1-thread and 4-thread runs (same seed) — chunking is not thread-count-invariant",
+        );
+        // No duplicate read names (the duplication symptom of the temp-file bug).
+        let names: Vec<&String> = la.iter().step_by(4).collect();
+        let unique: HashSet<&&String> = names.iter().collect();
+        assert_eq!(
+            names.len(),
+            unique.len(),
+            "{which}: duplicate read names present",
+        );
+    }
+}
+
+#[test]
 fn gen_reads_with_default_model_produces_well_formed_fastq() {
     // Smoke test: run gen-reads end-to-end through the real binary with all defaults
     // (no custom error model, no input VCF) and verify the output is well-formed

--- a/template_config/gen_reads_template.yml
+++ b/template_config/gen_reads_template.yml
@@ -184,3 +184,13 @@ sv_max_length_fraction: 0.25
 # Set to 1 to disable parallelism entirely. Omit (or set to .) to use all available cores.
 # (default: auto)
 num_threads: .
+
+# Target size (in base pairs) of a sub-contig chunk — the unit of parallel work.
+# Contigs are split into chunks so a single large chromosome parallelizes across
+# cores instead of pinning one. The size is derived from the genome size (not the
+# thread count), so output is byte-identical regardless of num_threads.
+#   omit / .  -> auto: ~genome/256, clamped to [1 Mbp, 25 Mbp] (recommended)
+#   0         -> disable chunking (one chunk per whole contig)
+#   <integer> -> fixed chunk size in bp
+# (default: auto)
+chunk_size: .

--- a/template_config/gen_reads_template.yml
+++ b/template_config/gen_reads_template.yml
@@ -185,12 +185,12 @@ sv_max_length_fraction: 0.25
 # (default: auto)
 num_threads: .
 
-# Target size (in base pairs) of a sub-contig chunk — the unit of parallel work.
-# Contigs are split into chunks so a single large chromosome parallelizes across
-# cores instead of pinning one. The size is derived from the genome size (not the
-# thread count), so output is byte-identical regardless of num_threads.
-#   omit / .  -> auto: ~genome/256, clamped to [1 Mbp, 25 Mbp] (recommended)
-#   0         -> disable chunking (one chunk per whole contig)
-#   <integer> -> fixed chunk size in bp
-# (default: auto)
+# Experimental, opt-in: target size (in base pairs) of a sub-contig chunk — the
+# unit of parallel work. Splitting a contig lets several cores share one large
+# chromosome. DISABLED BY DEFAULT: read generation is memory-bandwidth bound, so
+# chunking did not improve wall time in our benchmarks. The size is independent
+# of the thread count, so output is byte-identical regardless of num_threads.
+#   omit / . / 0 -> disabled: one chunk per whole contig (default)
+#   <integer>    -> opt in with a fixed chunk size in bp
+# (default: disabled)
 chunk_size: .

--- a/tools/neat_vs_rneat_benchmark.sh
+++ b/tools/neat_vs_rneat_benchmark.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Quantitative benchmark: NEAT 4 (Python) vs rneat (Rust), same input + params.
+# Measures wall-clock time and peak RSS via /usr/bin/time -v, REPS times per
+# config, reporting the median.
+#
+# Fairness: identical reference, coverage, read length, paired-end fragment
+# params, and FASTQ-only output. RNG seeds cannot match across tools (different
+# generators) so this compares resource usage, not output identity.
+#
+# Usage: tools/neat_vs_rneat_benchmark.sh [outdir]
+#   REPS=3 GENOMES=... THREAD_MODES=... override defaults via env.
+set -uo pipefail
+
+# ---- configuration ----------------------------------------------------------
+RNEAT_BIN="${RNEAT_BIN:-$(cd "$(dirname "$0")/.." && pwd)/target/release/rneat}"
+NEAT_BIN="${NEAT_BIN:-$HOME/anaconda3/envs/neat/bin/neat}"
+DATA_DIR="${DATA_DIR:-$HOME/code/data}"
+GTIME="${GTIME:-/usr/bin/time}"
+
+COVERAGE=10
+READ_LEN=151
+FRAG_MEAN=350
+FRAG_SD=50
+SEED=42
+REPS="${REPS:-3}"
+
+# genomes: "label:fasta_path"
+GENOMES=(
+  "ecoli:$DATA_DIR/ecoli.fa"
+  "yeast:$DATA_DIR/yeast.fa"
+  "c_elegans:$DATA_DIR/c_elegans.fa"
+)
+THREAD_MODES=(1 all)
+
+OUTDIR="${1:-/tmp/neat_vs_rneat_run}"
+mkdir -p "$OUTDIR"
+PERREP="$OUTDIR/per_rep.tsv"
+MEDIAN="$OUTDIR/median.tsv"
+echo -e "genome\tsize_mb\tthreads\ttool\trep\twall_s\tpeak_rss_mb\texit" > "$PERREP"
+echo -e "genome\tsize_mb\tthreads\ttool\twall_s_med\tpeak_rss_mb_med\tn_ok" > "$MEDIAN"
+
+NCORES=$(nproc)
+
+# ---- helpers ----------------------------------------------------------------
+parse_time() {  # /usr/bin/time -v file -> "wall_seconds peak_rss_mb"
+  awk '
+    /Elapsed \(wall clock\)/ {
+      n=split($NF,a,":");
+      if (n==3) wall=a[1]*3600+a[2]*60+a[3];
+      else if (n==2) wall=a[1]*60+a[2];
+      else wall=a[1];
+    }
+    /Maximum resident set size/ { rss=$NF/1024 }
+    END { printf "%.2f %.1f", wall, rss }
+  ' "$1"
+}
+
+median() {  # stdin: numbers, one per line -> median
+  sort -n | awk '{v[NR]=$1} END{ if(NR==0){print "NA"; exit}
+    if(NR%2){print v[(NR+1)/2]} else {printf "%.2f", (v[NR/2]+v[NR/2+1])/2} }'
+}
+
+run_config() {
+  local label="$1" fasta="$2" mode="$3" tool="$4" cfg="$5" cmd_outdir="$6"
+  local nthreads; [ "$mode" = "all" ] && nthreads=$NCORES || nthreads=$mode
+  local size_mb; size_mb=$(awk -v b="$(stat -c%s "$fasta")" 'BEGIN{printf "%.1f", b/1048576}')
+  local walls=() rsss=() ok=0
+
+  for rep in $(seq 1 "$REPS"); do
+    local tf="$OUTDIR/${tool}_${label}_t${mode}_r${rep}.time"
+    local log="$OUTDIR/${tool}_${label}_t${mode}_r${rep}.log"
+    rm -rf "$cmd_outdir"; mkdir -p "$cmd_outdir"
+    echo ">>> [$tool] $label threads=$mode rep=$rep/$REPS"
+    if [ "$tool" = "neat" ]; then
+      "$GTIME" -v -o "$tf" "$NEAT_BIN" read-simulator -c "$cfg" -o "$cmd_outdir" -p bench > "$log" 2>&1
+    else
+      "$GTIME" -v -o "$tf" "$RNEAT_BIN" gen-reads -c "$cfg" > "$log" 2>&1
+    fi
+    local ec=$? parsed wall rss
+    parsed=$(parse_time "$tf"); wall=${parsed% *}; rss=${parsed#* }
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$label" "$size_mb" "$mode" "$tool" "$rep" "$wall" "$rss" "$ec" >> "$PERREP"
+    echo "    wall=${wall}s rss=${rss}MB exit=$ec"
+    if [ "$ec" -eq 0 ]; then walls+=("$wall"); rsss+=("$rss"); ok=$((ok+1)); fi
+  done
+
+  local wmed rmed
+  wmed=$(printf "%s\n" "${walls[@]}" | median)
+  rmed=$(printf "%s\n" "${rsss[@]}" | median)
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$label" "$size_mb" "$mode" "$tool" "$wmed" "$rmed" "$ok" >> "$MEDIAN"
+}
+
+# ---- main loop --------------------------------------------------------------
+for mode in "${THREAD_MODES[@]}"; do
+  [ "$mode" = "all" ] && nthreads=$NCORES || nthreads=$mode
+  for entry in "${GENOMES[@]}"; do
+    label="${entry%%:*}"; fasta="${entry#*:}"
+    [ -f "$fasta" ] || { echo "MISSING: $fasta"; continue; }
+
+    neat_cfg="$OUTDIR/neat_${label}_t${mode}.yml"
+    cat > "$neat_cfg" <<EOF
+reference: $fasta
+read_len: $READ_LEN
+coverage: $COVERAGE
+paired_ended: true
+fragment_mean: $FRAG_MEAN
+fragment_st_dev: $FRAG_SD
+produce_fastq: true
+produce_bam: false
+produce_vcf: false
+rng_seed: $SEED
+threads: $nthreads
+overwrite_output: true
+EOF
+
+    rneat_out="$OUTDIR/rneat_${label}_t${mode}"
+    rneat_cfg="$OUTDIR/rneat_${label}_t${mode}.yml"
+    cat > "$rneat_cfg" <<EOF
+reference: $fasta
+read_len: $READ_LEN
+coverage: $COVERAGE
+paired_ended: true
+fragment_mean: $FRAG_MEAN
+fragment_st_dev: $FRAG_SD
+produce_fastq: true
+produce_vcf: false
+produce_bam: false
+overwrite_output: true
+rng_seed: benchmark seed forty two
+output_dir: $rneat_out
+output_prefix: bench
+EOF
+    [ "$mode" != "all" ] && echo "num_threads: $nthreads" >> "$rneat_cfg"
+
+    run_config "$label" "$fasta" "$mode" "neat"  "$neat_cfg"  "$OUTDIR/neat_${label}_t${mode}"
+    run_config "$label" "$fasta" "$mode" "rneat" "$rneat_cfg" "$rneat_out"
+  done
+done
+
+echo; echo "=== MEDIAN RESULTS (REPS=$REPS, ${NCORES} cores) ==="
+column -t -s$'\t' "$MEDIAN"


### PR DESCRIPTION
## Summary

Three related changes to `gen-reads`, plus an honest reframing of the NEAT comparison. Despite the branch name, the sub-contig chunking it adds is **disabled by default** — benchmarking showed read generation is memory-bandwidth bound, so chunking doesn't help (details below). The lasting wins here are **deterministic output** and **accurate docs**.

## What's included

**1. Deterministic, byte-identical FASTQ output across thread counts.**
Final FASTQ is now concatenated in contig order (previously `HashMap`-iteration order, which varied run-to-run). Same seed ⇒ identical reads in identical order regardless of `num_threads`. Verified by a new e2e regression test.

**2. Opt-in sub-contig chunking (default OFF).**
A `chunk_size` config key can split contigs into sub-contig chunks so one large chromosome can be worked by several cores. It's off by default (`chunk_size: 0`/omitted = one chunk per contig); set `chunk_size: <n>` to opt in. Determinism is preserved (chunk size is independent of thread count). A determinism bug found during development — the R2 temp file was named with whole-contig coords, so chunks of a multi-chunk contig shared one R2 file and duplicated/raced R2 reads — was fixed and is now guarded by tests.

**3. Honest NEAT comparison.**
NEAT 4.x is a strong, actively developed tool and the speed gap has closed, so the README/template no longer imply rneat is "faster." The comparison now leads with the durable advantages: native cancer tumor/normal workflow + CNV/per-tissue models, low and flat memory, byte-identical reproducibility, and single-binary deployment. The Parallel Processing section now states the workload is memory-bandwidth bound.

## Behavior vs `develop`
- **Identical read set** to `develop` (same-seed A/B: matching md5 of sorted records for R1 and R2).
- **Identical performance** (same-session A/B on c_elegans: ~365 s 1-thread, ~400 s 8-thread for both).
- Only difference: FASTQ line *order* is now deterministic (an improvement).

## Why chunking is disabled (benchmark conclusion)
Read generation is **memory-bandwidth bound**, not CPU/parallelism bound:
- rneat 8-thread is *slower* than 1-thread regardless of chunking (~400 s vs ~365 s) — and `develop` shows the same, so it's inherent.
- Finer chunking monotonically worsened wall time (25 Mbp → 396 s, 1 Mbp → 441 s).
- Swapping to mimalloc changed nothing (~392 s), ruling out allocator contention.

NEAT 4 parallelizes well (1162 → 331 s) only because it's CPU-bound (Python overhead) with headroom; it parallelizes just to *catch up* to rneat's already-fast single thread. Full write-up in `docs/subcontig_chunking_plan.md`.

## Tests
Full suite green (642). Adds: chunk-math unit tests, `resolve_chunk_size` config-mode test, and an e2e test asserting byte-identical FASTQ across thread counts with no duplicate read names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
