### PR TITLE
feat(delta): whole-genome simulation via region-sharded array jobs (#283)

### DIFF
--- a/scripts/delta/genome_array.sbatch
+++ b/scripts/delta/genome_array.sbatch
@@ -1,0 +1,101 @@
+#!/bin/bash
+# SLURM array job: sharded whole-genome simulation on Delta.
+#
+# Each array task simulates ONE genome window (shard_<taskid>.bed from
+# make_shard_beds.sh) with a SINGLE-THREADED rneat process. This is rneat's fast
+# path on Delta: in-process threading regresses on the dual-socket EPYC (memory-
+# bandwidth/allocator bound), but the work is embarrassingly parallel ACROSS
+# processes, and SLURM spreads array tasks over many nodes so each gets
+# independent memory bandwidth. Reads/variants come out in absolute genome
+# coordinates (target_bed is a generation-time filter), so merge_shards.sh
+# concatenates the per-shard outputs into a whole-genome dataset.
+#
+# Workflow:
+#   samtools faidx REF.fa
+#   N=$(bash scripts/delta/make_shard_beds.sh REF.fa.fai 25000000 $SCRATCH/shards)
+#   SHARD_DIR=$SCRATCH/shards OUTROOT=$SCRATCH/wg_$(date +%s) REFERENCE=REF.fa \
+#     sbatch --array=0-$((N-1))%64 scripts/delta/genome_array.sbatch
+#   # then, after the array finishes:
+#   SHARD_OUTROOT=<OUTROOT> bash scripts/delta/merge_shards.sh
+#
+# The `%64` throttle caps concurrently-running tasks (tune to balance node
+# spread vs. per-node memory-bandwidth contention — see the procs-per-node note).
+#
+# cpus-per-task here is the packing knob, NOT parallelism (rneat runs 1 thread):
+# a few cores + the mem request limit how many shards co-reside on a node, which
+# governs per-node bandwidth contention. 4 cpus / 16 GB → ~15 shards/node.
+# The bandwidth-optimal value is what the procs-per-node sweep determines.
+
+#SBATCH --job-name=rneat-wgshard
+#SBATCH --partition=cpu
+#SBATCH --account=bhrd-delta-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16G
+#SBATCH --time=08:00:00
+#SBATCH --output=%x_%A_%a.out
+#SBATCH --error=%x_%A_%a.err
+
+set -euo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH resolution
+
+REFERENCE="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
+SHARD_DIR="${SHARD_DIR:-$SCRATCH/shards}"
+OUTROOT="${OUTROOT:-$SCRATCH/wg_$SLURM_ARRAY_JOB_ID}"
+COVERAGE="${COVERAGE:-30}"
+READ_LEN="${READ_LEN:-151}"
+FRAG_MEAN="${FRAG_MEAN:-350}"
+FRAG_SD="${FRAG_SD:-50}"
+PLOIDY="${PLOIDY:-2}"
+SV_RATE_SCALE="${SV_RATE_SCALE:-0}"        # germline-style by default; >0 for SVs
+SEED_ROOT="${SEED_ROOT:-rneat wg shard}"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
+RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
+
+source "$HOME/.cargo/env" 2>/dev/null || true
+
+TASK="${SLURM_ARRAY_TASK_ID:?this script must be submitted with --array}"
+BED="$(printf '%s/shard_%04d.bed' "$SHARD_DIR" "$TASK")"
+[[ -f "$BED" ]] || { echo "shard BED not found: $BED" >&2; exit 1; }
+[[ -f "$REFERENCE" ]] || { echo "reference not found: $REFERENCE" >&2; exit 1; }
+
+OUTDIR="$OUTROOT/shard_$(printf '%04d' "$TASK")"
+mkdir -p "$OUTDIR"
+
+# Idempotent: skip a shard whose outputs already exist (cheap re-submit of a
+# partially-completed array).
+if [[ -f "$OUTDIR/s_r1.fastq.gz" && -f "$OUTDIR/s.vcf.gz" ]]; then
+    echo "shard $TASK already done — skipping."
+    exit 0
+fi
+
+echo "=== wg shard $TASK : $(cat "$BED") ==="
+echo "ref=$REFERENCE  cov=${COVERAGE}x  sv_rate_scale=$SV_RATE_SCALE  out=$OUTDIR"
+
+# Single-thread (fastest per-process on Delta); per-shard distinct seed so the
+# shards are independent draws. target_bed restricts generation to this window.
+cat > "$OUTDIR/sim.yml" <<YAML
+reference: $REFERENCE
+read_len: $READ_LEN
+coverage: $COVERAGE
+ploidy: $PLOIDY
+paired_ended: true
+fragment_mean: $FRAG_MEAN
+fragment_st_dev: $FRAG_SD
+produce_fastq: true
+produce_vcf: true
+produce_bam: false
+overwrite_output: true
+output_dir: $OUTDIR
+output_filename: s
+rng_seed: $SEED_ROOT $TASK
+sv_rate_scale: $SV_RATE_SCALE
+target_bed: $BED
+num_threads: 1
+YAML
+
+/usr/bin/time -v -o "$OUTDIR/time.txt" "$RNEAT_BIN" gen-reads -c "$OUTDIR/sim.yml"
+echo "shard $TASK complete: $(grep -m1 'Elapsed' "$OUTDIR/time.txt" 2>/dev/null || true)"

--- a/scripts/delta/make_shard_beds.sh
+++ b/scripts/delta/make_shard_beds.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Partition a reference genome into anchor-windows for sharded simulation.
+#
+# Writes one BED per shard (shard_0000.bed, shard_0001.bed, …) into OUTDIR, each
+# a contiguous window of the genome (large contigs split at SHARD_BP boundaries).
+# Prints the shard COUNT to stdout — feed it to `sbatch --array=0-$((N-1))`.
+#
+# rneat's target_bed restricts read GENERATION to these regions in ABSOLUTE
+# reference coordinates and anchors each fragment in exactly one window (reads
+# may extend past the window edge; ownership is by anchor), so the union of all
+# shards reconstructs a whole-genome run with no double-counting or gaps — and
+# outputs merge by simple concatenation (read names carry contig+coords).
+#
+# Usage:
+#   bash scripts/delta/make_shard_beds.sh REF.fa.fai [SHARD_BP] OUTDIR
+#   N=$(bash scripts/delta/make_shard_beds.sh $SCRATCH/neat_data/GRCh38.fa.fai 25000000 $SCRATCH/shards)
+#   sbatch --array=0-$((N-1)) ... scripts/delta/genome_array.sbatch
+#
+# SHARD_BP default 25,000,000 (25 Mb) → ~124 shards for GRCh38 primary assembly.
+
+set -euo pipefail
+
+FAI="${1:?usage: make_shard_beds.sh REF.fa.fai [SHARD_BP] OUTDIR}"
+SHARD_BP="${2:-25000000}"
+OUTDIR="${3:?need OUTDIR}"
+[[ -f "$FAI" ]] || { echo "fai not found: $FAI (run: samtools faidx REF.fa)" >&2; exit 1; }
+
+mkdir -p "$OUTDIR"
+rm -f "$OUTDIR"/shard_*.bed
+
+idx=0
+# fai columns: name<TAB>length<TAB>offset<TAB>linebases<TAB>linewidth
+while IFS=$'\t' read -r name len _rest; do
+    [[ -n "$name" && "$len" =~ ^[0-9]+$ ]] || continue
+    start=0
+    while (( start < len )); do
+        end=$(( start + SHARD_BP )); (( end > len )) && end="$len"
+        printf '%s\t%d\t%d\n' "$name" "$start" "$end" \
+            > "$(printf '%s/shard_%04d.bed' "$OUTDIR" "$idx")"   # BED: 0-based, half-open
+        idx=$(( idx + 1 ))
+        start="$end"
+    done
+done < "$FAI"
+
+echo "$idx"   # shard count → use as `--array=0-$((idx-1))`

--- a/scripts/delta/merge_shards.sh
+++ b/scripts/delta/merge_shards.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Merge sharded whole-genome simulation outputs into one dataset.
+#
+# After the genome_array.sbatch array finishes, concatenates the per-shard
+# outputs under SHARD_OUTROOT into whole-genome FASTQ + truth VCF:
+#   - FASTQ: raw concat (gzip members concatenate; read names carry contig+coords
+#            and shards are disjoint, so names are globally unique — no rename).
+#   - VCF:   bcftools concat (disjoint, ordered shards) then sort, bgzip, index.
+#
+# Run on a login node or as a dependent job (sbatch --dependency=afterok:<arrayjobid>).
+# Needs bcftools (bioinf env). Verifies every expected shard is present first.
+#
+# Usage:
+#   SHARD_OUTROOT=$SCRATCH/wg_<arrayjobid> bash scripts/delta/merge_shards.sh
+#   (optional) OUT_PREFIX=$SCRATCH/wg_<id>/merged  EXPECT_SHARDS=<N>
+
+set -euo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-$(cd "$(dirname "$0")/../.." && pwd)}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH + setup_conda/conda_activate
+
+SHARD_OUTROOT="${SHARD_OUTROOT:?set SHARD_OUTROOT to the array OUTROOT (e.g. \$SCRATCH/wg_<jobid>)}"
+OUT_PREFIX="${OUT_PREFIX:-$SHARD_OUTROOT/merged}"
+
+setup_conda
+conda_activate bioinf   # bcftools
+
+mapfile -t SHARDS < <(find "$SHARD_OUTROOT" -maxdepth 1 -type d -name 'shard_*' | sort)
+[[ "${#SHARDS[@]}" -gt 0 ]] || { echo "no shard_* dirs under $SHARD_OUTROOT" >&2; exit 1; }
+echo "Found ${#SHARDS[@]} shard dirs under $SHARD_OUTROOT"
+
+# Completeness check: every shard must have both outputs, and the count must
+# match EXPECT_SHARDS if given (catches a partially-failed array before merge).
+missing=0
+r1_list=(); vcf_list=()
+for d in "${SHARDS[@]}"; do
+    if [[ -f "$d/s_r1.fastq.gz" && -f "$d/s_r2.fastq.gz" && -f "$d/s.vcf.gz" ]]; then
+        r1_list+=("$d/s_r1.fastq.gz"); vcf_list+=("$d/s.vcf.gz")
+    else
+        echo "  INCOMPLETE: $d" >&2; missing=$(( missing + 1 ))
+    fi
+done
+if (( missing > 0 )); then
+    echo "ERROR: $missing shard(s) incomplete — rerun those array tasks before merging." >&2
+    exit 1
+fi
+if [[ -n "${EXPECT_SHARDS:-}" && "${#SHARDS[@]}" -ne "$EXPECT_SHARDS" ]]; then
+    echo "ERROR: found ${#SHARDS[@]} shards, expected $EXPECT_SHARDS." >&2
+    exit 1
+fi
+
+echo "[1/2] Concatenating FASTQ (${#r1_list[@]} shards)..."
+cat "${r1_list[@]}"                         > "${OUT_PREFIX}_r1.fastq.gz"
+cat "${SHARDS[@]/%//s_r2.fastq.gz}"         > "${OUT_PREFIX}_r2.fastq.gz"
+
+echo "[2/2] Concatenating + sorting truth VCF..."
+for v in "${vcf_list[@]}"; do [[ -f "$v.tbi" || -f "$v.csi" ]] || bcftools index -f -t "$v"; done
+# concat (disjoint regions) → sort → bgzip → index. -a allows any order.
+bcftools concat -a -Ou "${vcf_list[@]}" \
+    | bcftools sort -Oz -o "${OUT_PREFIX}.vcf.gz"
+bcftools index -f -t "${OUT_PREFIX}.vcf.gz"
+
+reads=$(( $(zcat "${OUT_PREFIX}_r1.fastq.gz" | wc -l) / 4 ))
+vars=$(bcftools view -H "${OUT_PREFIX}.vcf.gz" | wc -l)
+echo
+echo "════════════════════════════════════════════════════════════════"
+echo "Merged whole-genome dataset:"
+echo "  ${OUT_PREFIX}_r1.fastq.gz / _r2.fastq.gz   ($reads read pairs)"
+echo "  ${OUT_PREFIX}.vcf.gz                        ($vars truth variants)"
+echo "════════════════════════════════════════════════════════════════"

--- a/scripts/delta/tune_procs_per_node.sbatch
+++ b/scripts/delta/tune_procs_per_node.sbatch
@@ -1,0 +1,118 @@
+#!/bin/bash
+# SLURM job: how many single-thread rneat processes saturate ONE Delta node?
+#
+# The whole-genome strategy is region-sharding (genome_array.sbatch): many
+# single-thread rneat processes, since in-process threading regresses on the
+# dual-socket EPYC. The open knob is how many shards to pack per node — too few
+# wastes cores, too many saturates per-node memory bandwidth (the bottleneck).
+#
+# This launches K identical single-thread rneat processes CONCURRENTLY on one
+# exclusive node for K in PROC_COUNTS, and measures aggregate throughput
+# (K / makespan) and per-process slowdown. Throughput climbs with K, then
+# plateaus/drops at the bandwidth wall — the peak is the optimal shards/node,
+# which maps to genome_array's cpus-per-task (= 128/K_opt) and %throttle.
+#
+# Per-process work is one full GENOME at COVERAGE (a stand-in for a shard);
+# outputs go to node-local /tmp (740 GB SSD) so the measurement reflects
+# CPU/memory bandwidth, not Lustre I/O.
+#
+# Prereqs: setup.sh (rneat built); GENOME staged.
+# Usage:
+#   sbatch scripts/delta/tune_procs_per_node.sbatch
+#   GENOME=$SCRATCH/neat_data/ecoli.fa COVERAGE=30 PROC_COUNTS="1 2 4 8 16 32 64 128" \
+#     sbatch scripts/delta/tune_procs_per_node.sbatch
+
+#SBATCH --job-name=rneat-ppn
+#SBATCH --partition=cpu
+#SBATCH --account=bhrd-delta-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=128
+#SBATCH --mem=240G
+#SBATCH --time=04:00:00
+#SBATCH --exclusive
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"
+
+GENOME="${GENOME:-$SCRATCH/neat_data/ecoli.fa}"     # per-process workload (a shard stand-in)
+COVERAGE="${COVERAGE:-30}"
+READ_LEN="${READ_LEN:-151}"
+PROC_COUNTS="${PROC_COUNTS:-1 2 4 8 16 32 64 128}"
+OUTDIR="${OUTDIR:-$SCRATCH/ppn_$SLURM_JOB_ID}"
+WORK="${WORK_LOCAL:-/tmp/ppn_$SLURM_JOB_ID}"        # node-local SSD for per-proc output
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
+RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
+
+source "$HOME/.cargo/env" 2>/dev/null || true
+mkdir -p "$OUTDIR" "$WORK"
+[[ -f "$GENOME" ]] || { echo "genome not staged: $GENOME" >&2; exit 1; }
+
+echo "=== procs-per-node sweep: $SLURM_JOB_ID ==="
+echo "Genome: $GENOME  ${COVERAGE}x   K values: $PROC_COUNTS"
+echo "Per-proc output on node-local: $WORK"
+
+TSV="$OUTDIR/ppn.tsv"
+printf "procs\tmakespan_s\tproc_median_s\tthroughput_per_s\tefficiency_pct\n" > "$TSV"
+
+# median of integer/float args via sort (no gawk asort dependency)
+median() { printf '%s\n' "$@" | sort -n | awk '{v[NR]=$1} END{ if(NR==0){print 0;exit}
+    print (NR%2)?v[(NR+1)/2]:(v[NR/2]+v[NR/2+1])/2 }'; }
+
+t1=""   # single-process makespan baseline (for efficiency)
+for K in $PROC_COUNTS; do
+    rm -rf "$WORK"/*
+    echo "── K=$K concurrent single-thread processes ──"
+    start=$SECONDS
+    for i in $(seq 1 "$K"); do
+        d="$WORK/p$i"; mkdir -p "$d"
+        cat > "$d/sim.yml" <<YAML
+reference: $GENOME
+read_len: $READ_LEN
+coverage: $COVERAGE
+ploidy: 2
+paired_ended: true
+fragment_mean: 350
+fragment_st_dev: 50
+produce_fastq: true
+produce_vcf: false
+produce_bam: false
+overwrite_output: true
+output_dir: $d
+output_filename: s
+rng_seed: ppn $K $i
+num_threads: 1
+YAML
+        # /usr/bin/time per process → per-proc elapsed; run in background.
+        ( /usr/bin/time -f '%e' -o "$d/t" "$RNEAT_BIN" gen-reads -c "$d/sim.yml" >/dev/null 2>"$d/log" ) &
+    done
+    wait
+    makespan=$(( SECONDS - start ))
+    [[ -z "$t1" ]] && t1="$makespan"
+
+    walls=(); for i in $(seq 1 "$K"); do
+        w=$(cat "$WORK/p$i/t" 2>/dev/null || echo 0); walls+=("$w")
+    done
+    pmed=$(median "${walls[@]}")
+    # throughput = jobs completed per second; efficiency = K=1 makespan / this makespan.
+    thru=$(awk -v k="$K" -v m="$makespan" 'BEGIN{printf "%.4f", (m>0)? k/m : 0}')
+    eff=$(awk -v t="$t1" -v m="$makespan" 'BEGIN{printf "%.1f", (m>0)? 100*t/m : 0}')
+    printf "%s\t%s\t%s\t%s\t%s\n" "$K" "$makespan" "$pmed" "$thru" "$eff" >> "$TSV"
+    echo "   makespan=${makespan}s  proc_median=${pmed}s  throughput=${thru}/s  efficiency=${eff}%"
+done
+
+echo
+echo "=== PROCS-PER-NODE RESULTS ($(basename "$GENOME") ${COVERAGE}x) ==="
+column -t -s "$(printf '\t')" "$TSV"
+echo
+# Optimal K = max throughput (the bandwidth-saturation knee).
+best=$(awk -F'\t' 'NR>1 && $4>mx{mx=$4; k=$1} END{print k}' "$TSV")
+echo "Peak aggregate throughput at K=$best processes/node."
+echo "→ genome_array.sbatch: set --cpus-per-task=$(( 128 / (best>0?best:1) )) (≈$best shards/node), or throttle the array with %$best per node-equivalent."
+
+rm -rf "$WORK"
+archive_run ppn "$OUTDIR" ppn.tsv


### PR DESCRIPTION
The parallel track for fast whole-genome runs. rneat's in-process threading regresses on Delta's dual-socket EPYC, but read-gen is embarrassingly parallel across **processes** — so run a genome as many single-threaded rneat processes (one per window) spread across nodes by a SLURM array, each with independent memory bandwidth (the per-node bottleneck).

- **`make_shard_beds.sh`** — partition `REF.fai` into anchor-windows (one BED/shard), prints count for `--array=0-N`.
- **`genome_array.sbatch`** — each task runs rneat single-threaded with `target_bed`=its window. Verified in `runner.rs`: target_bed is a generation-time filter in **absolute coords** that anchors each fragment in exactly one window → shards reconstruct a full run with no double-count/gaps. Idempotent per shard; cpus/mem = per-node packing knob; `%N` array throttle = node-spread knob.
- **`merge_shards.sh`** — completeness-checks, then `cat` FASTQ (read names carry contig+coords → globally unique) + `bcftools concat|sort` VCF.

**Validated locally** (ecoli, 4×1.5 Mb windows): anchors land cleanly in each window (disjoint, covering); merge → 458,363 pairs (= sum, **0 dup names**), 5,064 variants (**sorted**, spans contig), ≈ the single-run 30× count. No rneat code change.

Closes #283 (mechanism); the per-node packing optimum (`cpus-per-task`/`%N`) is refined by the procs-per-node sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)