### PR TITLE
fix(delta): tune_sweep silently exited when allocator libs absent

### DIFF
--- a/scripts/delta/tune_sweep.sbatch
+++ b/scripts/delta/tune_sweep.sbatch
@@ -57,7 +57,10 @@ mkdir -p "$OUTDIR"
 [[ -f "$GFASTA" ]] || { echo "Genome not staged: $GFASTA" >&2; exit 1; }
 
 # ── Locate optional allocators (no-op variant if absent) ─────────────────
-find_so() { for p in "$@"; do [[ -f "$p" ]] && { echo "$p"; return; }; done; }
+# Always return 0: a non-zero return here would propagate through the bare
+# `MIMALLOC_SO=$(find_so ...)` assignment and trip `set -e` (silently exiting
+# the whole job before any output) whenever the allocator isn't installed.
+find_so() { local p; for p in "$@"; do [[ -e "$p" ]] && { printf '%s\n' "$p"; return 0; }; done; return 0; }
 CONDA_LIB="$(conda info --base 2>/dev/null)/envs/bioinf/lib"
 MIMALLOC_SO="${MIMALLOC_SO:-$(find_so "$CONDA_LIB"/libmimalloc.so* 2>/dev/null)}"
 JEMALLOC_SO="${JEMALLOC_SO:-$(find_so "$CONDA_LIB"/libjemalloc.so* 2>/dev/null)}"


### PR DESCRIPTION
tune_sweep died in ~8s with empty .out/.err (OUTDIR created, nothing else) — a `set -e` gotcha: `find_so` returned non-zero on no match, and the bare `MIMALLOC_SO=$(find_so ...)` assignment propagated it, exiting the whole job silently before any output. Triggers whenever mimalloc/jemalloc aren't installed in the env. Fix: `find_so` always `return 0`. Reproduced + verified the fix locally under `set -euo pipefail`.

Also: to actually exercise the allocator variants, mimalloc/jemalloc must be in the bioinf env — re-run `setup.sh` (now retrofits them, #293) or `conda install -n bioinf -c conda-forge mimalloc jemalloc`. Without them the sweep still runs baseline (+numactl) variants cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)