### PR TITLE
fix: treat reference N as gaps in gen-reads (v1.17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 6/15/2026
 =========
-## rneat (unreleased)
+## rneat v1.17.2
 
 ### Fix: reference N bases are now treated as gaps, not filled with random sequence
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+6/15/2026
+=========
+## rneat (unreleased)
+
+### Fix: reference N bases are now treated as gaps, not filled with random sequence
+
+`gen-reads` previously overwrote **every** reference `N` with a random base at
+FASTA load time (`apply_n_substitution`). Because the region machinery treats
+masked bases as ordinary sequence (only `N`/`X` mark gaps), the loaded reference
+contained no `N` — so each contig became a single non-N region and the gap
+exclusions were silently bypassed:
+
+- read fragments were anchored across centromere/telomere N-tracts,
+- de-novo mutations were sampled inside N regions, and
+- the v1.13.1 SV alignability gate (#224), which counts only `N`, always passed
+  — making that fix inert in the real pipeline.
+
+N bases are now left as-is at load. The existing non-N machinery (`map_buffer` /
+`get_non_n_regions`) governs read anchoring, mutation placement, and SV
+anchoring, so assembly gaps remain coverage dropouts. Output FASTQ is still
+ACGTN-only (bases are unmasked at write time); reads spanning short interior N
+runs may emit `N`. The model-training subcommands (`gen-mut-model`,
+`gen-gc-bias`) already read raw sequence and were unaffected. Added an
+end-to-end regression test asserting no variants are placed inside an N tract.
+
 6/9/2026
 ========
 ## rneat v1.17.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "bincode",
  "bstr",
@@ -1095,7 +1095,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.17.1'
+version = '1.17.2'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/common/src/file_tools/fasta_stream.rs
+++ b/common/src/file_tools/fasta_stream.rs
@@ -5,7 +5,6 @@ use crate::{
         nucleotides::{
             Nucleotide,
             Nucleotide::{N, X},
-            NucleotideSelector,
         },
         sequence_block::{RegionType, SequenceMap},
     },
@@ -172,20 +171,6 @@ pub fn map_buffer(sequence: &[Nucleotide]) -> Vec<SequenceMap> {
     };
     map.push(SequenceMap::from(region_type, region_start, region_end));
     map
-}
-
-/// Replaces each N base in `sequence` with a randomly sampled masked base in-place.
-pub fn apply_n_substitution(
-    sequence: &mut Vec<Nucleotide>,
-    selector: &NucleotideSelector,
-    rng: &mut NeatRng,
-) -> Result<(), NeatRngError> {
-    for base in sequence.iter_mut() {
-        if *base == N {
-            *base = selector.sample_bases(rng.random()?).get_masked();
-        }
-    }
-    Ok(())
 }
 
 /// Converts a raw FASTA sequence string to nucleotides, stochastically resolving

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -15,9 +15,7 @@ use crate::{
         file_tools::{
             bam_writer::{BamBodyWriter, BamContext, BamRecordStager, concat_temp_bams},
             bed_reader::read_bed,
-            fasta_stream::{
-                FastaStream, apply_n_substitution, map_buffer, resolve_iupac_bases,
-            },
+            fasta_stream::{FastaStream, map_buffer, resolve_iupac_bases},
             fastq_tools::{combine_temp_fastqs, write_block_fastq, generate_read, write_read_to_fastq, reverse_complement, Strand},
             file_io::{VectorBuffer, append_to_file},
             vcf_tools::{read_vcf, write_vcf},
@@ -29,7 +27,7 @@ use crate::{
         structs::{
             bed_record::BedRecord,
             mutated_map::{AdCounter, MutatedMap},
-            nucleotides::{Nucleotide, NucleotideSelector},
+            nucleotides::Nucleotide,
             read_record::ReadRecord,
             sequence_block::{RegionType, SequenceBlock, SequenceMap},
             variants::{Variant, SvData},
@@ -133,9 +131,6 @@ pub fn run_neat(
         None => GcBiasModel::default(),
     };
 
-    info!("Initialize Nucleotide selector");
-    let nuc_sub_model: NucleotideSelector = NucleotideSelector::new();
-
     let target_bed = match &config.target_bed {
         Some(path) => {
             info!("Loading target BED: {:?}", path);
@@ -160,14 +155,17 @@ pub fn run_neat(
     for (idx, result) in fasta.enumerate() {
         let (name, raw) = result?;
         let mut child_rng = rng.derive_child(idx as u64);
-        let (mut seq, iupac_count) = resolve_iupac_bases(&raw, &mut child_rng)?;
+        let (seq, iupac_count) = resolve_iupac_bases(&raw, &mut child_rng)?;
         if iupac_count > 0 {
             warn!(
                 "Contig {}: resolved {} IUPAC ambiguity base(s) to ACGT",
                 name, iupac_count
             );
         }
-        apply_n_substitution(&mut seq, &nuc_sub_model, &mut child_rng)?;
+        // N bases are left as-is. The non-N region machinery (map_buffer /
+        // get_non_n_regions) excludes them from read anchoring, mutation
+        // placement, and SV anchoring, so assembly gaps stay as coverage
+        // dropouts rather than being filled with fabricated sequence.
         contig_order_in_file.push(name.clone());
         reference_map.insert(name, seq);
     }

--- a/rneat/tests/common/mod.rs
+++ b/rneat/tests/common/mod.rs
@@ -201,6 +201,18 @@ pub fn write_iupac_fasta(path: &Path) {
     writeln!(f, ">chr1\n{}", seq).unwrap();
 }
 
+/// Writes a single-contig FASTA with two ACGT flanks separated by a hard N tract.
+/// Layout (1-based, inclusive): left flank [1, 240], N tract [241, 480],
+/// right flank [481, 720]. Used to assert the read/variant pipeline treats the
+/// N tract as an assembly gap (no anchors, no variants) rather than filling it.
+pub fn write_n_tract_fasta(path: &Path) {
+    use std::io::Write as _;
+    let flank: String = "ACGT".chars().cycle().take(240).collect();
+    let n_tract: String = "N".repeat(240);
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, ">chr1\n{flank}{n_tract}{flank}").unwrap();
+}
+
 /// Build a `gen-seq-error-model` config YAML with a training FASTQ and (optionally)
 /// a bin set. Output model is written into `output_file`.
 pub fn write_gen_seq_error_model_config(

--- a/rneat/tests/pipeline_e2e.rs
+++ b/rneat/tests/pipeline_e2e.rs
@@ -7,7 +7,8 @@ mod common;
 
 use common::{
     GenReadsConfig, fresh_workdir, h1n1_reference, read_gzip_fastq_lines, rneat,
-    write_gen_seq_error_model_config, write_iupac_fasta, write_synthetic_fastq_gz,
+    write_gen_seq_error_model_config, write_iupac_fasta, write_n_tract_fasta,
+    write_synthetic_fastq_gz,
 };
 use std::collections::HashSet;
 
@@ -334,6 +335,57 @@ fn gen_reads_with_iupac_reference_produces_no_iupac_in_output() {
             );
         }
     }
+}
+
+#[test]
+fn gen_reads_treats_n_tract_as_gap_no_variants_inside() {
+    // Regression for the N-handling fix: reference N bases are assembly gaps, not
+    // sequence to fill. A central N tract must be excluded from variant placement
+    // by the non-N region machinery. Pre-fix, `apply_n_substitution` overwrote every
+    // N with a random base at load time, so the entire contig became one NonNRegion
+    // and de-novo variants were sampled across the gap. The reference has flanks at
+    // 1-based [1, 240] and [481, 720] with a hard N tract at [241, 480].
+    let (_dir, work) = fresh_workdir();
+    let ref_path = work.join("n_tract_ref.fa");
+    write_n_tract_fasta(&ref_path);
+
+    let mut config = GenReadsConfig::new(ref_path, work.clone(), "n_tract_run");
+    config.coverage = 50;
+    config.produce_vcf = true;
+    // High rate so, pre-fix, many variants would have landed in the 240 bp gap.
+    config.mutation_rate = Some(0.05);
+    let yaml = config.write_yaml();
+    rneat()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let out_vcf_gz = work.join("n_tract_run.vcf.gz");
+    assert!(out_vcf_gz.exists(), "output VCF not produced: {out_vcf_gz:?}");
+    let vcf_lines: Vec<String> = {
+        use flate2::read::MultiGzDecoder;
+        use std::io::{BufRead, BufReader};
+        let r = BufReader::new(MultiGzDecoder::new(std::fs::File::open(&out_vcf_gz).unwrap()));
+        r.lines().map(|l| l.unwrap()).collect()
+    };
+
+    let variants_in_gap: Vec<&String> = vcf_lines
+        .iter()
+        .filter(|l| !l.starts_with('#'))
+        .filter(|l| {
+            l.split('\t')
+                .nth(1)
+                .and_then(|p| p.parse::<usize>().ok())
+                // 1-based N tract span [241, 480].
+                .map(|p| (241..=480).contains(&p))
+                .unwrap_or(false)
+        })
+        .collect();
+    assert!(
+        variants_in_gap.is_empty(),
+        "variants were placed inside the N tract [241, 480]; N regions must be excluded: {variants_in_gap:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`gen-reads` was overwriting **every** reference `N` with a random base at FASTA load time (`apply_n_substitution`). Because the region machinery treats masked bases as ordinary sequence (only `N`/`X` mark gaps), the loaded reference contained no `N` — so each contig became a single non-N region and all gap exclusions were silently bypassed:

- read fragments were anchored across centromere/telomere N-tracts,
- de-novo mutations were sampled inside N regions, and
- the v1.13.1 SV alignability gate (#224), which counts only `N`, always passed — making that fix **inert** in the real pipeline.

The fill landed in the streaming-FASTA refactor (2026-05-08) and silently neutralized the v1.13.1 SV gate that shipped later (2026-06-02).

## Change

- Remove the `apply_n_substitution` call and the now-dead function (and its `NucleotideSelector` import). `N` stays `N` at load; the existing non-N machinery (`map_buffer` / `get_non_n_regions`) governs read anchoring, mutation placement, and SV anchoring, so assembly gaps remain coverage dropouts rather than fabricated sequence.
- Output FASTQ is still ACGTN-only (bases unmasked at write time); reads spanning short interior `N` runs may emit `N` (valid).
- The model-training subcommands (`gen-mut-model`, `gen-gc-bias`) already read raw sequence and were unaffected.
- Add e2e regression test `gen_reads_treats_n_tract_as_gap_no_variants_inside` (+ `write_n_tract_fasta` helper) asserting no variants land inside an N tract — verified it **fails** under the old fill behavior.
- Bump workspace version `1.17.1` → `1.17.2`; CHANGELOG entry added.

## Behavior note

Enabling the previously-inert v1.13.1 SV alignability gate may slightly shift SV placement near N-tracts in existing seeded runs — expected and desirable, but a behavior change.

## Testing

- `cargo build`: clean
- Full suite green: `common` 338 passed; `rneat` 246 lib + all integration suites passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)