### PR TITLE
ci(delta): fix conda activation + install NEAT from bioconda

### DIFF
--- a/scripts/delta/baseline_capture.sbatch
+++ b/scripts/delta/baseline_capture.sbatch
@@ -72,8 +72,8 @@ RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
 source "$HOME/.cargo/env"
 module load samtools/1.22-cce19.0.0
 module load htslib/1.22-gcc13.3.1
-module load anaconda3_cpu 2>/dev/null || module load miniforge 2>/dev/null || true
-conda activate bioinf   # bcftools (mpileup/stats/query)
+setup_conda
+conda_activate bioinf   # bcftools (mpileup/stats/query)
 
 mkdir -p "$OUTDIR"
 DIR_A="$OUTDIR/run_t${THREADS_A}"

--- a/scripts/delta/benchmark.sbatch
+++ b/scripts/delta/benchmark.sbatch
@@ -61,8 +61,8 @@ REPS=3       # repetitions per config; median is reported
 
 # ── Environment ─────────────────────────────────────────────────────────
 source "$HOME/.cargo/env"
-module load anaconda3_cpu 2>/dev/null || module load miniforge 2>/dev/null || true
-conda activate "$CONDA_ENV_NAME"
+setup_conda
+conda_activate "$CONDA_ENV_NAME"
 NEAT_BIN="$(conda run -n "$CONDA_ENV_NAME" which neat 2>/dev/null || echo '')"
 
 NCORES=$SLURM_CPUS_PER_TASK

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -76,8 +76,8 @@ PREFIX="$OUTDIR/sample"
 source "$HOME/.cargo/env"
 module load samtools/1.22-cce19.0.0
 module load htslib/1.22-gcc13.3.1
-module load anaconda3_cpu 2>/dev/null || module load miniforge 2>/dev/null || true
-conda activate bioinf   # provides bwa-mem2, gatk4, bcftools (not available as modules)
+setup_conda
+conda_activate bioinf   # provides bwa-mem2, gatk4, bcftools (not available as modules)
 
 mkdir -p "$OUTDIR"
 REF_DIR="$(dirname "$REFERENCE")"

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -63,8 +63,8 @@ PREFIX="sample"
 source "$HOME/.cargo/env"
 module load samtools/1.22-cce19.0.0
 module load htslib/1.22-gcc13.3.1
-module load anaconda3_cpu 2>/dev/null || module load miniforge 2>/dev/null || true
-conda activate bioinf   # provides bwa-mem2, gatk4, bcftools (not available as modules)
+setup_conda
+conda_activate bioinf   # provides bwa-mem2, gatk4, bcftools (not available as modules)
 
 mkdir -p "$OUTDIR"
 REF_DIR="$(dirname "$REFERENCE")"

--- a/scripts/delta/lib_report.sh
+++ b/scripts/delta/lib_report.sh
@@ -32,6 +32,37 @@ fi
 # (persists), NEVER scratch. Override with RESULTS_DIR=...
 RESULTS_DIR="${RESULTS_DIR:-/projects/$ACCESS_PROJECT/$USER/rneat-access-results}"
 
+# ── conda activation (Delta) ─────────────────────────────────────────────
+# On Delta the miniforge module puts conda's legacy `activate` on PATH but NOT
+# `conda` itself, so `source activate` bootstraps the base env + shell
+# functions. Override the module with CONDA_MODULE=...; no-op if conda is
+# already available. The `set +u` is required: conda's activate scripts read
+# unbound vars (e.g. $PS1) and would abort under our `set -u`.
+setup_conda() {
+    command -v conda >/dev/null 2>&1 && return 0
+    module load "${CONDA_MODULE:-miniforge3-python}" 2>/dev/null || true
+    set +u
+    command -v conda >/dev/null 2>&1 || source activate 2>/dev/null || true
+    if ! command -v conda >/dev/null 2>&1 && [[ -n "${CONDA_PREFIX:-}" ]]; then
+        source "$CONDA_PREFIX/etc/profile.d/conda.sh" 2>/dev/null || true
+    fi
+    set -u
+    command -v conda >/dev/null 2>&1 || {
+        echo "ERROR: conda unavailable after 'module load ${CONDA_MODULE:-miniforge3-python}' + 'source activate'." >&2
+        echo "       Set CONDA_MODULE=<your module> or initialize conda before running." >&2
+        return 1
+    }
+}
+
+# set-u-safe environment activation (same unbound-var reason as above).
+conda_activate() {
+    set +u
+    conda activate "$1" || source activate "$1"
+    local rc=$?
+    set -u
+    return "$rc"
+}
+
 # Emit five space-separated resource values for the current SLURM job:
 #   elapsed_s alloc_cpus alloc_nodes maxrss_kb core_hours
 # Best-effort: prints zeros when not under SLURM or sacct is unavailable, so the

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -57,7 +57,7 @@ cargo build --release 2>&1 | tail -5
 echo "      Binary: $CARGO_TARGET_DIR/release/rneat"
 
 # ── 2. NEAT 4 conda env ─────────────────────────────────────────────────
-module load anaconda3_cpu 2>/dev/null || module load miniforge 2>/dev/null || true
+setup_conda   # load the conda module + bootstrap `conda` (Delta: miniforge3-python)
 
 if conda env list | grep -q "^${CONDA_ENV_NAME} "; then
     echo "[2/4] Conda env '$CONDA_ENV_NAME' already exists — skipping."

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -60,12 +60,15 @@ echo "      Binary: $CARGO_TARGET_DIR/release/rneat"
 module load anaconda3_cpu 2>/dev/null || module load miniforge 2>/dev/null || true
 
 if conda env list | grep -q "^${CONDA_ENV_NAME} "; then
-    echo "[2/3] Conda env '$CONDA_ENV_NAME' already exists — skipping."
+    echo "[2/4] Conda env '$CONDA_ENV_NAME' already exists — skipping."
 else
-    echo "[2/3] Creating conda env for NEAT 4..."
-    conda create -y -n "$CONDA_ENV_NAME" python=3.11
-    conda run -n "$CONDA_ENV_NAME" pip install neat-genreads
-    echo "      NEAT 4 installed: $(conda run -n $CONDA_ENV_NAME neat --version 2>&1 || echo 'check with: conda run -n $CONDA_ENV_NAME neat --version')"
+    # Install NEAT 4 from bioconda (the method NEAT's own README recommends):
+    # it pulls NEAT's conda-only runtime deps (e.g. bcftools), which a bare
+    # `pip install neat-genreads` into a python-only env would miss. No clone
+    # of the NEAT repo is needed. Only used by benchmark.sbatch.
+    echo "[2/4] Creating conda env for NEAT 4 (bioconda)..."
+    conda create -y -n "$CONDA_ENV_NAME" -c conda-forge -c bioconda neat
+    echo "      NEAT 4 installed: $(conda run -n "$CONDA_ENV_NAME" neat --version 2>&1 | head -1 || true)"
 fi
 
 # ── 3. bioinf conda env (bwa-mem2, gatk4, bcftools) ────────────────────


### PR DESCRIPTION
Answering 'do I need to clone NEAT 4 on Delta?' → **no**, but `setup.sh`'s install was fragile.

NEAT 4 is on **bioconda** as `neat` 4.6.1 (noarch), which is what NEAT's own README recommends — it pulls NEAT's conda-only runtime deps (e.g. `bcftools`) that a bare `pip install neat-genreads` into a python-only env would miss and break the benchmark at runtime. Switched `setup.sh` to `conda create -n neat4 -c conda-forge -c bioconda neat`. No NEAT repo clone needed.

NEAT 4 is only used by `benchmark.sbatch` (NEAT-vs-rneat throughput); baseline/germline/cancer don't touch it.

(Also fixes a cosmetic `[2/3]`→`[2/4]` step-label.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)