### PR TITLE
Faster FASTQ compression: libdeflate block-gzip + single-pass combine (~22% single-thread); v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,50 @@
-6/7/2026
+6/9/2026
 ========
-## rneat v1.16.1
+## rneat v1.17.0
 
-## Soliciting feedback
-Added a form soliciting feedback from users on `rneat` real world uses and and other feedback 
-that doesn't require direct action. For bugs and features, continue to use those templates on github.
+### Faster FASTQ compression (libdeflate + single-pass combine)
+
+Gzip was ~25–27% of single-threaded wall time. Two changes cut that:
+
+- **libdeflate block-gzip** — a new `BlockGzWriter` compresses FASTQ output with
+  libdeflate (~2–3× faster than zlib for the same gzip) in independent ~256 KiB
+  gzip members. The result is a standard multi-member gzip file (read
+  transparently by `gunzip`, `zcat`, and downstream tools); memory stays bounded
+  to one block.
+- **Single-pass combine** — per-contig temp files are now byte-concatenated into
+  the final FASTQ instead of being decompressed and re-compressed, so each read
+  is compressed once (in the parallel per-contig write) instead of twice.
+
+Net effect: ~22% faster single-threaded read generation (e.g. the c_elegans
+benchmark dropped from ~365 s to ~283 s), with no multi-threaded regression and
+unchanged memory.
+
+### Deterministic, byte-identical FASTQ output (#251)
+
+For a given seed, FASTQ output is now byte-identical regardless of `num_threads`
+(previously the read *set* was stable but record order varied). Read names are
+unique per fragment and the final files are assembled in contig order.
+
+### Opt-in sub-contig chunking (#251)
+
+A new `chunk_size` config key can split contigs into sub-contig chunks so a
+single large chromosome can be worked by multiple cores. It is **disabled by
+default**: benchmarking showed read generation is memory-bandwidth bound, so
+chunking does not improve wall time on commodity hardware (and can mildly
+regress it). It is kept for CPU-bound or many-memory-channel scenarios. See the
+README "Parallel Processing" section, including guidance that **fewer threads
+can be faster** on bandwidth-limited desktops.
+
+### Packaging and docs
+
+- **`CITATION.cff`** and a **Bioconda recipe** (`conda-recipe/`) for one-command
+  installation (Bioconda submission in review).
+- A **NEAT 2 vs NEAT 4 vs rneat** comparison table in the README, framed around
+  rneat's durable advantages (native cancer workflow, low/flat memory,
+  reproducibility, single-binary deployment).
+- A **feedback form** for soliciting real-world `rneat` usage notes that don't
+  require direct action. For bugs and features, continue to use the GitHub
+  templates.
 
 6/6/2026
 ========

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "flate2",
  "itertools",
  "lazy_static",
+ "libdeflater",
  "log",
  "noodles",
  "proptest",
@@ -591,6 +592,24 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libdeflate-sys"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+dependencies = [
+ "libdeflate-sys",
+]
 
 [[package]]
 name = "libm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "bincode",
  "bstr",
@@ -1093,7 +1093,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.16.0'
+version = '1.17.0'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/README.md
+++ b/README.md
@@ -337,6 +337,30 @@ num_threads: 1
 
 Omit `num_threads` (or set it to `.`) to restore the default all-cores behaviour.
 
+**Thread count and hardware — fewer threads can be faster:**
+
+Read generation moves a lot of data relative to the arithmetic it does, so it is
+largely **memory-bandwidth bound**. On a typical desktop or laptop (which has
+only a couple of memory channels), a single `rneat` thread can already saturate
+much of the available memory bandwidth — so adding cores yields little speedup
+and, past a point, can even run *slower* as threads contend for the memory bus.
+In our desktop benchmarks, large references ran about as fast (sometimes faster)
+on **1–4 threads** as on all 8.
+
+Practical guidance:
+
+- **Desktop / laptop:** try `num_threads: 1` (or a small number) and compare — it
+  is often as fast or faster than all-cores for a single large run, and leaves
+  cores free for other work. If you are simulating **many samples**, running
+  several single-threaded `rneat` jobs in parallel typically beats one
+  many-threaded job.
+- **HPC nodes** with many memory channels (and multiple sockets) have far more
+  aggregate bandwidth, so higher `num_threads` scales better there.
+- Either way, the same reads are generated regardless of `num_threads` (the seed
+  fixes the read content per contig; only their order within the file may
+  differ), so it is safe to tune the thread count purely for speed on your
+  hardware.
+
 **BAM output is fully parallel:**
 
 `rneat` uses a per-contig temp-file strategy: each contig worker writes its alignment records to a private temporary BAM body file, then a single concatenation pass assembles them in reference order into the final coordinate-sorted BAM.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ line), the current Python 3 NEAT 4.x, and `rneat`.
 
 |                                            | **NEAT 2.x** (genReads)        | **NEAT 4.x**                              | **`rneat`**                                              |
 | ------------------------------------------ | ------------------------------ | ----------------------------------------- | -------------------------------------------------------- |
-| Latest version                             | 2.1                            | 4.5.3                                      | 1.16.0                                                   |
+| Latest version                             | 2.1                            | 4.5.3                                      | 1.17.0                                                   |
 | Language                                   | Python 2                       | Python 3                                  | Rust                                                     |
 | FASTQ reads (single / paired)              | ✅                             | ✅                                        | ✅                                                       |
 | Golden BAM + VCF truth set                 | ✅                             | ✅                                        | ✅                                                       |

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,6 +27,7 @@ statrs = "0.18.0"
 vectorize = "0.2.0"
 lazy_static = "1.5.0"
 bstr = "1"
+libdeflater = "1.25.2"
 
 [dev-dependencies]
 proptest = "1"

--- a/common/src/file_tools.rs
+++ b/common/src/file_tools.rs
@@ -4,6 +4,7 @@
 pub mod bam_reader;
 pub mod bam_writer;
 pub mod bed_reader;
+pub mod block_gz;
 pub mod fasta_stream;
 pub mod fastq_tools;
 pub mod file_io;

--- a/common/src/file_tools/block_gz.rs
+++ b/common/src/file_tools/block_gz.rs
@@ -1,0 +1,119 @@
+//! Block-wise gzip writer backed by libdeflate.
+//!
+//! libdeflate compresses substantially faster than streaming zlib/zlib-ng for
+//! the same gzip output, but its API is one-shot (compress a whole buffer),
+//! not streaming. `BlockGzWriter` bridges that: it buffers incoming bytes and,
+//! whenever it has accumulated ~`BLOCK_SIZE`, compresses that block into an
+//! independent gzip *member* and writes it out. Concatenated gzip members form
+//! a standard multi-member gzip stream — `gunzip`, `zcat`, `MultiGzDecoder`,
+//! and every common bioinformatics tool read them transparently.
+//!
+//! Memory is bounded to one block regardless of total output size, preserving
+//! rneat's streaming, low-memory behaviour while cutting compression CPU.
+
+use libdeflater::{CompressionLvl, Compressor};
+use log::error;
+use std::io::{self, Write};
+
+/// Uncompressed bytes buffered before a block is emitted. 256 KiB balances
+/// compression ratio (bigger = slightly better) against memory and per-member
+/// header overhead (smaller = more gzip headers).
+const BLOCK_SIZE: usize = 256 * 1024;
+
+/// A `Write` adapter that emits multi-member gzip via libdeflate.
+///
+/// Call [`BlockGzWriter::finish`] to flush the final partial block and observe
+/// any error. As a safety net `Drop` also flushes (matching `flate2::GzEncoder`,
+/// whose `Drop` likewise finalizes and swallows errors), so existing code that
+/// relies on drop-finalization keeps working.
+pub struct BlockGzWriter<W: Write> {
+    inner: W,
+    buf: Vec<u8>,
+    compressor: Compressor,
+    finished: bool,
+    /// Whether any gzip member has been emitted. If none has by finalize time,
+    /// we emit an empty member so the output is still a valid (empty) gzip
+    /// stream — matching `GzEncoder`, and avoiding 0-byte files that a decoder
+    /// would reject with "unexpected end of file" (e.g. a fully deleted contig).
+    wrote_any: bool,
+}
+
+impl<W: Write> BlockGzWriter<W> {
+    pub fn new(inner: W) -> Self {
+        // CompressionLvl::default() is libdeflate level 6 — the same ratio
+        // target as flate2's Compression::default(), so output size is
+        // comparable and only the speed changes.
+        Self {
+            inner,
+            buf: Vec::with_capacity(BLOCK_SIZE),
+            compressor: Compressor::new(CompressionLvl::default()),
+            finished: false,
+            wrote_any: false,
+        }
+    }
+
+    /// Compress `block` (which may be empty) as one gzip member and write it.
+    fn emit_member(&mut self, block: &[u8]) -> io::Result<()> {
+        let bound = self.compressor.gzip_compress_bound(block.len());
+        let mut out = vec![0u8; bound];
+        let n = self
+            .compressor
+            .gzip_compress(block, &mut out)
+            .map_err(|e| io::Error::other(format!("libdeflate gzip compression failed: {e:?}")))?;
+        self.inner.write_all(&out[..n])?;
+        self.wrote_any = true;
+        Ok(())
+    }
+
+    /// Emit the buffered remainder, and — if nothing was ever written — an empty
+    /// member, so the stream is always valid gzip.
+    fn flush_buffered(&mut self) -> io::Result<()> {
+        if !self.buf.is_empty() {
+            let block = std::mem::take(&mut self.buf);
+            self.emit_member(&block)?;
+        }
+        if !self.wrote_any {
+            self.emit_member(&[])?;
+        }
+        Ok(())
+    }
+
+    /// Flush the final partial block and the inner writer. After this, `Drop`
+    /// is a no-op.
+    pub fn finish(mut self) -> io::Result<()> {
+        self.flush_buffered()?;
+        self.finished = true;
+        self.inner.flush()
+        // self drops here; Drop sees `finished` and does nothing.
+    }
+}
+
+impl<W: Write> Write for BlockGzWriter<W> {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(data);
+        // Emit full blocks, keeping any remainder buffered.
+        while self.buf.len() >= BLOCK_SIZE {
+            let rest = self.buf.split_off(BLOCK_SIZE);
+            let block = std::mem::replace(&mut self.buf, rest);
+            self.emit_member(&block)?;
+        }
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // Do not force a block boundary on every flush() — that would create
+        // many tiny gzip members. Blocks are emitted at BLOCK_SIZE or finish().
+        self.inner.flush()
+    }
+}
+
+impl<W: Write> Drop for BlockGzWriter<W> {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        if let Err(e) = self.flush_buffered() {
+            error!("BlockGzWriter: failed to flush final gzip block on drop: {e}");
+        }
+    }
+}

--- a/common/src/file_tools/block_gz.rs
+++ b/common/src/file_tools/block_gz.rs
@@ -29,6 +29,9 @@ const BLOCK_SIZE: usize = 256 * 1024;
 pub struct BlockGzWriter<W: Write> {
     inner: W,
     buf: Vec<u8>,
+    /// Reused scratch buffer for compressed output, so we don't allocate a fresh
+    /// buffer per block (which adds allocator pressure that hurts multi-thread).
+    out: Vec<u8>,
     compressor: Compressor,
     finished: bool,
     /// Whether any gzip member has been emitted. If none has by finalize time,
@@ -46,6 +49,7 @@ impl<W: Write> BlockGzWriter<W> {
         Self {
             inner,
             buf: Vec::with_capacity(BLOCK_SIZE),
+            out: Vec::new(),
             compressor: Compressor::new(CompressionLvl::default()),
             finished: false,
             wrote_any: false,
@@ -55,12 +59,14 @@ impl<W: Write> BlockGzWriter<W> {
     /// Compress `block` (which may be empty) as one gzip member and write it.
     fn emit_member(&mut self, block: &[u8]) -> io::Result<()> {
         let bound = self.compressor.gzip_compress_bound(block.len());
-        let mut out = vec![0u8; bound];
+        if self.out.len() < bound {
+            self.out.resize(bound, 0);
+        }
         let n = self
             .compressor
-            .gzip_compress(block, &mut out)
+            .gzip_compress(block, &mut self.out)
             .map_err(|e| io::Error::other(format!("libdeflate gzip compression failed: {e:?}")))?;
-        self.inner.write_all(&out[..n])?;
+        self.inner.write_all(&self.out[..n])?;
         self.wrote_any = true;
         Ok(())
     }

--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -4,7 +4,6 @@
 //! This one needs a major overhaul, it is autogenerating quality scores etc.
 //! Will wait to get other things set up first
 use crate::rng::{NeatRng, NeatRngError};
-use flate2::read::MultiGzDecoder;
 use log::debug;
 use std::collections::HashMap;
 use std::fs::File;
@@ -13,7 +12,6 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::file_tools::bam_writer::BamRecordStager;
-use crate::file_tools::block_gz::BlockGzWriter;
 use crate::file_tools::file_io::append_to_file;
 use crate::models::quality_scores::QualityScoreModel;
 use crate::models::sequencing_error_model::{
@@ -282,22 +280,22 @@ pub fn combine_temp_fastqs(
 }
 
 fn stream_gzip_files(files: &[PathBuf], output: &PathBuf) -> Result<(), FastqToolsError> {
-    let out_file = append_to_file(output)?;
-    // libdeflate block-gzip is much faster than streaming zlib for the final
-    // re-compression pass. Temp files may be multi-member gzip, so decode with
-    // MultiGzDecoder (GzDecoder stops after the first member).
-    let mut writer = BufWriter::new(BlockGzWriter::new(out_file));
+    // The per-contig temp files are each already a complete (multi-member) gzip
+    // stream. gzip streams concatenate, so the final file is just the raw bytes
+    // of every temp appended in order — no decompress, no recompress. This drops
+    // an entire compression pass (each read is compressed once, in the parallel
+    // per-contig write, instead of twice) and turns the previously single-
+    // threaded combine into pure I/O.
+    let mut out_file = BufWriter::new(append_to_file(output)?);
     for file in files {
-        let f = File::open(file).map_err(|e| FastqToolsError::FastqReadError(e.to_string()))?;
-        let mut decoder = MultiGzDecoder::new(BufReader::new(f));
-        std::io::copy(&mut decoder, &mut writer)
+        let mut f = BufReader::new(
+            File::open(file).map_err(|e| FastqToolsError::FastqReadError(e.to_string()))?,
+        );
+        std::io::copy(&mut f, &mut out_file)
             .map_err(|e| FastqToolsError::FastqWriteError(e.to_string()))?;
     }
-    // Flush BufWriter into the BlockGzWriter, then finalize the last gzip block.
-    let enc = writer
-        .into_inner()
-        .map_err(|e| FastqToolsError::FastqWriteError(e.to_string()))?;
-    enc.finish()
+    out_file
+        .flush()
         .map_err(|e| FastqToolsError::FastqWriteError(e.to_string()))?;
     Ok(())
 }

--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -4,9 +4,7 @@
 //! This one needs a major overhaul, it is autogenerating quality scores etc.
 //! Will wait to get other things set up first
 use crate::rng::{NeatRng, NeatRngError};
-use flate2::Compression;
-use flate2::read::GzDecoder;
-use flate2::write::GzEncoder;
+use flate2::read::MultiGzDecoder;
 use log::debug;
 use std::collections::HashMap;
 use std::fs::File;
@@ -15,6 +13,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::file_tools::bam_writer::BamRecordStager;
+use crate::file_tools::block_gz::BlockGzWriter;
 use crate::file_tools::file_io::append_to_file;
 use crate::models::quality_scores::QualityScoreModel;
 use crate::models::sequencing_error_model::{
@@ -78,13 +77,13 @@ pub fn reverse_complement(sequence: Vec<Nucleotide>) -> Vec<Nucleotide> {
     rev_comp
 }
 
-pub fn write_block_fastq<T: Write, W: Write>(
+pub fn write_block_fastq<B1: Write, B2: Write>(
     block_fragments: Vec<(usize, usize)>,
     block_map: &MutatedMap,
     sequence_block: &SequenceBlock,
     paired_ended: bool,
-    buffer1: &mut GzEncoder<T>,
-    buffer2: &mut GzEncoder<W>,
+    buffer1: &mut B1,
+    buffer2: &mut B2,
     read_length: usize,
     long_reads: bool,
     read_name_prefix: &str,
@@ -284,14 +283,22 @@ pub fn combine_temp_fastqs(
 
 fn stream_gzip_files(files: &[PathBuf], output: &PathBuf) -> Result<(), FastqToolsError> {
     let out_file = append_to_file(output)?;
-    let enc = GzEncoder::new(out_file, Compression::default());
-    let mut writer = BufWriter::new(enc);
+    // libdeflate block-gzip is much faster than streaming zlib for the final
+    // re-compression pass. Temp files may be multi-member gzip, so decode with
+    // MultiGzDecoder (GzDecoder stops after the first member).
+    let mut writer = BufWriter::new(BlockGzWriter::new(out_file));
     for file in files {
         let f = File::open(file).map_err(|e| FastqToolsError::FastqReadError(e.to_string()))?;
-        let mut decoder = GzDecoder::new(BufReader::new(f));
+        let mut decoder = MultiGzDecoder::new(BufReader::new(f));
         std::io::copy(&mut decoder, &mut writer)
             .map_err(|e| FastqToolsError::FastqWriteError(e.to_string()))?;
     }
+    // Flush BufWriter into the BlockGzWriter, then finalize the last gzip block.
+    let enc = writer
+        .into_inner()
+        .map_err(|e| FastqToolsError::FastqWriteError(e.to_string()))?;
+    enc.finish()
+        .map_err(|e| FastqToolsError::FastqWriteError(e.to_string()))?;
     Ok(())
 }
 
@@ -463,9 +470,9 @@ pub fn generate_read(
     })
 }
 
-pub fn write_read_to_fastq<T: Write>(
+pub fn write_read_to_fastq<W: Write>(
     record: &ReadRecord,
-    buffer: &mut GzEncoder<T>,
+    buffer: &mut W,
 ) -> Result<(), FastqToolsError> {
     buffer.write_all(format!("@{}\n", record.name).as_bytes())?;
     buffer.write_all(record.sequence.as_bytes())?;
@@ -486,6 +493,8 @@ pub fn quality_scores_to_char_vec(array: &[usize]) -> Result<Vec<u8>, FastqTools
 #[cfg(test)]
 mod tests {
     use super::*;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
     use crate::file_tools::bam_writer::{BamRecordStager, BamWriter};
     use crate::file_tools::file_io::{VectorBuffer, create_output_file, read_gzip_lines};
     use crate::structs::nucleotides::Nucleotide::*;

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -1,3 +1,4 @@
+use common::file_tools::block_gz::BlockGzWriter;
 use common::file_tools::file_io::create_output_file;
 use common::rng::NeatRng;
 use common::structs::variants::{Genotype, SvType, VariantType};
@@ -586,7 +587,7 @@ fn process_contig(
         ));
         let file1 = append_to_file(&file_to_write_1)?;
         let writer1 = BufWriter::new(&file1);
-        let mut buffer1 = GzEncoder::new(writer1, Compression::default());
+        let mut buffer1 = BlockGzWriter::new(writer1);
         let bam_stager: Option<&mut dyn BamRecordStager> = bam_body_writer
             .as_mut()
             .map(|w| w as &mut dyn BamRecordStager);
@@ -598,7 +599,7 @@ fn process_contig(
             ));
             let file2 = append_to_file(&file_to_write_2)?;
             let writer2 = BufWriter::new(&file2);
-            let mut buffer2 = GzEncoder::new(writer2, Compression::default());
+            let mut buffer2 = BlockGzWriter::new(writer2);
             debug!("Writing paired-ended contig fastq files");
             write_block_fastq(
                 block_fragments,


### PR DESCRIPTION
## Summary

Faster FASTQ compression for `gen-reads`, plus the v1.17.0 release bump/changelog. Rebased on the latest `develop` (includes #251), so this is the last feature for the v1.17.0 release.

Gzip was ~25–27% of single-threaded wall time. Two changes remove most of it:

1. **libdeflate block-gzip** — new `BlockGzWriter` compresses with libdeflate (~2–3× faster than zlib for the same gzip) in independent ~256 KiB members → a standard multi-member gzip file (read transparently by `gunzip`/`zcat`/`MultiGzDecoder`/downstream tools). Memory stays bounded to one block.
2. **Single-pass combine** — per-contig temp files are byte-concatenated into the final FASTQ instead of decompressed + re-compressed, so each read is compressed **once** (in the parallel per-contig write) instead of twice. The previously single-threaded combine becomes pure I/O.

## Benchmark (8-core desktop, paired-end 10×, 3-rep medians)

| | zlib-ng (before) | this PR | |
|---|---|---|---|
| yeast — 1 thread | 42.6 s | **33.0 s** | −22% |
| yeast — 8 thread | 46.5 s | 46.7 s | parity |
| c_elegans — 1 thread | 365 s | **283 s** | −22% |
| c_elegans — 8 thread | ~380–400 s | 377 s | parity → slightly better |

Single-thread is now essentially as fast as no-compression (we compress once, fast, instead of twice, slow). No multi-thread regression. Memory unchanged.

## Correctness
- Output verified valid gzip (`gunzip -t`), correct read counts.
- Combined with #251's deterministic ordering (now in `develop`), output is **byte-identical across thread counts** — verified 1-thread vs 8-thread.
- Full suite green (642).

## Release
Carries the **v1.17.0** version bump + CHANGELOG (libdeflate + #251 + Bioconda/CITATION + comparison table + feedback form). Merging this completes v1.17.0 on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
