### PR TITLE
fix(delta): setup.sh tool-version checks abort on SIGPIPE under pipefail

### DIFF
--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -82,9 +82,11 @@ else
         -c bioconda -c conda-forge \
         bcftools bwa-mem2 gatk4
     echo "      Tools installed:"
-    conda run -n "$BIOINF_ENV_NAME" bcftools  --version | head -1
-    conda run -n "$BIOINF_ENV_NAME" bwa-mem2  version   2>&1 | head -1
-    conda run -n "$BIOINF_ENV_NAME" gatk      --version 2>&1 | head -1
+    # `|| true`: head -1 closes the pipe after one line, so the tool gets
+    # SIGPIPE (exit 141) and `set -o pipefail` would otherwise abort setup.
+    conda run -n "$BIOINF_ENV_NAME" bcftools  --version 2>&1 | head -1 || true
+    conda run -n "$BIOINF_ENV_NAME" bwa-mem2  version   2>&1 | head -1 || true
+    conda run -n "$BIOINF_ENV_NAME" gatk      --version 2>&1 | head -1 || true
 fi
 
 # ── 4. hap.py Apptainer image ───────────────────────────────────────────


### PR DESCRIPTION
The bioinf-env tool-version checks pipe `conda run ... | head -1`. `head` closes the pipe after one line → the tool gets SIGPIPE (exit 141) → `set -o pipefail` propagates it → `set -e` aborts setup before the hap.py SIF pull (step 4). Hit in practice on the `bwa-mem2 version` check (bcftools happened to finish writing before SIGPIPE).

Fix: append `|| true` to the three informational checks. (Re-running setup.sh already works around it, since an existing `bioinf` env short-circuits the whole block.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)