### PR TITLE
ci(delta): persist outcomes + resource accounting for ACCESS final report

### DIFF
--- a/scripts/delta/baseline_capture.sbatch
+++ b/scripts/delta/baseline_capture.sbatch
@@ -44,6 +44,7 @@ set -euo pipefail
 
 # ── Parameters ───────────────────────────────────────────────────────────
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$(dirname "$0")/lib_report.sh"   # archive_run() + durable RESULTS_DIR
 
 # chr22 is the right size for a baseline: big enough to be meaningful, small
 # enough to run cheaply and repeat per release.
@@ -247,3 +248,6 @@ if [[ "$det_fastq" != "PASS" || "$det_vcf" != "PASS" ]]; then
     echo "WARNING: determinism check did NOT pass — investigate before relying on this baseline." >&2
 fi
 echo "Commit baseline.json alongside the release tag; diff future runs against it."
+
+# Persist report artifacts off scratch + record provenance/resources.
+archive_run baseline "$OUTDIR" baseline.json het_af_histogram.tsv bcftools_stats.txt

--- a/scripts/delta/benchmark.sbatch
+++ b/scripts/delta/benchmark.sbatch
@@ -29,6 +29,7 @@ set -euo pipefail
 
 # ── Paths (edit these) ──────────────────────────────────────────────────
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$(dirname "$0")/lib_report.sh"            # archive_run() + durable RESULTS_DIR
 DATA_DIR="${DATA_DIR:-$SCRATCH/neat_data}"        # reference FASTAs live here
 OUTDIR="${OUTDIR:-$SCRATCH/benchmark_$SLURM_JOB_ID}"
 
@@ -192,3 +193,6 @@ echo "=== MEDIAN RESULTS (REPS=$REPS) ==="
 column -t -s$'\t' "$MEDIAN"
 echo
 echo "Full per-rep data: $PERREP"
+
+# Persist report artifacts off scratch + record provenance/resources.
+archive_run benchmark "$OUTDIR" median.tsv per_rep.tsv

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -41,6 +41,7 @@ set -euo pipefail
 
 # ── Parameters (edit these) ─────────────────────────────────────────────
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$(dirname "$0")/lib_report.sh"   # archive_run() + durable RESULTS_DIR
 
 # Reference genome. For a smoke test use chr22; for a full-scale run swap
 # in GRCh38. Must be uncompressed (.fa, not .fa.gz) for BWA-MEM2 indexing.
@@ -245,3 +246,6 @@ Key outputs in $OUTDIR:
 Top-line results:
 EOF
 [[ -f "${SCORE_PREFIX}.stats.csv" ]] && column -t -s',' "${SCORE_PREFIX}.stats.csv" || echo "  (score file not found)"
+
+# Persist report artifacts off scratch + record provenance/resources.
+archive_run cancer "$OUTDIR" scored.stats.csv

--- a/scripts/delta/collect_report.sh
+++ b/scripts/delta/collect_report.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Aggregate all archived Delta runs into a single report-ready REPORT.md for the
+# ACCESS final report. Reads the run_manifest.tsv files (and the key result
+# artifacts beside them) that archive_run() persisted under RESULTS_DIR.
+#
+# Usage:
+#   bash scripts/delta/collect_report.sh                 # writes $RESULTS_DIR/REPORT.md
+#   RESULTS_DIR=/path bash scripts/delta/collect_report.sh [output.md]
+#
+# No external deps beyond coreutils/awk — safe to run on a login node.
+
+set -euo pipefail
+
+RESULTS_DIR="${RESULTS_DIR:-${WORK:-$HOME}/rneat-access-results}"
+OUT="${1:-$RESULTS_DIR/REPORT.md}"
+
+[[ -d "$RESULTS_DIR" ]] || { echo "No results dir: $RESULTS_DIR (run some jobs first)" >&2; exit 1; }
+mapfile -t MANIFESTS < <(find "$RESULTS_DIR" -name run_manifest.tsv | sort)
+[[ "${#MANIFESTS[@]}" -gt 0 ]] || { echo "No run_manifest.tsv under $RESULTS_DIR" >&2; exit 1; }
+
+# Read one value from a TSV manifest by key.
+mval() { awk -F'\t' -v k="$2" '$1==k{print $2; exit}' "$1"; }
+
+{
+    echo "# rneat on Delta (NCSA ACCESS) — results"
+    echo
+    echo "_Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) from \`$RESULTS_DIR\` — ${#MANIFESTS[@]} run(s)._"
+    echo
+    echo "## Run summary"
+    echo
+    echo "| Kind | Date (UTC) | rneat | git | Reference | Core-hours | Max RSS (GB) | Job |"
+    echo "|------|------------|-------|-----|-----------|-----------:|-------------:|-----|"
+    total_ch="0.0"
+    for m in "${MANIFESTS[@]}"; do
+        kind=$(mval "$m" kind);        date=$(mval "$m" date_utc)
+        ver=$(mval "$m" rneat_version); gitd=$(mval "$m" git)
+        ref=$(mval "$m" reference);     ch=$(mval "$m" core_hours)
+        rss=$(mval "$m" maxrss_kb);     jid=$(mval "$m" slurm_job_id)
+        rss_gb=$(awk -v r="${rss:-0}" 'BEGIN{printf "%.2f", r/1048576}')
+        echo "| $kind | $date | $ver | $gitd | $ref | ${ch:-0} | $rss_gb | $jid |"
+        total_ch=$(awk -v t="$total_ch" -v c="${ch:-0}" 'BEGIN{printf "%.3f", t+c}')
+    done
+    echo
+    echo "**Total core-hours (≈ Delta CPU SUs): $total_ch**"
+    echo
+
+    # Inline the key result artifact for each run, grouped by kind.
+    echo "## Outcomes by run"
+    for m in "${MANIFESTS[@]}"; do
+        d=$(dirname "$m"); kind=$(mval "$m" kind); jid=$(mval "$m" slurm_job_id)
+        echo
+        echo "### $kind — job $jid"
+        local_emitted=0
+        for art in baseline.json median.tsv scored.summary.csv scored.stats.csv het_af_histogram.tsv; do
+            if [[ -f "$d/$art" ]]; then
+                echo
+                echo "<details><summary>\`$art\`</summary>"
+                echo
+                echo '```'
+                # Cap very long files so the report stays readable.
+                head -200 "$d/$art"
+                [[ $(wc -l < "$d/$art") -gt 200 ]] && echo "... (truncated)"
+                echo '```'
+                echo
+                echo "</details>"
+                local_emitted=1
+            fi
+        done
+        [[ "$local_emitted" -eq 0 ]] && echo "_(no inlined artifacts; see $d)_"
+    done
+
+    echo
+    echo "---"
+    echo "_Artifacts and SLURM logs for each run live under \`$RESULTS_DIR/<kind>/job_<id>/\`._"
+} > "$OUT"
+
+echo "Wrote $OUT (${#MANIFESTS[@]} runs, total core-hours above)."

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -37,6 +37,7 @@ set -euo pipefail
 
 # ── Parameters (edit these) ─────────────────────────────────────────────
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$(dirname "$0")/lib_report.sh"   # archive_run() + durable RESULTS_DIR
 
 # Start with chr22 to validate the pipeline cheaply, then swap to GRCh38.
 REFERENCE="${REFERENCE:-$SCRATCH/neat_data/chr22.fa}"
@@ -208,3 +209,6 @@ EOF
 [[ -f "${SCORE_PREFIX}.summary.csv" ]] \
     && column -t -s',' "${SCORE_PREFIX}.summary.csv" \
     || echo "  (summary file not found)"
+
+# Persist report artifacts off scratch + record provenance/resources.
+archive_run germline "$OUTDIR" scored.summary.csv scored.extended.csv sim.yml

--- a/scripts/delta/lib_report.sh
+++ b/scripts/delta/lib_report.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Shared reporting/persistence helpers for the Delta SLURM jobs.
+#
+# Source this from each *.sbatch AFTER REPO_ROOT/RNEAT_BIN/REFERENCE are set:
+#     source "$(dirname "$0")/lib_report.sh"
+# and call archive_run() once near the end of the job.
+#
+# WHY THIS EXISTS: the jobs do their heavy work in $SCRATCH, which Delta PURGES
+# (files untouched ~30 days are deleted). For the ACCESS final report we need
+# outcomes preserved on DURABLE storage, consolidated, with per-run provenance
+# and resource (core-hour / SU) accounting. archive_run() copies the small
+# report artifacts off scratch and writes a run_manifest.tsv; collect_report.sh
+# later aggregates all runs into a single REPORT.md.
+
+# Durable results root. Defaults to the project/work filesystem (persists),
+# NEVER scratch. Override with RESULTS_DIR=... if your durable path differs
+# (on Delta this is typically /projects/<account>/... exposed as $WORK).
+RESULTS_DIR="${RESULTS_DIR:-${WORK:-$HOME}/rneat-access-results}"
+
+# Emit five space-separated resource values for the current SLURM job:
+#   elapsed_s alloc_cpus alloc_nodes maxrss_kb core_hours
+# Best-effort: prints zeros when not under SLURM or sacct is unavailable, so the
+# caller can always `read` exactly five fields.
+_resource_values() {
+    local jid="${SLURM_JOB_ID:-}"
+    if [[ -z "$jid" ]] || ! command -v sacct >/dev/null 2>&1; then
+        echo "0 0 0 0 0.0"; return
+    fi
+    # First (allocation) line; ElapsedRaw is seconds, MaxRSS like 1234K/M/G.
+    local line elapsed cpus nodes maxrss
+    line=$(sacct -j "$jid" --noheader --parsable2 \
+        --format=ElapsedRaw,AllocCPUS,AllocNodes,MaxRSS 2>/dev/null | head -1)
+    elapsed=$(echo "$line" | cut -d'|' -f1); cpus=$(echo "$line" | cut -d'|' -f2)
+    nodes=$(echo "$line" | cut -d'|' -f3); maxrss=$(echo "$line" | cut -d'|' -f4)
+    elapsed=${elapsed:-0}; cpus=${cpus:-0}; nodes=${nodes:-0}
+    local rss_kb=0
+    case "$maxrss" in
+        *K) rss_kb=${maxrss%K} ;;
+        *M) rss_kb=$(awk -v v="${maxrss%M}" 'BEGIN{printf "%.0f", v*1024}') ;;
+        *G) rss_kb=$(awk -v v="${maxrss%G}" 'BEGIN{printf "%.0f", v*1048576}') ;;
+    esac
+    # Core-hours = elapsed_hours * allocated CPUs (≈ Delta CPU SUs).
+    local core_hours
+    core_hours=$(awk -v e="$elapsed" -v c="$cpus" 'BEGIN{printf "%.3f", (e/3600.0)*c}')
+    echo "${elapsed:-0} ${cpus:-0} ${nodes:-0} ${rss_kb:-0} ${core_hours:-0.0}"
+}
+
+# archive_run <kind> <source_outdir> [artifact-file ...]
+# Copies the named (small) report artifacts off scratch into the durable
+# results dir and writes run_manifest.tsv with provenance + resource usage.
+# Large data (FASTQ/BAM) is intentionally left in scratch — only report-
+# relevant files (csv/tsv/json/logs) are persisted.
+archive_run() {
+    local kind="$1" outdir="$2"; shift 2
+    local jid="${SLURM_JOB_ID:-local}"
+    local dest="$RESULTS_DIR/$kind/job_${jid}"
+    mkdir -p "$dest"
+
+    local f
+    for f in "$@"; do
+        [[ -e "$outdir/$f" ]] && cp -f "$outdir/$f" "$dest/" 2>/dev/null || true
+    done
+    # SLURM stdout/err (written to the submit dir as <jobname>_<jobid>.out/.err).
+    local base="${SLURM_JOB_NAME:-job}_${jid}"
+    [[ -f "${base}.out" ]] && cp -f "${base}.out" "$dest/" 2>/dev/null || true
+    [[ -f "${base}.err" ]] && cp -f "${base}.err" "$dest/" 2>/dev/null || true
+
+    local ver git_desc
+    ver="$("${RNEAT_BIN:-rneat}" --version 2>/dev/null || echo unknown)"
+    git_desc="$(git -C "${REPO_ROOT:-.}" describe --tags --always --dirty 2>/dev/null || echo unknown)"
+    local elapsed_s alloc_cpus alloc_nodes maxrss_kb core_hours
+    read -r elapsed_s alloc_cpus alloc_nodes maxrss_kb core_hours < <(_resource_values)
+
+    # Tab-separated key/value manifest — robust to parse with awk, no jq needed.
+    printf '%s\t%s\n' \
+        kind          "$kind" \
+        date_utc      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        slurm_job_id  "$jid" \
+        rneat_version "$ver" \
+        git           "$git_desc" \
+        reference     "$(basename "${REFERENCE:-NA}")" \
+        elapsed_s     "${elapsed_s:-0}" \
+        alloc_cpus    "${alloc_cpus:-0}" \
+        alloc_nodes   "${alloc_nodes:-0}" \
+        maxrss_kb     "${maxrss_kb:-0}" \
+        core_hours    "${core_hours:-0.0}" \
+        artifacts     "$*" \
+        > "$dest/run_manifest.tsv"
+
+    echo "[archive] $kind -> $dest  (core_hours=${core_hours:-0.0}, files: $*)"
+}

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -98,10 +98,20 @@ Setup complete.
 
 Next steps:
   1. Place reference genome(s) and input data in \$SCRATCH
-  2. Edit scripts/delta/benchmark.sbatch  — set ACCOUNT and DATA_DIR
-  3. Edit scripts/delta/cancer_pipeline.sbatch — set ACCOUNT, REFERENCE, etc.
-  4. Submit:
-       sbatch scripts/delta/benchmark.sbatch
-       sbatch scripts/delta/cancer_pipeline.sbatch
+  2. Set your ACCESS account in all jobs:
+       sed -i 's/<YOUR_ALLOCATION>/<your-account>/' scripts/delta/*.sbatch
+  3. (optional) Point results at durable storage for the ACCESS final report —
+     defaults to \${WORK:-\$HOME}/rneat-access-results (NOT scratch, which is purged):
+       export RESULTS_DIR=/projects/<account>/rneat-access-results
+  4. Submit jobs:
+       sbatch scripts/delta/baseline_capture.sbatch   # simulator baseline
+       sbatch scripts/delta/germline_e2e.sbatch       # SNP/indel recall
+       sbatch scripts/delta/benchmark.sbatch          # NEAT-vs-rneat throughput
+       sbatch scripts/delta/cancer_pipeline.sbatch    # somatic SNV/indel recall
+  5. Build the ACCESS final-report document once runs finish:
+       bash scripts/delta/collect_report.sh           # -> \$RESULTS_DIR/REPORT.md
 
+Each job persists its result artifacts + a provenance/resource manifest under
+\$RESULTS_DIR (off scratch); collect_report.sh aggregates them (incl. total
+core-hours ≈ SUs) into REPORT.md.
 EOF


### PR DESCRIPTION
## Problem
The Delta jobs write everything to `$SCRATCH` (purged ~30 days), with no durable copy, no consolidation across runs, and no resource accounting. ACCESS final reports need outcomes preserved, consolidated, with provenance + SU/core-hour usage — none of which existed.

## What
- **`lib_report.sh`** — `archive_run()` copies each job's *small* result artifacts off scratch into a durable `RESULTS_DIR` (default `${WORK:-$HOME}/rneat-access-results`, override-able; **never scratch**) and writes `run_manifest.tsv`: rneat `--version`, `git describe`, reference, and `sacct` resource usage (elapsed, CPUs, MaxRSS, **core-hours ≈ Delta CPU SUs**). Large FASTQ/BAM stay in scratch.
- **`collect_report.sh`** — aggregates all `run_manifest.tsv` + key artifacts into a report-ready **`REPORT.md`** (runs table, **total core-hours**, inlined outcomes in collapsible sections). No jq/external deps.
- Wired `archive_run` into all four jobs (`baseline_capture`, `germline_e2e`, `benchmark`, `cancer_pipeline`).
- `setup.sh` closing instructions updated: account `sed`, `RESULTS_DIR`, full job list, and the `collect_report.sh` step.

## Validated locally (no SLURM)
Synthetic run data → `archive_run` persists artifacts + manifest; `collect_report.sh` emits a correct `REPORT.md` with the runs table and inlined results. `sacct` resource fields read 0 off-SLURM and populate on Delta. All scripts pass `bash -n`.

## Note
`RESULTS_DIR` defaults to `${WORK:-$HOME}/...`; confirm Delta's durable path (likely `/projects/<account>/...`) and `export RESULTS_DIR` accordingly — documented in `setup.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)