### PR TITLE
ci(delta): set ACCESS account + fix $SCRATCH/repo-path so jobs run under sbatch

### DIFF
--- a/scripts/delta/baseline_capture.sbatch
+++ b/scripts/delta/baseline_capture.sbatch
@@ -31,7 +31,7 @@
 
 #SBATCH --job-name=rneat-baseline
 #SBATCH --partition=cpu
-#SBATCH --account=<YOUR_ALLOCATION>
+#SBATCH --account=bhrd-delta-cpu
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=16

--- a/scripts/delta/benchmark.sbatch
+++ b/scripts/delta/benchmark.sbatch
@@ -16,7 +16,7 @@
 
 #SBATCH --job-name=rneat-benchmark
 #SBATCH --partition=cpu
-#SBATCH --account=<YOUR_ALLOCATION>
+#SBATCH --account=bhrd-delta-cpu
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=64

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -28,7 +28,7 @@
 
 #SBATCH --job-name=rneat-cancer
 #SBATCH --partition=cpu
-#SBATCH --account=<YOUR_ALLOCATION>
+#SBATCH --account=bhrd-delta-cpu
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=64

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -24,7 +24,7 @@
 
 #SBATCH --job-name=rneat-germline
 #SBATCH --partition=cpu
-#SBATCH --account=<YOUR_ALLOCATION>
+#SBATCH --account=bhrd-delta-cpu
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=64

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -98,8 +98,8 @@ Setup complete.
 
 Next steps:
   1. Place reference genome(s) and input data in \$SCRATCH
-  2. Set your ACCESS account in all jobs:
-       sed -i 's/<YOUR_ALLOCATION>/<your-account>/' scripts/delta/*.sbatch
+  2. ACCESS account is preset to bhrd-delta-cpu in the *.sbatch files.
+     Override per-submit if needed:  sbatch --account=<other> scripts/delta/<job>.sbatch
   3. (optional) Point results at durable storage for the ACCESS final report —
      defaults to \${WORK:-\$HOME}/rneat-access-results (NOT scratch, which is purged):
        export RESULTS_DIR=/projects/<account>/rneat-access-results


### PR DESCRIPTION
Fills the `--account=<YOUR_ALLOCATION>` placeholder in all four Delta job scripts with the granted allocation **bhrd-delta-cpu**. `setup.sh` updated to note it's preset and overridable per-submit (`sbatch --account=<other>`).

Account IDs aren't credentials (useless without allocation membership), so committing it is fine; this unblocks submitting the Delta verification/baseline jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)