### PR TITLE
ci(delta): benchmark Phase A (head-to-head) + Phase B (rneat scaling)

### DIFF
--- a/scripts/delta/benchmark.sbatch
+++ b/scripts/delta/benchmark.sbatch
@@ -1,18 +1,23 @@
 #!/bin/bash
 # SLURM job: NEAT 4 (Python) vs rneat (Rust) throughput benchmark on Delta.
 #
-# Tests wall-clock time and peak RSS across thread counts 1→64 on multiple
-# genome sizes. Results land in $OUTDIR/median.tsv — one row per
-# (genome, threads, tool) combination.
+# Two phases (see config below):
+#   A. Head-to-head rneat vs NEAT 4 at 1 thread across genome sizes -> the
+#      "rneat is faster + uses less memory" claim (wall-clock + peak RSS).
+#   B. rneat-only thread-scaling sweep on a MULTI-CONTIG genome -> rneat's
+#      parallel speedup curve (NEAT's 1-thread time from A is the baseline).
 #
-# Mirrors tools/neat_vs_rneat_benchmark.sh but runs under SLURM on a full
-# 64-core Delta CPU node with proper module loading.
+# This replaces the old full (genomes x 8 threads x reps x 2 tools) cross
+# product, which redundantly swept threads on single-contig genomes (where
+# rneat can't parallelize) and ran NEAT at every thread count — that overran
+# the walltime. Results land in $OUTDIR/median.tsv (one row per genome/threads/
+# tool) and per_rep.tsv (raw).
 #
 # Usage:
 #   sbatch scripts/delta/benchmark.sbatch
-#
-# To override defaults without editing this file:
-#   OUTDIR=/path/to/out sbatch scripts/delta/benchmark.sbatch
+# Overrides (no edits needed):
+#   SCALING_GENOME=chrset:/path/multi.fa SCALING_THREAD_MODES="1 8 64" \
+#   REPS=2 sbatch scripts/delta/benchmark.sbatch
 
 #SBATCH --job-name=rneat-benchmark
 #SBATCH --partition=cpu
@@ -21,7 +26,10 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=128
 #SBATCH --mem=240G
-#SBATCH --time=08:00:00
+# Lean A/B design: ~3 genomes x 2 tools @ 1 thread + ~4 rneat scaling points.
+# Far smaller than the old cross-product; 6h is ample (NEAT at 1 thread is the
+# slowest single run, ~13 min/rep on chr22 at 10x).
+#SBATCH --time=06:00:00
 # Exclusive node: this is the headline rneat-vs-NEAT4 performance comparison, so
 # we want the whole node to ourselves — co-located jobs add noise to wall-clock
 # and memory-bandwidth measurements. (Justified only for the benchmark; the
@@ -44,17 +52,27 @@ CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
 RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
 CONDA_ENV_NAME="neat4"
 
-# Genomes to benchmark — label:fasta_path pairs. Smaller genomes run fast
-# and exercise single-thread performance; larger ones expose scaling behaviour.
-# The paths below assume you've staged the files into DATA_DIR.
+# PHASE A — head-to-head rneat vs NEAT 4 at a single thread count (HEADTOHEAD_THREADS)
+# across genome sizes. This is the core "rneat is faster + leaner" claim. We do
+# NOT sweep threads with both tools: most of these genomes are few-contig, and
+# rneat parallelizes per-contig (sub-contig chunking off by default), so a thread
+# sweep on a single-contig genome (e.g. chr22) is pure redundancy — every mode
+# returns the same number — and NEAT-at-every-thread-count is what blew the
+# 8h walltime. Missing files are skipped.
 GENOMES=(
-    "ecoli:$DATA_DIR/ecoli.fa"
-    "chr22:$DATA_DIR/chr22.fa"
-    "human:$DATA_DIR/GRCh38.fa"       # comment out if not staged
+    "ecoli:$DATA_DIR/ecoli.fa"        # single-contig, tiny
+    "yeast:$DATA_DIR/yeast.fa"        # MULTI-contig (~16) — also the Phase B genome
+    "chr22:$DATA_DIR/chr22.fa"        # single-contig, ~50 Mb
+    "human:$DATA_DIR/GRCh38.fa"       # multi-contig, large — staged only for a big run
 )
+HEADTOHEAD_THREADS="${HEADTOHEAD_THREADS:-1}"
 
-# Thread counts to test. 128 = full Delta CPU node; include 1 as the serial baseline.
-THREAD_MODES=(1 2 4 8 16 32 64 128)
+# PHASE B — rneat thread-scaling curve. Only meaningful on a MULTI-CONTIG genome
+# (rneat's unit of parallelism is the contig), so chr22 alone can't show scaling.
+# rneat only: NEAT 4's single-thread time from Phase A is the reference baseline;
+# sweeping NEAT across threads is the expensive, low-value part we're cutting.
+SCALING_GENOME="${SCALING_GENOME:-yeast:$DATA_DIR/yeast.fa}"
+SCALING_THREAD_MODES=(${SCALING_THREAD_MODES:-1 4 16 64 128})
 
 # Simulation parameters — must be identical between NEAT 4 and rneat for
 # a fair comparison.
@@ -144,17 +162,12 @@ run_one() {
         "$label" "$size_mb" "$nthreads" "$tool" "$wmed" "$rmed" "$ok" >> "$MEDIAN"
 }
 
-# ── Main loop ────────────────────────────────────────────────────────────
-for entry in "${GENOMES[@]}"; do
-    label="${entry%%:*}"
-    fasta="${entry#*:}"
-    [[ -f "$fasta" ]] || { echo "MISSING genome: $fasta — skipping"; continue; }
-
-    for nthreads in "${THREAD_MODES[@]}"; do
-        # rneat config
-        rneat_out="$OUTDIR/rneat_${label}_t${nthreads}"
-        rneat_cfg="$OUTDIR/rneat_${label}_t${nthreads}.yml"
-        cat > "$rneat_cfg" <<YAML
+# run_rneat / run_neat <label> <fasta> <nthreads>: write the tool's config and
+# time it. Factored out so Phase A and Phase B share one definition.
+run_rneat() {
+    local label="$1" fasta="$2" nthreads="$3"
+    local out="$OUTDIR/rneat_${label}_t${nthreads}" cfg="$OUTDIR/rneat_${label}_t${nthreads}.yml"
+    cat > "$cfg" <<YAML
 reference: $fasta
 read_len: $READ_LEN
 coverage: $COVERAGE
@@ -167,15 +180,16 @@ produce_bam: false
 overwrite_output: true
 rng_seed: delta benchmark seed
 num_threads: $nthreads
-output_dir: $rneat_out
+output_dir: $out
 output_filename: bench
 YAML
-        run_one "$label" "$fasta" "$nthreads" "rneat" "$rneat_cfg" "$rneat_out"
-
-        # NEAT 4 config (skip if binary not found)
-        if [[ -n "${NEAT_BIN:-}" ]]; then
-            neat_cfg="$OUTDIR/neat_${label}_t${nthreads}.yml"
-            cat > "$neat_cfg" <<YAML
+    run_one "$label" "$fasta" "$nthreads" "rneat" "$cfg" "$out"
+}
+run_neat() {
+    local label="$1" fasta="$2" nthreads="$3"
+    [[ -n "${NEAT_BIN:-}" ]] || { echo "  NEAT binary not found — skipping NEAT for $label"; return; }
+    local cfg="$OUTDIR/neat_${label}_t${nthreads}.yml"
+    cat > "$cfg" <<YAML
 reference: $fasta
 read_len: $READ_LEN
 coverage: $COVERAGE
@@ -189,11 +203,34 @@ rng_seed: 42
 threads: $nthreads
 overwrite_output: true
 YAML
-            run_one "$label" "$fasta" "$nthreads" "neat" "$neat_cfg" \
-                "$OUTDIR/neat_${label}_t${nthreads}"
-        fi
-    done
+    run_one "$label" "$fasta" "$nthreads" "neat" "$cfg" "$OUTDIR/neat_${label}_t${nthreads}"
+}
+
+# ── Phase A: head-to-head (rneat vs NEAT) at HEADTOHEAD_THREADS ───────────
+echo
+echo "=== Phase A: head-to-head @ ${HEADTOHEAD_THREADS} thread(s) ==="
+for entry in "${GENOMES[@]}"; do
+    label="${entry%%:*}"; fasta="${entry#*:}"
+    [[ -f "$fasta" ]] || { echo "MISSING genome: $fasta — skipping"; continue; }
+    run_rneat "$label" "$fasta" "$HEADTOHEAD_THREADS"
+    run_neat  "$label" "$fasta" "$HEADTOHEAD_THREADS"
 done
+
+# ── Phase B: rneat thread-scaling on a multi-contig genome ───────────────
+sc_label="${SCALING_GENOME%%:*}"; sc_fasta="${SCALING_GENOME#*:}"
+if [[ -f "$sc_fasta" ]]; then
+    echo
+    echo "=== Phase B: rneat thread-scaling on $sc_label (multi-contig) ==="
+    ncontigs=$(grep -c '^>' "$sc_fasta" 2>/dev/null || echo '?')
+    echo "    ($sc_label has $ncontigs contigs; rneat parallelizes per contig)"
+    for nthreads in "${SCALING_THREAD_MODES[@]}"; do
+        # Skip the threads value already measured in Phase A (no need to repeat).
+        [[ "$nthreads" == "$HEADTOHEAD_THREADS" ]] && continue
+        run_rneat "$sc_label" "$sc_fasta" "$nthreads"
+    done
+else
+    echo "Phase B skipped: scaling genome not staged ($sc_fasta)."
+fi
 
 echo
 echo "=== MEDIAN RESULTS (REPS=$REPS) ==="


### PR DESCRIPTION
The old benchmark (genomes × 8 threads × 3 reps × 2 tools) overran the 8h walltime: chr22 is single-contig so rneat can't parallelize on it → 7/8 thread modes were identical, and NEAT-at-every-thread was the cost killer. Only the chr22 single-thread head-to-head finished (rneat **3.0× faster, 6.8× less RAM** — that result stands).

Restructured into two targeted phases:
- **A — head-to-head** rneat vs NEAT 4 @ 1 thread across genomes → speed + RAM ratios.
- **B — rneat-only thread scaling** on a multi-contig genome (yeast, ~35 contigs) → scaling curve; NEAT's 1-thread time from A is the baseline.

Shared `run_rneat`/`run_neat` helpers; `SCALING_GENOME`/`SCALING_THREAD_MODES` overridable; walltime 8h→6h. Dry-run verified phase dispatch (missing genomes skip cleanly). **Needs yeast + ecoli staged in $SCRATCH/neat_data.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)