### PR TITLE
release: bump version to v1.17.3 (fix Windows build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+6/16/2026
+=========
+## rneat v1.17.3
+
+### Fix: Windows release build (VS2026 runner)
+
+The `windows-latest` GitHub runner was upgraded to the `windows-2025-vs2026`
+image (Visual Studio 2026), and the v1.17.2 Windows build failed with
+`couldn't determine visual studio generator` while compiling `libz-ng-sys` (the
+`zlib-ng` backend for `flate2`). The transitive `cmake` build dependency was
+pinned at 0.1.54, which predates VS2026 support. Bumped `cmake` to 0.1.58
+(VS2026 support landed in 0.1.55) via `Cargo.lock`; no source or other platform
+changes. Re-released as v1.17.3 to produce the missing Windows binary.
+
 6/15/2026
 =========
 ## rneat v1.17.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -262,9 +262,9 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "bincode",
  "bstr",
@@ -394,9 +394,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -1095,7 +1095,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -1221,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.17.2'
+version = '1.17.3'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."


### PR DESCRIPTION
## Summary

Fixes the Windows release build, which began failing at **v1.17.2** when the `windows-latest` GitHub runner was upgraded to the `windows-2025-vs2026` image (Visual Studio 2026).

The build panicked while compiling `libz-ng-sys` (the `zlib-ng` backend for `flate2`):

```
error: failed to run custom build command for `libz-ng-sys v1.1.22`
  couldn't determine visual studio generator
```

The transitive `cmake` build dependency was pinned at **0.1.54**, which predates VS2026 support. VS2026 support landed in cmake-rs **0.1.55**.

## Changes

- Bump `cmake` 0.1.54 → 0.1.58 via `Cargo.lock` (pulls cc/find-msvc-tools/shlex forward as build-dep siblings)
- Bump workspace version 1.17.2 → 1.17.3 (`Cargo.toml`, `Cargo.lock`)
- Add v1.17.3 `CHANGELOG.md` entry

Lockfile-only dependency change — no source edits, no impact on the Linux/macOS/RHEL8 targets. Release build verified locally.

## Follow-up

After merge to `main`, push a `v1.17.3` tag to re-trigger the release workflow and produce the missing `rneat-x86_64-pc-windows-msvc.exe` asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)