### PR TITLE
feat(delta): optional SHUFFLE flag in germline_e2e (read-order randomization)

### DIFF
--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -201,6 +201,16 @@ remaining defects of the kind already found.
    parameters (purity, coverage, tumor mutation rate) to ensure rneat handles
    diverse inputs rather than a single tuned case.
 
+5. **Simulation-only timing for the community.** Benchmark *just the rneat
+   simulation stage* (FASTQ + truth VCF generation, no downstream alignment or
+   variant calling) across genome sizes, coverages, and the sharded whole-genome
+   configuration, to publish concrete real-world wall-clock / throughput numbers
+   users can plan around (e.g. "whole human genome at 30× in N minutes on K
+   nodes"). This isolates the simulator's own performance — rneat's core
+   contribution — from pipeline overhead, and is the headline deliverable for
+   communicating rneat's HPC performance to the community. (The sharded GRCh38
+   run in item 2 is the first such measurement at whole-genome scale.)
+
 ---
 
 ## 5. Phase 3 — stretch goals (time permitting)

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -23,7 +23,10 @@
 # Usage:
 #   sbatch scripts/delta/germline_e2e.sbatch
 #   REFERENCE=/path/ref.fa COVERAGE=30 TOOLS="rneat neat" sbatch scripts/delta/germline_e2e.sbatch
-#   TOOLS=rneat sbatch ...   # rneat only (skip the NEAT 4 arm)
+#   TOOLS=rneat sbatch ...        # rneat only (skip the NEAT 4 arm)
+#   SHUFFLE=1 TOOLS=rneat sbatch ...   # randomize read order before alignment
+#       (off by default; run once shuffled vs unshuffled to confirm the caller
+#        is read-order-independent — same recall expected)
 
 #SBATCH --job-name=rneat-germline
 #SBATCH --partition=cpu
@@ -58,6 +61,12 @@ COVERAGE="${COVERAGE:-30}"
 READ_LEN="${READ_LEN:-151}"
 FRAG_MEAN="${FRAG_MEAN:-350}"
 FRAG_SD="${FRAG_SD:-50}"
+# Read-order randomization before alignment (off by default). rneat/NEAT emit
+# reads in genome order; SHUFFLE=1 randomizes (seqkit, paired) to mimic real
+# sequencer output and to demonstrate the caller is order-independent. Needs
+# seqkit in the bioinf env (setup.sh installs it).
+SHUFFLE="${SHUFFLE:-0}"
+SHUFFLE_SEED="${SHUFFLE_SEED:-11}"
 
 HAPPY_SIF="${HAPPY_SIF:-$SCRATCH/sif/happy_v0.3.12.sif}"
 NEAT_ENV="${NEAT_ENV:-neat4}"         # conda env with NEAT 4
@@ -202,6 +211,26 @@ for tool in $TOOLS; do
             ;;
         *) echo "  unknown tool '$tool' — skipping." >&2; continue ;;
     esac
+
+    # Optional read-order randomization (SHUFFLE=1; off by default). rneat (and
+    # NEAT) write reads in genome-coordinate order, whereas a real sequencer's
+    # FASTQ is in arbitrary order. The caller is order-independent (the BAM is
+    # coordinate-sorted before calling, no order-based dup-marking), so this does
+    # not change recall in principle — the flag exists to *demonstrate* that
+    # (shuffled vs unshuffled diff) and to better mimic real input. seqkit's
+    # per-index permutation with a fixed seed shuffles R1/R2 identically, keeping
+    # mates in register.
+    if [[ "$SHUFFLE" == "1" ]]; then
+        sh1="$wd/shuf_r1.fastq.gz"; sh2="$wd/shuf_r2.fastq.gz"
+        if [[ -f "$sh1" && -f "$sh2" ]]; then
+            echo "  [$tool shuffle] shuffled FASTQ present — skipping."
+        else
+            echo "  [$tool shuffle] randomizing read order (seqkit, paired)..."
+            seqkit shuffle -s "$SHUFFLE_SEED" -o "$sh1" "$r1"
+            seqkit shuffle -s "$SHUFFLE_SEED" -o "$sh2" "$r2"
+        fi
+        r1="$sh1"; r2="$sh2"
+    fi
 
     align_call_score "$tool" "$wd" "$r1" "$r2" "$truth"
     # Stage the summary at the top level with a tool tag for the report.

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -84,14 +84,16 @@ echo "             $(conda run -n "$CONDA_ENV_NAME" bcftools --version 2>/dev/nu
 # via LD_PRELOAD to isolate allocator lock contention on Delta's EPYC); numactl
 # (a system tool on Delta) covers the NUMA lever. Harmless extras in this env.
 if conda env list | grep -q "^${BIOINF_ENV_NAME} "; then
-    echo "[3/4] Conda env '$BIOINF_ENV_NAME' exists — ensuring tuning allocators present..."
+    echo "[3/4] Conda env '$BIOINF_ENV_NAME' exists — ensuring tuning allocators + seqkit present..."
     conda run -n "$BIOINF_ENV_NAME" sh -c 'ls "$CONDA_PREFIX"/lib/libmimalloc.so* >/dev/null 2>&1' \
         || conda install -y -n "$BIOINF_ENV_NAME" -c conda-forge mimalloc jemalloc
+    conda run -n "$BIOINF_ENV_NAME" which seqkit >/dev/null 2>&1 \
+        || conda install -y -n "$BIOINF_ENV_NAME" -c bioconda seqkit
 else
-    echo "[3/4] Creating bioinf conda env (bcftools, bwa-mem2, gatk4, mimalloc, jemalloc)..."
+    echo "[3/4] Creating bioinf conda env (bcftools, bwa-mem2, gatk4, seqkit, mimalloc, jemalloc)..."
     conda create -y -n "$BIOINF_ENV_NAME" \
         -c bioconda -c conda-forge \
-        bcftools bwa-mem2 gatk4 mimalloc jemalloc
+        bcftools bwa-mem2 gatk4 seqkit mimalloc jemalloc
     echo "      Tools installed:"
     # `|| true`: head -1 closes the pipe after one line, so the tool gets
     # SIGPIPE (exit 141) and `set -o pipefail` would otherwise abort setup.


### PR DESCRIPTION
rneat/NEAT emit reads in genome-coordinate order; a real sequencer's FASTQ is arbitrary-order. The germline caller is order-independent (BAM coordinate-sorted before calling, no order-based dup-marking), so recall shouldn't change — but it's a fair methodological question to settle.

`SHUFFLE=1` (off by default) randomizes paired read order with seqkit (same seed on R1/R2 → identical per-index permutation, mates stay in register) before BWA-MEM2. Run shuffled vs unshuffled and diff `scored.summary.csv` to demonstrate order-independence (and to better mimic real input). `setup.sh` adds seqkit to the bioinf env (create + retrofit). Idempotent; no effect when SHUFFLE unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)