### PR TITLE
ci(delta): add bcftools to the neat4 env (NEAT needs it)

### DIFF
--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -62,12 +62,13 @@ setup_conda   # load the conda module + bootstrap `conda` (Delta: miniforge3-pyt
 if conda env list | grep -q "^${CONDA_ENV_NAME} "; then
     echo "[2/4] Conda env '$CONDA_ENV_NAME' already exists — skipping."
 else
-    # Install NEAT 4 from bioconda (the method NEAT's own README recommends):
-    # it pulls NEAT's conda-only runtime deps (e.g. bcftools), which a bare
-    # `pip install neat-genreads` into a python-only env would miss. No clone
-    # of the NEAT repo is needed. Only used by benchmark.sbatch.
+    # Install NEAT 4 from bioconda (the method NEAT's own README recommends),
+    # plus bcftools: NEAT shells out to `bcftools sort` at runtime (see its
+    # environment.yml, bcftools==1.22*), but the bioconda `neat` package does NOT
+    # pull it — without it NEAT dies with FileNotFoundError: 'bcftools'. Used by
+    # benchmark.sbatch (throughput) and germline_e2e.sbatch (NEAT fidelity arm).
     echo "[2/4] Creating conda env for NEAT 4 (bioconda)..."
-    conda create -y -n "$CONDA_ENV_NAME" -c conda-forge -c bioconda neat
+    conda create -y -n "$CONDA_ENV_NAME" -c conda-forge -c bioconda neat bcftools
     echo "      NEAT 4 installed: $(conda run -n "$CONDA_ENV_NAME" neat --version 2>&1 | head -1 || true)"
 fi
 


### PR DESCRIPTION
The NEAT arm of the germline fidelity comparison failed with `FileNotFoundError: 'bcftools'`. NEAT 4 shells out to `bcftools sort` at runtime (its `environment.yml` pins `bcftools==1.22*`), but the bioconda `neat` package doesn't pull bcftools, and NEAT runs via `conda run -n neat4` (isolated PATH). Add `bcftools` to the `neat4` env in setup.sh.

Immediate fix on an existing env: `conda install -n neat4 -c conda-forge -c bioconda bcftools`.

(rneat arm of the same run was fine — SNP recall/precision 0.99/0.99; indels pending #287.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)