### PR TITLE
fix: pad PE fragments so R2 deletions don't drop the pair (#287 regression)

### DIFF
--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -92,15 +92,20 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
     ad_counter: &mut AdCounter,
 ) -> Result<(), FastqToolsError> {
     debug!("writing reads for {}", sequence_block.contig);
-    // For SE reads, fragment_length == read_length exactly.  Sequencing-error deletions advance
-    // seq_index without writing bases, so the generation loop can exhaust the fragment before
-    // writing read_length bases, causing a TruncatedRead.  Fetching a small pad beyond `end`
-    // gives the loop extra reference bases to consume.  For PE, fragments are large relative to
-    // read_length so no padding is needed (and it would shift R2 coordinates).
+    // Pad the fetched fragment with extra reference beyond `end` so deletions
+    // (sequencing-error or literal-variant) near a read's tail have bases to
+    // consume instead of exhausting the buffer and raising TruncatedRead.
+    //   - SE: the single read can end with a deletion -> small tail pad.
+    //   - PE: R2 is generated FORWARD over the right-end window, which ends at
+    //     `end`, so a deletion in R2 needs reference *beyond* `end`. Without
+    //     this pad, any deletion in R2 truncated the read and dropped the whole
+    //     pair (~14% coverage loss at 30x). A read-length pad covers any literal
+    //     deletion (all < the SV threshold). The pad does NOT shift R2's
+    //     coordinates — the R2 window still starts at `end - effective_read_len`.
     let seq_len = sequence_block.sequence.len();
-    let se_pad = if paired_ended { 0 } else { 32 };
+    let frag_pad = if paired_ended { read_length } else { 32 };
     for (frag_idx, (start, end)) in block_fragments.into_iter().enumerate() {
-        let padded_end = (end + se_pad).min(seq_len);
+        let padded_end = (end + frag_pad).min(seq_len);
         let fragment = sequence_block.get_subseq(start, padded_end)?;
         // In long-read mode a fragment may be shorter than read_length; truncate the read
         // to the actual fragment length rather than discarding it.
@@ -218,8 +223,11 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
             // read. Applying VCF-anchored indels during a reverse walk mis-placed
             // them (insertion base order / deletion anchor), so reverse reads
             // carried garbled indels; forward-generate-then-flip avoids that.
-            let r2_sub: &[Nucleotide] = match fragment.len().checked_sub(effective_read_len) {
-                Some(s) => &fragment[s..],
+            // R2 window starts at (end - effective_read_len); since `fragment`
+            // is padded beyond `end`, &fragment[off..] is the window plus the
+            // deletion buffer (so R2 deletions don't truncate and drop the pair).
+            let r2_sub: &[Nucleotide] = match (end - start).checked_sub(effective_read_len) {
+                Some(off) => &fragment[off..],
                 // Fragment shorter than a read: skip the pair to avoid an
                 // orphaned R1 (matches the TruncatedRead handling below).
                 None => continue,


### PR DESCRIPTION
**Regression from #287.** Generating R2 forward over the right-end window (which ends at `end`) meant a deletion in an R2 read had no reference left to consume → `TruncatedRead` → the whole pair dropped. Measured **~14.5% read-pair loss** at 30× (458361 → 391732), which dropped cancer somatic **SNV recall 0.94 → 0.77** purely from lost coverage (while #287 correctly fixed indels: precision 0.065 → 0.52).

**Fix:** pad the fetched fragment `read_length` bases beyond `end` for PE (literal deletions are all < the SV threshold, so a read-length pad always covers them), and key the R2 sub-window at `end - effective_read_len` so the pad doesn't shift R2 coordinates. SE keeps its small tail pad.

**Verified** (ecoli 30×, bwa-mem2):
- read pairs **back to 458361** (was 391732)
- SNV alt strand balance **0.498** — #285 SNP fix intact
- indels **270 called vs 275 truth** — #287 indel fix intact
- full workspace suite green

After this, all three read-gen fixes (#285 SNP strand, #287 indel strand, this coverage restore) compose correctly: re-run cancer should show ~0.94 SNV recall AND good indel precision together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)