### PR TITLE
perf: libdeflate compression everywhere (BAM/VCF, cancer-merge, filter-reads); v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 6/9/2026
 ========
+## rneat v1.17.1
+
+### Faster compression across all subcommands
+
+v1.17.0 made `gen-reads` FASTQ output fast; this extends the same libdeflate
+speedup to the remaining output paths:
+
+- **BAM and `.vcf.gz`** now use libdeflate via the `noodles-bgzf` `libdeflate`
+  feature (the golden VCF and BAM writers previously used slower zlib).
+- **`gen-cancer-reads`** (the tumor/normal FASTQ merge) and **`filter-reads`**
+  FASTQ output now use the libdeflate `BlockGzWriter`.
+- **BAM-only runs** no longer compress the generated FASTQ into a discarded
+  buffer (it now goes to a null sink), removing wasted work.
+
 ## rneat v1.17.0
 
 ### Faster FASTQ compression (libdeflate + single-pass combine)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "bincode",
  "bstr",
@@ -288,6 +288,7 @@ dependencies = [
  "libdeflater",
  "log",
  "noodles",
+ "noodles-bgzf",
  "proptest",
  "serde",
  "serde_derive",
@@ -736,6 +737,7 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "flate2",
+ "libdeflater",
 ]
 
 [[package]]
@@ -1093,7 +1095,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.17.0'
+version = '1.17.1'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."
@@ -25,5 +25,10 @@ log = "0.4.21"
 tempfile = "3.14.0"
 flate2 = { version = "1.1.2", features = ["zlib-ng"], default-features = false }
 noodles = { version = "0.109.0", features = ["bam", "sam", "bgzf", "core"] }
+# Direct dep solely to enable noodles-bgzf's `libdeflate` backend (the `noodles`
+# umbrella has no passthrough feature for it). Cargo feature unification turns
+# libdeflate on for the bgzf used via `noodles::bgzf`, so BAM and .vcf.gz output
+# get the faster compressor too. Version tracks what noodles 0.109 resolves.
+noodles-bgzf = { version = "0.46", features = ["libdeflate"] }
 itertools = "0.14.0"
 rayon = "1.10"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -21,6 +21,8 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 flate2 = { workspace = true }
 noodles = { workspace = true }
+# Enables noodles-bgzf's libdeflate backend for BAM / .vcf.gz (feature unification).
+noodles-bgzf = { workspace = true }
 itertools = { workspace = true }
 bincode = "2.0.0-rc.3"
 statrs = "0.18.0"

--- a/rneat/src/filter_reads/utils/filter_lib.rs
+++ b/rneat/src/filter_reads/utils/filter_lib.rs
@@ -1,8 +1,7 @@
 use crate::filter_reads::errors::FilterReadsError;
+use common::file_tools::block_gz::BlockGzWriter;
 use common::structs::bed_record::BedRecord;
-use flate2::Compression;
 use flate2::read::MultiGzDecoder;
-use flate2::write::GzEncoder;
 use log::*;
 use std::collections::HashMap;
 use std::fs::File;
@@ -47,7 +46,7 @@ fn prep_files_for_filtering(
     file_in: &PathBuf,
     is_gzip: bool,
     file_out: &PathBuf,
-) -> Result<(ReaderType, GzEncoder<File>), FilterReadsError> {
+) -> Result<(ReaderType, BlockGzWriter<File>), FilterReadsError> {
     // Open file for reading.
     let lines: ReaderType = {
         if is_gzip {
@@ -57,7 +56,7 @@ fn prep_files_for_filtering(
         }
     };
     let out_file = create_output_file(file_out, true)?;
-    let buffer = GzEncoder::new(out_file, Compression::default());
+    let buffer = BlockGzWriter::new(out_file);
     Ok((lines, buffer))
 }
 

--- a/rneat/src/gen_cancer_reads/utils/fastq_merge.rs
+++ b/rneat/src/gen_cancer_reads/utils/fastq_merge.rs
@@ -11,17 +11,16 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 
-use flate2::Compression;
 use flate2::read::MultiGzDecoder;
-use flate2::write::GzEncoder;
 
 use crate::gen_cancer_reads::errors::GenCancerReadsError;
+use common::file_tools::block_gz::BlockGzWriter;
 
 /// Stream each `(path, tag)` input, prefix the header line of every 4-line FASTQ
 /// record with `<tag>_`, and write the concatenation to `out` (gzip).
 pub fn tag_and_concat(inputs: &[(&Path, &str)], out: &Path) -> Result<(), GenCancerReadsError> {
     let f = File::create(out)?;
-    let mut w = GzEncoder::new(BufWriter::new(f), Compression::default());
+    let mut w = BlockGzWriter::new(BufWriter::new(f));
     for (path, tag) in inputs {
         let r = BufReader::new(MultiGzDecoder::new(File::open(path)?));
         for (i, line) in r.lines().enumerate() {
@@ -45,6 +44,8 @@ pub fn tag_and_concat(inputs: &[(&Path, &str)], out: &Path) -> Result<(), GenCan
 #[cfg(test)]
 mod tests {
     use super::*;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
     use std::io::Read;
 
     fn write_gz(path: &Path, body: &str) {

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -812,14 +812,14 @@ fn process_chunk(
         }
     } else if ctx.config.produce_bam {
         // BAM-only: generate reads and stage them into the BAM body writer.
-        // The FASTQ buffers drain into null sinks and are discarded.
+        // The FASTQ bytes are discarded, so write them to a null sink rather
+        // than compressing them into a throwaway buffer (the records still flow
+        // to the BAM writer via bam_stager).
         let bam_stager: Option<&mut dyn BamRecordStager> = bam_body_writer
             .as_mut()
             .map(|w| w as &mut dyn BamRecordStager);
-        let null1: VectorBuffer = VectorBuffer::new();
-        let null2: VectorBuffer = VectorBuffer::new();
-        let mut buf1 = GzEncoder::new(null1, Compression::default());
-        let mut buf2 = GzEncoder::new(null2, Compression::default());
+        let mut buf1 = std::io::sink();
+        let mut buf2 = std::io::sink();
         debug!("BAM-only: generating reads for {}", contig_name);
         write_block_fastq(
             block_fragments,


### PR DESCRIPTION
## Summary

Follow-up to v1.17.0: extends the libdeflate compression win from `gen-reads` FASTQ to the **rest** of rneat's output paths, so the whole tool is consistent.

1. **BAM + `.vcf.gz` → libdeflate.** The golden VCF and BAM writers use `noodles::bgzf`, which was building with its default (zlib) backend. Enable `noodles-bgzf`'s `libdeflate` feature via a direct dependency (the `noodles` umbrella has no passthrough feature; Cargo feature-unification turns it on for the bgzf used through `noodles::bgzf`). Verified active via `cargo tree -e features` — `noodles-bgzf` now shares `libdeflate-sys` with our `BlockGzWriter`.
2. **`gen-cancer-reads` + `filter-reads` FASTQ → `BlockGzWriter`.** These FASTQ outputs were still on slow zlib `GzEncoder`; now they get the same libdeflate path as `gen-reads`.
3. **BAM-only runs stop compressing discarded FASTQ.** In `produce_bam`-only mode the generated FASTQ was compressed into a throwaway buffer; it now goes to `io::sink()` (records still flow to the BAM writer), removing pure-waste CPU.

## Verification
- `noodles-bgzf` confirmed compiled with the `libdeflate` feature.
- Full suite green (**649**), including the cancer-merge and filter round-trip tests (which decode the output and check content), so output remains valid gzip.

## Release
Patch bump **1.17.0 → 1.17.1** + CHANGELOG (avoids develop colliding with the released v1.17.0 tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
