### PR TITLE
ci(delta): triplicate support via job arrays (per-rep seeds)

### DIFF
--- a/scripts/delta/baseline_capture.sbatch
+++ b/scripts/delta/baseline_capture.sbatch
@@ -58,9 +58,12 @@ READ_LEN="${READ_LEN:-151}"
 FRAG_MEAN="${FRAG_MEAN:-350}"
 FRAG_SD="${FRAG_SD:-50}"
 PLOIDY="${PLOIDY:-2}"
-# Fixed seed string — determinism + the baseline both depend on this being
-# constant across runs/versions. Do not change between releases you compare.
-SEED="${SEED:-rneat delta baseline v1}"
+# Seed string — determinism + the baseline depend on this being constant across
+# runs/versions. When run as a job array (`sbatch --array=1-3`) for triplicate
+# replication, the array task id is appended so each replicate uses a distinct
+# seed (independent draw) while staying constant within a run; SLURM schedules
+# the tasks across (likely different) nodes. Plain submit → no suffix.
+SEED="${SEED:-rneat delta baseline v1}${SLURM_ARRAY_TASK_ID:+ rep$SLURM_ARRAY_TASK_ID}"
 # Two thread counts for the determinism check. Output must be content-identical.
 THREADS_A=1
 THREADS_B="${THREADS_B:-8}"

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -101,6 +101,10 @@ else
     echo "[1/6] Simulating tumor/normal reads..."
     PAIRED_FLAG=""
     [[ "$PAIRED" == "true" ]] && PAIRED_FLAG="--paired-ended --fragment-mean $FRAG_MEAN --fragment-st-dev $FRAG_SD"
+    # Under `sbatch --array=1-3` (triplicate), each replicate uses a distinct
+    # seed root (independent draw); SLURM spreads tasks across nodes. Plain
+    # submit uses the default root.
+    RNG_SEED_ROOT="${RNG_SEED_ROOT:-cancer-simulate}${SLURM_ARRAY_TASK_ID:+-rep$SLURM_ARRAY_TASK_ID}"
     bash "$REPO_ROOT/tools/cancer_simulate.sh" \
         --reference "$REFERENCE" \
         --output-prefix "$PREFIX" \
@@ -109,6 +113,7 @@ else
         --read-len "$READ_LEN" \
         --tumor-model "$TUMOR_MODEL" \
         --sv-rate-scale "$SV_RATE_SCALE" \
+        --rng-seed "$RNG_SEED_ROOT" \
         --rneat-bin "$RNEAT_BIN" \
         $PAIRED_FLAG
     echo "[1/6] Simulation complete."

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -47,6 +47,12 @@ source "$REPO_ROOT/scripts/delta/lib_report.sh"   # archive_run() + Delta path r
 REFERENCE="${REFERENCE:-$SCRATCH/neat_data/chr22.fa}"
 OUTDIR="${OUTDIR:-$SCRATCH/germline_$SLURM_JOB_ID}"
 TOOLS="${TOOLS:-rneat neat}"          # which simulators to run + score
+# Seeds. Under `sbatch --array=1-3` (triplicate), each replicate gets a distinct
+# seed (independent draw) and SLURM spreads tasks across nodes; plain submit uses
+# the base seeds.
+SEED="${SEED:-germline fidelity delta}${SLURM_ARRAY_TASK_ID:+ rep$SLURM_ARRAY_TASK_ID}"
+NEAT_SEED="${NEAT_SEED:-42}"
+[[ -n "${SLURM_ARRAY_TASK_ID:-}" ]] && NEAT_SEED=$((NEAT_SEED + SLURM_ARRAY_TASK_ID))
 
 COVERAGE="${COVERAGE:-30}"
 READ_LEN="${READ_LEN:-151}"
@@ -102,7 +108,7 @@ produce_bam: false
 overwrite_output: true
 output_dir: $wd
 output_filename: sample
-rng_seed: germline fidelity delta
+rng_seed: $SEED
 sv_rate_scale: 0
 num_threads: $THREADS
 YAML
@@ -124,7 +130,7 @@ fragment_st_dev: $FRAG_SD
 produce_fastq: true
 produce_vcf: true
 produce_bam: false
-rng_seed: 42
+rng_seed: $NEAT_SEED
 overwrite_output: true
 YAML
     conda run -n "$NEAT_ENV" neat read-simulator -c "$wd/sim.yml" -o "$wd" -p sample


### PR DESCRIPTION
Adds `sbatch --array=1-3` support to baseline/germline/cancer so Phase 1 runs in triplicate across (likely different) nodes — reproducibility + node-variance for the report.

**Different seed per replicate** (not same-seed): determinism is already proven (byte-identical across thread counts), so same-seed × 3 would give identical metrics by construction — only varying the seed adds information (shows metrics are robust to the random draw, not a lucky seed), while job-array scheduling also captures node variance. baseline/germline-rneat append ` repN` to the seed; germline-NEAT uses `42+N`; cancer uses rng root `cancer-simulate-repN`. Plain (non-array) submit unchanged; `set -u` safe.

Run: `sbatch --array=1-3 scripts/delta/baseline_capture.sbatch` (etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)