### PR TITLE
perf: zero-copy fragment in read-gen hot loop (get_subseq_slice)

### DIFF
--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -106,7 +106,10 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
     let frag_pad = if paired_ended { read_length } else { 32 };
     for (frag_idx, (start, end)) in block_fragments.into_iter().enumerate() {
         let padded_end = (end + frag_pad).min(seq_len);
-        let fragment = sequence_block.get_subseq(start, padded_end)?;
+        // Zero-copy: the fragment is only read (R1 reads it, R2 reads a suffix),
+        // never stored or mutated, so borrow it instead of allocating + copying
+        // a Vec per fragment. Borrows sequence_block for the iteration.
+        let fragment = sequence_block.get_subseq_slice(start, padded_end)?;
         // In long-read mode a fragment may be shorter than read_length; truncate the read
         // to the actual fragment length rather than discarding it.
         let effective_read_len = if long_reads {
@@ -179,7 +182,7 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
         let quality_scores_1 =
             quality_score_model.generate_quality_scores(effective_read_len, rng)?;
         let r1_record = match generate_read(
-            &fragment,
+            fragment,
             &reads1_flagged,
             &read1_variants,
             effective_read_len,

--- a/common/src/structs/sequence_block.rs
+++ b/common/src/structs/sequence_block.rs
@@ -59,11 +59,15 @@ impl SequenceBlock {
         self.ref_end - self.ref_start
     }
 
-    pub fn get_subseq(
+    /// Borrowed view of a sub-sequence — zero-copy. Preferred in the read-gen
+    /// hot loop, where the fragment is only read (not stored/mutated): avoids a
+    /// per-fragment heap allocation + copy. `get_subseq` delegates here for
+    /// callers that need an owned Vec.
+    pub fn get_subseq_slice(
         &self,
         request_start: usize,
         request_end: usize,
-    ) -> Result<Vec<Nucleotide>, SequenceBlockError> {
+    ) -> Result<&[Nucleotide], SequenceBlockError> {
         let block_start = request_start + self.ref_start;
         let block_end = request_end + self.ref_start;
         if request_start >= request_end {
@@ -84,7 +88,15 @@ impl SequenceBlock {
             );
             return Err(SequenceBlockError::OutOfBoundsError);
         }
-        Ok(self.sequence[request_start..request_end].to_owned())
+        Ok(&self.sequence[request_start..request_end])
+    }
+
+    pub fn get_subseq(
+        &self,
+        request_start: usize,
+        request_end: usize,
+    ) -> Result<Vec<Nucleotide>, SequenceBlockError> {
+        Ok(self.get_subseq_slice(request_start, request_end)?.to_owned())
     }
 }
 


### PR DESCRIPTION
Per-fragment `get_subseq().to_owned()` allocated + copied a Vec for every fragment, but the fragment is only **read** (R1 reads it, R2 reads a suffix) — never stored or mutated. Add `get_subseq_slice` → borrowed `&[Nucleotide]` (same validation; `get_subseq` delegates for owned-Vec callers) and use it in `write_block_fastq`, eliminating the alloc+copy.

**Byte-identical** (ecoli 30× same-seed FASTQ `85b5be09…` / VCF `18275424…` match pre-change); full suite green (340 common tests). Single-thread **39.9→38.7s (~3%)**, on top of #299's ~3–4% (~6–7% cumulative).

This is the single-thread lever from the scaling analysis: each sharded whole-genome worker runs single-threaded on a (slow) Delta core, so per-read savings compound across the genome. The remaining per-read allocations (contig `Arc<str>`, quality-buffer reuse) are wider/riskier surface for diminishing returns — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)