### PR TITLE
build(conda): fill v1.17.4 tarball sha256 in reference recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 0000000000000000000000000000000000000000000000000000000000000000  # TODO: fill after v1.17.4 tag is pushed
+  sha256: 2dd8958533944d0cb21f2c73bdd521f10f18932eeeea2c771f30bb07127de99c
 
 build:
   number: 0


### PR DESCRIPTION
Follow-up to #260: replaces the placeholder `sha256` (the v1.17.4 tag had to exist before it could be computed) with the real digest of the v1.17.4 source tarball. Matches the recipe pushed to Bioconda PR #66122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)