### PR TITLE
ci(delta): set genome_array packing default from procs-per-node sweep

### DIFF
--- a/scripts/delta/genome_array.sbatch
+++ b/scripts/delta/genome_array.sbatch
@@ -31,7 +31,16 @@
 #SBATCH --account=bhrd-delta-cpu
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=4
+# cpus-per-task is the per-node PACKING knob (rneat runs 1 thread); SLURM packs
+# ~128/cpus-per-task shards onto a shared node. The procs-per-node sweep
+# (tune_procs_per_node.sbatch) found per-node aggregate throughput plateaus near
+# 32-64 procs but per-process efficiency craters there (5-11%); the efficient
+# zone is ≤8 procs/node (≥29% eff, each shard near full speed). With a
+# core-hour-rich budget and minimum-wall-clock the goal, pack LIGHT and spread
+# across many nodes: 16 → ~8 shards/node (each ~29% eff). Lower it (→ more
+# shards/node, fewer nodes, cheaper) or raise it (→ fewer/node, faster per shard,
+# more nodes) per your node availability.
+#SBATCH --cpus-per-task=16
 #SBATCH --mem=16G
 #SBATCH --time=08:00:00
 #SBATCH --output=%x_%A_%a.out


### PR DESCRIPTION
The procs-per-node sweep settled the shards-per-node knob. Delta (ecoli 30×): single-thread **processes scale ~3.5× from 1→64/node** (0.0118→0.0409 jobs/s) — opposite of threads, which regress immediately — so multi-process sharding is rneat's HPC parallelism model. Per-process efficiency craters in the high-K zone (K=2 60%, K=8 29%, K=32 11%, K=64 5%); throughput plateaus ~32–64.

Bump `genome_array` `cpus-per-task` 4→16 (≈8 shards/node, ~29% eff, each shard near full speed). Prior default packed ~32/node (11% eff). Knob + tradeoff documented inline. GRCh38 (~124×25 Mb shards) projects to **~20–26 min** wall-clock vs **~16 h** single-thread serial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)