### PR TITLE
fix(delta): normalize indels before som.py scoring (-N)

### DIFF
--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -214,7 +214,14 @@ else
     echo "[6/6] Scoring with hap.py som.py (Apptainer)..."
     [[ -f "$HAPPY_SIF" ]] || { echo "hap.py SIF not found: $HAPPY_SIF — run setup.sh first" >&2; exit 1; }
 
+    # -N (--normalize-all) runs `bcftools norm` on BOTH truth and query before
+    # comparison — essential for indels: without it, a truth indel and Mutect2's
+    # call for the same event can be left-aligned to different positions and get
+    # double-counted as FN + FP, deflating indel recall AND precision. SNVs are
+    # unaffected. HGREF is set so som.py's reference lookup resolves (silences the
+    # "No reference file found" warning) in addition to the explicit -r.
     apptainer exec \
+        --env "HGREF=/refs/$REF_NAME" \
         --bind "$REF_DIR:/refs:ro" \
         --bind "$OUTDIR:/work" \
         "$HAPPY_SIF" \
@@ -223,6 +230,7 @@ else
             "/work/$(basename "$FILTERED_VCF")" \
             -r "/refs/$REF_NAME" \
             -o "/work/scored" \
+            -N \
             --feature-table generic
     echo "[6/6] Scoring complete."
 fi


### PR DESCRIPTION
som.py's normalization (`--normalize-truth`/`-query`/`-N`, runs `bcftools norm`) is **off by default** and the cancer `som.py` call omitted it. Indels are representation-dependent — a truth indel and Mutect2's call for the same event can left-align to different positions and be double-counted as FN + FP, deflating indel recall AND precision (SNVs unaffected, exact match). Add `-N` so both truth and query are normalized against the reference before comparison; also set `HGREF` so som.py's ref lookup resolves (silences the warning) alongside `-r`.

Measure on existing outputs (no re-run needed): re-score with `-N` and compare the indel row to the current 0.60/0.56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)