### PR TITLE
fix(delta): resolve $SCRATCH and repo path so jobs run under sbatch

### DIFF
--- a/scripts/delta/baseline_capture.sbatch
+++ b/scripts/delta/baseline_capture.sbatch
@@ -43,8 +43,10 @@
 set -euo pipefail
 
 # ── Parameters ───────────────────────────────────────────────────────────
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-source "$(dirname "$0")/lib_report.sh"   # archive_run() + durable RESULTS_DIR
+# Under sbatch, $0 is a spooled copy — derive the repo from the submit dir
+# (run `sbatch` from the repo root) or override with RNEAT_REPO.
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # archive_run() + Delta path resolution
 
 # chr22 is the right size for a baseline: big enough to be meaningful, small
 # enough to run cheaply and repeat per release.

--- a/scripts/delta/benchmark.sbatch
+++ b/scripts/delta/benchmark.sbatch
@@ -28,8 +28,10 @@
 set -euo pipefail
 
 # ── Paths (edit these) ──────────────────────────────────────────────────
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-source "$(dirname "$0")/lib_report.sh"            # archive_run() + durable RESULTS_DIR
+# Under sbatch, $0 is a spooled copy — derive the repo from the submit dir
+# (run `sbatch` from the repo root) or override with RNEAT_REPO.
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # archive_run() + Delta path resolution
 DATA_DIR="${DATA_DIR:-$SCRATCH/neat_data}"        # reference FASTAs live here
 OUTDIR="${OUTDIR:-$SCRATCH/benchmark_$SLURM_JOB_ID}"
 

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -40,8 +40,10 @@
 set -euo pipefail
 
 # ── Parameters (edit these) ─────────────────────────────────────────────
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-source "$(dirname "$0")/lib_report.sh"   # archive_run() + durable RESULTS_DIR
+# Under sbatch, $0 is a spooled copy — derive the repo from the submit dir
+# (run `sbatch` from the repo root) or override with RNEAT_REPO.
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # archive_run() + Delta path resolution
 
 # Reference genome. For a smoke test use chr22; for a full-scale run swap
 # in GRCh38. Must be uncompressed (.fa, not .fa.gz) for BWA-MEM2 indexing.

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -36,8 +36,10 @@
 set -euo pipefail
 
 # ── Parameters (edit these) ─────────────────────────────────────────────
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-source "$(dirname "$0")/lib_report.sh"   # archive_run() + durable RESULTS_DIR
+# Under sbatch, $0 is a spooled copy — derive the repo from the submit dir
+# (run `sbatch` from the repo root) or override with RNEAT_REPO.
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # archive_run() + Delta path resolution
 
 # Start with chr22 to validate the pipeline cheaply, then swap to GRCh38.
 REFERENCE="${REFERENCE:-$SCRATCH/neat_data/chr22.fa}"

--- a/scripts/delta/lib_report.sh
+++ b/scripts/delta/lib_report.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Shared reporting/persistence helpers for the Delta SLURM jobs.
 #
-# Source this from each *.sbatch AFTER REPO_ROOT/RNEAT_BIN/REFERENCE are set:
-#     source "$(dirname "$0")/lib_report.sh"
-# and call archive_run() once near the end of the job.
+# Source this from each *.sbatch right after REPO_ROOT is set:
+#     source "$REPO_ROOT/scripts/delta/lib_report.sh"
+# (NOT via $(dirname "$0") — under sbatch $0 is a spooled copy). Sourcing also
+# resolves the Delta filesystem paths below, so do it before any $SCRATCH use.
+# Call archive_run() once near the end of the job.
 #
 # WHY THIS EXISTS: the jobs do their heavy work in $SCRATCH, which Delta PURGES
 # (files untouched ~30 days are deleted). For the ACCESS final report we need
@@ -12,10 +14,23 @@
 # report artifacts off scratch and writes a run_manifest.tsv; collect_report.sh
 # later aggregates all runs into a single REPORT.md.
 
-# Durable results root. Defaults to the project/work filesystem (persists),
-# NEVER scratch. Override with RESULTS_DIR=... if your durable path differs
-# (on Delta this is typically /projects/<account>/... exposed as $WORK).
-RESULTS_DIR="${RESULTS_DIR:-${WORK:-$HOME}/rneat-access-results}"
+# ── Delta filesystem paths ───────────────────────────────────────────────
+# Delta does NOT export $SCRATCH/$WORK to jobs, and these scripts run under
+# `set -u`, so resolve them here (this file is sourced before any $SCRATCH use).
+# Layout (confirmed): scratch = /scratch/<project>/$USER (purged ~30 days);
+# durable project space = /projects/<project>/$USER.
+# Override by exporting SCRATCH / RESULTS_DIR, or by setting ACCESS_PROJECT.
+: "${USER:=$(id -un)}"
+: "${ACCESS_PROJECT:=bhrd}"
+: "${SCRATCH:=/scratch/$ACCESS_PROJECT/$USER}"
+if [[ -n "${SLURM_JOB_ID:-}" && ! -d "$SCRATCH" ]]; then
+    echo "ERROR: scratch dir '$SCRATCH' not found — export SCRATCH=... or set ACCESS_PROJECT=..." >&2
+    exit 1
+fi
+
+# Durable results root for the ACCESS final report — the project filesystem
+# (persists), NEVER scratch. Override with RESULTS_DIR=...
+RESULTS_DIR="${RESULTS_DIR:-/projects/$ACCESS_PROJECT/$USER/rneat-access-results}"
 
 # Emit five space-separated resource values for the current SLURM job:
 #   elapsed_s alloc_cpus alloc_nodes maxrss_kb core_hours

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -20,6 +20,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# Resolve Delta paths ($SCRATCH isn't exported on Delta). setup.sh runs
+# interactively, so $0 is reliable here (unlike the spooled sbatch jobs).
+source "$(dirname "$0")/lib_report.sh"
 SIF_DIR="${SIF_DIR:-$SCRATCH/sif}"          # where to cache Apptainer .sif files
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
 CONDA_ENV_NAME="neat4"


### PR DESCRIPTION
Two latent bugs that would have killed every real Delta run, surfaced by a tiny account-test job:

1. $SCRATCH is NOT exported on Delta, and the scripts run under `set -u`, so every bare $SCRATCH reference aborted with "unbound variable". lib_report.sh now resolves the Delta layout (scratch=/scratch/$ACCESS_PROJECT/$USER, durable RESULTS_DIR=/projects/$ACCESS_PROJECT/$USER/...; ACCESS_PROJECT=bhrd default, all overridable) at source time, before any $SCRATCH use, and fail-fasts in-job if scratch is missing.

2. Under sbatch, $0 is a spooled copy (/var/spool/slurmd/.../slurm_script), so `dirname "$0"` broke both REPO_ROOT and the lib_report source. Jobs now derive REPO_ROOT from $SLURM_SUBMIT_DIR (run sbatch from the repo root) or $RNEAT_REPO, and source lib_report via $REPO_ROOT. setup.sh runs interactively so keeps $0 but now sources lib_report for path resolution.

Verified locally: clean env (no $SCRATCH) resolves to /scratch/bhrd/$USER and /projects/bhrd/$USER/...; fail-fast fires in-job when scratch is absent; SCRATCH override is honored; all scripts pass bash -n.