### PR TITLE
fix(delta): report germline fidelity summaries + capture MaxRSS (sstat)

### DIFF
--- a/scripts/delta/collect_report.sh
+++ b/scripts/delta/collect_report.sh
@@ -36,7 +36,14 @@ mval() { awk -F'\t' -v k="$2" '$1==k{print $2; exit}' "$1"; }
         ver=$(mval "$m" rneat_version); gitd=$(mval "$m" git)
         ref=$(mval "$m" reference);     ch=$(mval "$m" core_hours)
         rss=$(mval "$m" maxrss_kb);     jid=$(mval "$m" slurm_job_id)
-        rss_gb=$(awk -v r="${rss:-0}" 'BEGIN{printf "%.2f", r/1048576}')
+        # sacct often fails to record MaxRSS on Delta (empty/0); show "—" rather
+        # than a misleading "0.00 GB". Per-tool memory is in the benchmark's
+        # median.tsv (peak_rss_mb, from /usr/bin/time).
+        if [[ "${rss:-0}" =~ ^0*$ || -z "${rss:-}" ]]; then
+            rss_gb="—"
+        else
+            rss_gb=$(awk -v r="$rss" 'BEGIN{printf "%.2f", r/1048576}')
+        fi
         echo "| $kind | $date | $ver | $gitd | $ref | ${ch:-0} | $rss_gb | $jid |"
         total_ch=$(awk -v t="$total_ch" -v c="${ch:-0}" 'BEGIN{printf "%.3f", t+c}')
     done
@@ -51,7 +58,9 @@ mval() { awk -F'\t' -v k="$2" '$1==k{print $2; exit}' "$1"; }
         echo
         echo "### $kind — job $jid"
         local_emitted=0
-        for art in baseline.json median.tsv scored.summary.csv scored.stats.csv het_af_histogram.tsv; do
+        for art in baseline.json median.tsv tune.tsv \
+                   rneat_scored.summary.csv neat_scored.summary.csv \
+                   scored.summary.csv scored.stats.csv het_af_histogram.tsv; do
             if [[ -f "$d/$art" ]]; then
                 echo
                 echo "<details><summary>\`$art\`</summary>"
@@ -71,6 +80,8 @@ mval() { awk -F'\t' -v k="$2" '$1==k{print $2; exit}' "$1"; }
 
     echo
     echo "---"
+    echo "_Max RSS via sstat/sacct (\"—\" = not recorded by Slurm accounting); the"
+    echo "benchmark's median.tsv carries per-tool peak RSS from /usr/bin/time._"
     echo "_Artifacts and SLURM logs for each run live under \`$RESULTS_DIR/<kind>/job_<id>/\`._"
 } > "$OUT"
 

--- a/scripts/delta/lib_report.sh
+++ b/scripts/delta/lib_report.sh
@@ -88,18 +88,27 @@ _resource_values() {
             --format=ElapsedRaw,AllocCPUS,AllocNodes 2>/dev/null \
         | head -1 | awk -F'|' '{print $1+0, $2+0, $3+0}')
     : "${elapsed:=0}"; : "${cpus:=0}"; : "${nodes:=0}"
-    # MaxRSS is reported on the .batch/.extern SUB-steps, not the alloc line, so
-    # scan all rows and take the max (normalize K/M/G/T suffix to KB).
-    local rss_kb
-    rss_kb=$(sacct -j "$jid" --noheader --parsable2 --format=MaxRSS 2>/dev/null | awk '
-        { v=$1; if (v=="") next
+    # MaxRSS (KB). archive_run is called at job END but while the job is still
+    # RUNNING, so sacct hasn't finalized the .batch step's MaxRSS yet -> it comes
+    # back empty (every Delta run reported 0). sstat reports a *running* step's
+    # live RSS, so try it first (.batch then .0), and fall back to sacct. awk
+    # normalizes the K/M/G/T suffix to KB and takes the max across rows.
+    local max_rss_awk='
+        { v=$1; if (v=="" || v=="-") next
           u=substr(v,length(v),1); n=v
           if      (u=="K") n=substr(v,1,length(v)-1)
           else if (u=="M") n=substr(v,1,length(v)-1)*1024
           else if (u=="G") n=substr(v,1,length(v)-1)*1048576
           else if (u=="T") n=substr(v,1,length(v)-1)*1073741824
           if (n+0>max) max=n+0 }
-        END { printf "%.0f", max+0 }')
+        END { printf "%.0f", max+0 }'
+    local rss_kb=0
+    if command -v sstat >/dev/null 2>&1; then
+        rss_kb=$(sstat -a -j "$jid" --noheader --parsable2 --format=MaxRSS 2>/dev/null | awk "$max_rss_awk")
+    fi
+    if [[ -z "$rss_kb" || "$rss_kb" == 0 ]]; then
+        rss_kb=$(sacct -j "$jid" --noheader --parsable2 --format=MaxRSS 2>/dev/null | awk "$max_rss_awk")
+    fi
     # Core-hours = elapsed_hours * allocated CPUs (≈ Delta CPU SUs).
     local core_hours
     core_hours=$(awk -v e="$elapsed" -v c="$cpus" 'BEGIN{printf "%.3f", (e/3600.0)*c}')


### PR DESCRIPTION
Two gaps the first REPORT.md run exposed:

1. **Germline fidelity missing** — `collect_report.sh` only inlined `scored.summary.csv`, but `germline_e2e` archives `rneat_scored.summary.csv`/`neat_scored.summary.csv`, so the rneat-vs-NEAT 4 headline (job 19467097) showed "no inlined artifacts" despite the data being archived. Added those + `tune.tsv` to the inline list.

2. **MaxRSS = 0 everywhere** — `archive_run` runs at job end but while the job is still *running*, so `sacct` hasn't finalized the `.batch` step's MaxRSS. Query `sstat` (live running-step RSS) first, fall back to `sacct`; future runs record real memory. Also render unrecorded RSS as `—` (not `0.00`) with a footnote pointing to the benchmark's `/usr/bin/time` RSS.

Verified locally: K/M/G/T→KB normalization + the `—` logic. Existing archived runs still show `—` (their RSS was never captured); re-running collect_report will now inline the germline comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)