### PR TITLE
docs: ACCESS allocation report draft (Phase 1 + Phase 2/3 plan)

### DIFF
--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -1,0 +1,184 @@
+# Benchmarking rneat: Enhancing Performance of a Genome Sequencing Simulator for Cancer Genomics with Rust
+
+**ACCESS allocation report — DRAFT**
+Allocation: `bhrd-delta-cpu` (NCSA Delta). Core-hours used to date: ~2,500 of ~397,500.
+
+---
+
+## 1. Project summary
+
+`rneat` is a Rust port and extension of NEAT, a next-generation-sequencing read
+simulator. It generates FASTQ, a golden BAM, and a truth VCF whose statistical
+properties match real data, and it adds a native tumor/normal cancer workflow
+(`gen-cancer-reads`) with structural variants and an origin-tagged somatic truth
+set. This project used Delta to (1) verify rneat produces high-quality data on a
+small test set, (2) compare rneat to its predecessor NEAT 4 at scale on both
+performance and fidelity, and (3) validate the cancer workflow end-to-end through
+a real somatic-variant-calling pipeline.
+
+A central outcome is methodological: **benchmarking rneat against NEAT 4 and
+against GATK/Mutect2 surfaced — and we fixed — five real simulator defects** that
+unit tests had not caught. The verification process is itself a result.
+
+---
+
+## 2. Methods
+
+All runs on Delta CPU nodes (dual-socket AMD EPYC, 128 cores). Pipeline tools:
+BWA-MEM2 (alignment), GATK HaplotypeCaller (germline calling), GATK Mutect2 +
+FilterMutectCalls (somatic calling), hap.py / som.py (scoring against truth),
+NEAT 4.6.1 (reference simulator). Every run archives its result artifacts and
+SLURM resource usage (core-hours) to durable project storage; `collect_report.sh`
+aggregates them.
+
+Reference genomes: chr22 (GRCh38) for the verification tier; E. coli, yeast for
+performance scaling. Default 30× coverage, 151 bp paired-end, ploidy 2 unless
+noted.
+
+---
+
+## 3. Results (Phase 1 — complete)
+
+### 3.1 Simulator data quality (chr22, 30×)
+
+| Property | Result |
+|---|---|
+| Determinism (FASTQ + VCF, 1 vs 8 threads) | **byte-identical (PASS)** |
+| Mean coverage (covered bases) | 29.96× (requested 30×) |
+| Breadth | 0.77 (chr22 N-gaps correctly left uncovered) |
+| Heterozygous allele fraction | 0.486 (clean diploid binomial ~0.5) |
+| Ts/Tv | **2.35** (human-realistic) |
+
+Determinism holding byte-for-byte across thread counts is a guarantee NEAT 4 does
+not make.
+
+### 3.2 Performance vs NEAT 4 (single thread)
+
+| Genome | rneat wall | NEAT wall | **Speedup** | rneat RSS | NEAT RSS | **Memory** |
+|---|---|---|---|---|---|---|
+| E. coli (4.5 MB) | 33.0 s | 88.2 s | **2.7×** | 41 MB | 280 MB | **6.9×** |
+| yeast (11 MB) | 77.0 s | 214.7 s | **2.8×** | 53 MB | 172 MB | **3.2×** |
+| chr22 (49 MB) | 255.0 s | 749.0 s | **2.9×** | 227 MB | 1528 MB | **6.7×** |
+
+rneat is consistently ~2.7–2.9× faster and uses 3–7× less, flatter memory.
+
+**Multicore behavior (current default).** With its default per-contig
+parallelism, rneat does not gain from added threads on Delta's dual-socket EPYC —
+wall-clock is flat-to-slightly-higher with more threads (yeast: 1 thread 77 s →
+4 threads 110 s, plateau ~115 s), while on a single-socket machine it scales
+modestly (2 threads = 1.35×). rneat's single-thread efficiency, not thread
+scaling, is the source of its speed advantage. The behavior is consistent with
+memory-bandwidth saturation / allocator contention on NUMA hardware; Phase 2
+investigates whether code changes can recover multicore scaling, in which case
+these numbers will be revised.
+
+### 3.3 Germline fidelity vs NEAT 4 (chr22, 30×, identical pipeline)
+
+Caller recovery of each simulator's truth set through the same GATK pipeline:
+
+| | rneat SNP | NEAT SNP | rneat INDEL | NEAT INDEL |
+|---|---|---|---|---|
+| Recall | 0.989 | 0.989 | 0.982 | 0.969 |
+| Precision | 0.9996 | 0.991 | 0.989 | 0.972 |
+
+**Statistically equivalent**, with rneat marginally cleaner on precision. rneat
+faithfully reproduces NEAT 4's germline behavior.
+
+### 3.4 Cancer end-to-end (chr22, 30×, purity 0.6)
+
+Mutect2 tumor/normal recovery of rneat's somatic truth (after fixes + truth/query
+normalization):
+
+| | Recall | Precision |
+|---|---|---|
+| Somatic SNV | 0.925 | 0.872 |
+| Somatic indel | 0.900 | 0.844 |
+
+rneat's simulated tumor/normal data is recovered well by a standard somatic
+pipeline. **Scope:** SNV/indel only (Mutect2 does not call SVs), single
+purity/coverage point — both expanded in Phase 2.
+
+### 3.5 Defects found and fixed through verification
+
+Benchmarking surfaced five real bugs invisible to unit tests; each was diagnosed,
+fixed, and re-verified end-to-end:
+
+| # | Defect | Effect when fixed |
+|---|---|---|
+| #280 | Default mutation model near-random (uniform substitution matrix) | Ts/Tv 0.72 → 2.35 (NEAT parity) |
+| #285 | Alt alleles written only to forward-strand reads | somatic SNV recall 0.33 → 0.94 |
+| #287 | Indels garbled on reverse-strand reads | indel precision 0.07 → 0.49 (read-level) |
+| #289 | Coverage regression introduced by #287 (R2 deletion truncation) | restored −14.5% lost read pairs |
+| #290 | som.py indel normalization off by default (scoring) | cancer indel recall 0.60 → 0.90 |
+
+All affect every paired-end run, not just cancer. The somatic-SNV journey
+(0.33 → 0.94) and cancer-indel journey (0.20 → 0.90) trace the cumulative impact.
+
+---
+
+## 4. Phase 2 — robustness at scale (planned, key deliverables)
+
+Phase 1 established correctness and performance on a focused test set (chr22 and
+small genomes). Phase 2 closes the four gaps that Phase 1 deliberately did not
+cover, with an explicit goal of **avoiding over-tuning to chr22**: exercise rneat
+on substantial and *varied* inputs to confirm robustness and surface any
+remaining defects of the kind already found.
+
+1. **Whole-genome scale.** Run the full germline and cancer pipelines on GRCh38
+   (whole genome and large chromosome subsets), not just chr22. Confirms the
+   Phase 1 metrics hold at genome scale and that nothing was overfit to one
+   chromosome.
+
+2. **Multicore scaling / HPC tuning.** Resolve the thread regression so
+   whole-genome runs are fast (target: hours, not ~13 h single-threaded).
+   Isolation sweep (numactl × allocator × threads) to attribute the cause
+   (NUMA vs malloc contention), then reduce hot-loop allocations and/or enable
+   sub-contig chunking for large chromosomes, and chart the optimal full-genome
+   configuration.
+
+3. **Exercise the new cancer features deeply.** Validate structural-variant
+   realism downstream with SV-aware callers (Manta / Delly / GRIDSS), which the
+   SNV-focused Mutect2 path does not test. Exercise CNVs, BND/INV/INS, per-tissue
+   cancer models (BRCA / skin / lung), and the purity-mixing machinery — the
+   areas most likely to harbor bugs of the type found in Phase 1.
+
+4. **Input variety and parameter sweeps.** Run across a range of genome sizes and
+   compositions (bacterial, fungal, invertebrate, mammalian) and across cancer
+   parameters (purity, coverage, tumor mutation rate) to ensure rneat handles
+   diverse inputs rather than a single tuned case.
+
+---
+
+## 5. Phase 3 — stretch goals (time permitting)
+
+- **Long-read simulation.** Extend testing to long-read-style data
+  (longer fragments / single-molecule profiles) and validate against long-read
+  aligners/callers.
+- **Plant genomes and polyploidy.** Exercise large, repetitive plant genomes and
+  scope tuning for polyploid simulation (rneat's `ploidy` parameter and the
+  allele-dosage work tracked separately), where structural variation and high
+  copy number stress the simulator differently than human data.
+
+---
+
+## 6. Resource usage
+
+| | Core-hours |
+|---|---|
+| Documented production runs (9, archived) | **491** |
+| Total charged incl. exploratory / failed / timed-out runs | ~2,500 |
+| Remaining allocation | ~397,500 |
+
+The 9 archived production runs (3 baseline, 1 benchmark, 4 cancer, 1 germline)
+total 491 core-hours. The gap to the ~2,500 charged is dominated by a single
+timed-out benchmark that ran `--exclusive` (charging all 128 cores for 8 h ≈
+1,000 core-hours before being redesigned) plus failed/iterated runs during
+bug-fixing. Phase 1 was deliberately economical (chr22-scale); Phase 2's
+whole-genome runs and tuning sweeps are the primary consumers of the remaining
+allocation, where the binding constraint is per-run wall-clock, not core-hours.
+
+---
+
+_Run-level metrics and provenance for every job (version, git commit, reference,
+core-hours) are archived under the project results directory and assembled by
+`scripts/delta/collect_report.sh`._


### PR DESCRIPTION
Draft of the ACCESS final-report document at `docs/access_report_draft.md`: Phase 1 results, the five verification-found defects, Phase 2 plan (whole-genome, HPC tuning, deep cancer/SV validation, input variety), and Phase 3 stretch (long-read, plant/polyploidy). Core-hours from collect_report.sh. Living draft — will be revised as Phase 2 lands (e.g. multicore scaling if code changes recover it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)