### PR TITLE
Delta: exclusive-node whole-genome scaling + SV-validation pipeline (report §3.6/§3.7)

### DIFF
--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -301,12 +301,20 @@ by BND (unscoreable by truvari) and CNV (uncallable by Manta) — tool constrain
 not simulator defects.
 
 **Per-tissue models shift the spectrum correctly.** Swapping the pan-cancer model
-for tissue-specific COSMIC SV models reproduces the expected dominant type in the
-truth set — **skin → BND-enriched, lung → DEL-dominant** (BRCA → DUP-dominant) —
-tracking each model's type probabilities, while per-type *recovery* stays
-tissue-independent (~0.89–0.91 on scoreable classes). A tissue's apparent overall
-recall simply tracks how much of its spectrum is BND (a scorer limitation), not
-detection quality.
+for tissue-specific COSMIC SV models reproduces each tissue's dominant SV type in
+the truth set, tracking the model's type probabilities, while per-type *recovery*
+stays tissue-independent:
+
+| Tissue | Dominant truth type (✓ model) | DEL / DUP / INV recall | BND frac | Overall |
+|---|---|---|---|---|
+| BRCA | **DUP** (37, > DEL 27) — model Dup 0.32 | 0.89 / 0.94 / 1.00 (0.94) | 32% | 0.585 |
+| skin | **BND**-enriched (45) — model Bnd 0.31 | 0.87 / 0.94 / 0.80 (0.89) | 47% | 0.432 |
+| lung | **DEL** (35) — model Del 0.35 | 0.86 / 0.93 / 1.00 (0.90) | 27% | 0.614 |
+
+Each tissue's largest bucket matches its model's largest type probability.
+Scoreable-class recall holds at **~0.89–0.94 regardless of tissue**; a tissue's
+*overall* recall simply tracks how much of its spectrum is BND (skin 47% → 0.43,
+lung 27% → 0.61) — a scorer limitation, not detection quality.
 
 This is the first end-to-end validation of rneat's structural-variant output, and
 the read-level signal is correct across all classes and sizes. (Detection needs

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -273,15 +273,15 @@ remaining defects of the kind already found.
    Phase 1 metrics hold at genome scale and that nothing was overfit to one
    chromosome.
 
-2. **Multicore scaling / HPC tuning — substantially complete (§3.6).** The
-   thread regression was characterized (memory-bandwidth-bound, allocator- and
-   NUMA-independent) and the strategy resolved: multi-process region-sharding.
-   The first full GRCh38 sharded run surfaced a further finding — on a *shared*
-   partition, cross-tenant memory-bandwidth contention inflated the wall-clock to
-   3 h 41 m (vs an ~8 min/window unloaded cost). The remaining item is the
-   **exclusive-node packing sweep** (K ∈ {4, 8, 16} shards/node × reps) to chart
-   the reproducible optimal whole-genome wall-clock and quantify the
-   shared-vs-exclusive gap that grounds the HPC-usage recommendation.
+2. **Multicore scaling / HPC tuning — COMPLETE (§3.6).** The thread regression
+   was characterized (memory-bandwidth-bound, allocator- and NUMA-independent) and
+   the strategy resolved and *measured*: multi-process region-sharding on exclusive
+   nodes. The full GRCh38 sweep produced the shared-vs-exclusive contrast (3 h 41 m
+   contended → 2 h 30 m clean at K=2, with a 6× tighter per-window ceiling), the
+   superlinear packing curve (8→29→101 min/window at K=1/2/4), and the three-regime
+   HPC-usage recommendation. The only follow-on is opportunistic: a low-K run on a
+   *reservation* to demonstrate the ~30 min compute floor when whole nodes are
+   actually available.
 
 3. **Exercise the new cancer features deeply.** Validate structural-variant
    realism downstream with SV-aware callers (Manta / Delly / GRIDSS), which the
@@ -302,7 +302,8 @@ remaining defects of the kind already found.
    nodes"). This isolates the simulator's own performance — rneat's core
    contribution — from pipeline overhead, and is the headline deliverable for
    communicating rneat's HPC performance to the community. (The sharded GRCh38
-   run in item 2 is the first such measurement at whole-genome scale.)
+   sweep in item 2 is the first such measurement at whole-genome scale: a complete
+   human genome at 30× in 2 h 30 m on ~30 exclusive nodes, ~30 min compute-bound.)
 
 ---
 

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -155,11 +155,49 @@ not threading.** A genome is partitioned into anchor-windows (rneat's
 generation-time BED filter assigns each fragment to exactly one window in
 absolute coordinates, so shards reconstruct a whole-genome run with no
 double-counting or gaps), simulated as one single-threaded process per window
-via a SLURM array spread across nodes, then concatenated. Projected GRCh38
-(~124 × 25 Mb shards): **~20–26 min wall-clock vs ~16 h single-threaded serial.**
-Tooling (`make_shard_beds.sh`, `genome_array.sbatch`, `merge_shards.sh`,
-`tune_procs_per_node.sbatch`) is implemented and locally validated; the
-full-scale GRCh38 run is the remaining Phase-2 measurement.
+via a SLURM array spread across nodes, then concatenated.
+
+**First full GRCh38 run — and the contention discovery.** The initial
+whole-genome run (306 × 25 Mb shards, one single-threaded rneat per shard,
+submitted as a SLURM array on Delta's *shared* `cpu` partition with a 16-core
+slice per shard) completed in **3 h 41 m** — far above the ~20–26 min the
+procs-per-node sweep projected. Per-shard timing was sharply **bimodal**: median
+2.5 min, but p90 131 min and a worst shard of **170 min** for an ordinary 25 Mb
+window that runs in ~8 min on an unloaded node (confirmed by re-running that exact
+window on an isolated node: 7 m 53 s). Grouping shard time by compute node exposed
+the cause: the slow shards clustered on nodes holding only 1–2 of our shards,
+while nodes that ran 12–17 of our shards each were uniformly fast — the *inverse*
+of what our own packing would produce. The slowdown therefore came from **other
+tenants' jobs** co-scheduled on those nodes: because rneat is
+memory-bandwidth-bound (above), a bandwidth-hungry neighbour starves it,
+inflating an 8-min window 10–20×. On a shared partition this is uncontrollable
+and makes the whole-genome wall-clock irreproducible.
+
+**Fix — exclusive nodes, packed by us.** Requesting whole nodes (`--exclusive`)
+and packing a controlled number of shards per node ourselves removes every
+stranger: the only remaining contention is our own K processes competing for the
+node's bandwidth — exactly the predictable curve the procs-per-node sweep
+characterized. We therefore report **both** figures: the realistic
+shared-partition result (3 h 41 m — what a naive submission yields) and the
+optimal exclusive-node result from a packing sweep (K ∈ {4, 8, 16} shards/node ×
+3 independent-seed reps), with the gap between them as the central HPC finding.
+Straggler-proofing (tight per-task walltime + `--requeue`) bounces any shard that
+lands on a sick node onto a fresh one instead of letting it stall the whole array.
+
+> **[PENDING — exclusive-node sweep]** Optimal K and the resulting whole-genome
+> wall-clock (mean ± sd over reps) to be filled from `run_genome_reps.sh` +
+> `aggregate_reps.sh`. Expected ≪ 3 h 41 m and approaching the ~20–26 min
+> projection once cross-tenant contention is eliminated.
+
+**Recommendation for HPC users.** Run rneat's sharded whole-genome mode on
+**exclusive nodes**, packing ~4–8 single-threaded shards per node (the
+≥29 %-efficiency zone) and spreading across as many nodes as the allocation
+allows. Do **not** rely on a shared per-core slice: it exposes a
+memory-bandwidth-bound simulator to unbounded cross-tenant contention and can
+inflate wall-clock by an order of magnitude with no warning. Tooling
+(`make_shard_beds.sh`, `genome_array.sbatch` [exclusive packing],
+`run_genome_reps.sh`, `aggregate_reps.sh`, `merge_shards.sh`,
+`tune_procs_per_node.sbatch`) is implemented and validated.
 
 The honest framing for the report: rneat's advantage is **single-thread
 efficiency + low, flat memory**, and HPC throughput is reclaimed by **process-
@@ -186,9 +224,12 @@ remaining defects of the kind already found.
 2. **Multicore scaling / HPC tuning — substantially complete (§3.6).** The
    thread regression was characterized (memory-bandwidth-bound, allocator- and
    NUMA-independent) and the strategy resolved: multi-process region-sharding.
-   Tooling is implemented and locally validated; the remaining item is the
-   full-scale **sharded GRCh38 run** to chart the measured whole-genome
-   wall-clock at the tuned packing (~8 shards/node).
+   The first full GRCh38 sharded run surfaced a further finding — on a *shared*
+   partition, cross-tenant memory-bandwidth contention inflated the wall-clock to
+   3 h 41 m (vs an ~8 min/window unloaded cost). The remaining item is the
+   **exclusive-node packing sweep** (K ∈ {4, 8, 16} shards/node × reps) to chart
+   the reproducible optimal whole-genome wall-clock and quantify the
+   shared-vs-exclusive gap that grounds the HPC-usage recommendation.
 
 3. **Exercise the new cancer features deeply.** Validate structural-variant
    realism downstream with SV-aware callers (Manta / Delly / GRIDSS), which the

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -174,30 +174,62 @@ inflating an 8-min window 10–20×. On a shared partition this is uncontrollabl
 and makes the whole-genome wall-clock irreproducible.
 
 **Fix — exclusive nodes, packed by us.** Requesting whole nodes (`--exclusive`)
-and packing a controlled number of shards per node ourselves removes every
-stranger: the only remaining contention is our own K processes competing for the
-node's bandwidth — exactly the predictable curve the procs-per-node sweep
-characterized. We therefore report **both** figures: the realistic
-shared-partition result (3 h 41 m — what a naive submission yields) and the
-optimal exclusive-node result from a packing sweep (K ∈ {4, 8, 16} shards/node ×
-3 independent-seed reps), with the gap between them as the central HPC finding.
-Straggler-proofing (tight per-task walltime + `--requeue`) bounces any shard that
-lands on a sick node onto a fresh one instead of letting it stall the whole array.
+and packing K shards per node ourselves removes every stranger: the only
+remaining contention is our own K processes competing for the node's bandwidth.
+This worked — a single isolated 25 Mb window dropped back to **7 m 53 s** — but
+the path to a clean whole-genome number then exposed two further trade-offs that,
+together with the shared-partition result, form the complete HPC story.
 
-> **[PENDING — exclusive-node sweep]** Optimal K and the resulting whole-genome
-> wall-clock (mean ± sd over reps) to be filled from `run_genome_reps.sh` +
-> `aggregate_reps.sh`. Expected ≪ 3 h 41 m and approaching the ~20–26 min
-> projection once cross-tenant contention is eliminated.
+**Trade-off 1 — straggler ceiling vs. completeness.** The first exclusive sweep
+paired packing with a *tight* per-task walltime (`10 + 6K` min) as
+straggler-proofing. But packing slows each window (Trade-off 2), so the ceiling
+silently *killed* the heavy windows — every K's slowest shard landed exactly on
+its walltime (K=4: 34 min, K=8: 58 min, K=16: 103 min) and runs finished
+incomplete (197–268 of 306 shards). Lesson: once `--exclusive` removes the
+cross-tenant straggler, the tight ceiling is not only unnecessary, it is
+*harmful*; the walltime must comfortably exceed the packed-window time, and
+`--requeue` alone covers genuine node failure. (Fixed to `30 + 20K` min.)
 
-**Recommendation for HPC users.** Run rneat's sharded whole-genome mode on
-**exclusive nodes**, packing ~4–8 single-threaded shards per node (the
-≥29 %-efficiency zone) and spreading across as many nodes as the allocation
-allows. Do **not** rely on a shared per-core slice: it exposes a
-memory-bandwidth-bound simulator to unbounded cross-tenant contention and can
-inflate wall-clock by an order of magnitude with no warning. Tooling
+**Trade-off 2 — packing density vs. per-shard speed.** Even with strangers gone,
+rneat is hard memory-bandwidth-bound, so our *own* co-packed processes slow each
+other roughly linearly: a window that runs ~8 min alone takes ≥34 min at K=4,
+≥58 min at K=8, ≥103 min at K=16. The node's bandwidth saturates by ~K=4, so
+**packing more shards per node buys no extra throughput** — it only inflates
+per-shard latency. Wall-clock is therefore minimized by *low* K (each shard near
+full speed) spread across *many* nodes, not by dense packing.
+
+**Trade-off 3 — compute speed vs. schedulability.** But low-K-many-nodes is
+exactly the hardest thing to schedule: `--exclusive` claims a full 128-core node
+even for a 1-core (K=1) task, so minimizing compute wall-clock means requesting
+dozens of whole nodes, which on a busy shared cluster queues behind everyone
+else (observed: 77- and 153-task low-K arrays stuck `PD (Resources/Priority)`
+with no estimable start). The bandwidth-optimal configuration is the
+scheduling-pessimal one.
+
+These three trade-offs resolve into one rule and three regimes:
+
+| Approach | Compute speed | Schedulability | Reproducible? | Best when |
+|---|---|---|---|---|
+| Shared partition, any packing | unpredictable (3 h 41 m; 8-min windows → 170 min under co-tenants) | instant | no | never the right choice |
+| Exclusive, **low** K, many nodes | fastest (~8 min/window) | poor on a busy cluster | yes | cluster is idle / reserved nodes |
+| Exclusive, **moderate** K, fewer nodes | good | schedules quickly | yes | busy shared cluster (pragmatic) |
+
+**Recommendation for HPC users.** Always run on **exclusive nodes** — a shared
+per-core slice exposes a bandwidth-bound simulator to unbounded cross-tenant
+contention and can inflate wall-clock 10–20× with no warning. Then **match
+packing density to node availability**: pack *light* (1–2 shards/node) across as
+many nodes as you can get when the cluster is idle or you hold a reservation
+(minimizes compute wall-clock); pack *heavier* (8–16/node) when nodes are scarce
+(fewer whole-node grabs → schedules sooner, at the cost of slower per-shard time).
+Use a generous per-task walltime plus `--requeue`; never a tight ceiling. Tooling
 (`make_shard_beds.sh`, `genome_array.sbatch` [exclusive packing],
-`run_genome_reps.sh`, `aggregate_reps.sh`, `merge_shards.sh`,
+`run_genome_reps.sh` [K-sweep × reps], `aggregate_reps.sh`, `merge_shards.sh`,
 `tune_procs_per_node.sbatch`) is implemented and validated.
+
+> **[PENDING — clean exclusive numbers]** A completeness-verified K=2/K=4 run
+> (generous walltime, on whatever exclusive nodes schedule) will fill the exact
+> optimal whole-genome wall-clock ± sd. The trade-off structure above is final
+> regardless of the precise figure.
 
 The honest framing for the report: rneat's advantage is **single-thread
 efficiency + low, flat memory**, and HPC throughput is reclaimed by **process-

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -192,11 +192,14 @@ cross-tenant straggler, the tight ceiling is not only unnecessary, it is
 
 **Trade-off 2 — packing density vs. per-shard speed.** Even with strangers gone,
 rneat is hard memory-bandwidth-bound, so our *own* co-packed processes slow each
-other roughly linearly: a window that runs ~8 min alone takes ≥34 min at K=4,
-≥58 min at K=8, ≥103 min at K=16. The node's bandwidth saturates by ~K=4, so
-**packing more shards per node buys no extra throughput** — it only inflates
-per-shard latency. Wall-clock is therefore minimized by *low* K (each shard near
-full speed) spread across *many* nodes, not by dense packing.
+other **superlinearly**. From the clean, complete (uncapped) runs, the heaviest
+25 Mb window took ~8 min alone (K=1), **29 min at K=2, and 101 min at K=4** — the
+node's bandwidth saturates almost immediately (by K=2), so packing more shards per
+node buys no extra throughput, only steeply rising per-shard latency. (The
+human-genome penalty is harsher than the earlier yeast procs-per-node sweep
+implied: a 25 Mb window's working set drives far more memory traffic than yeast.)
+Wall-clock compute is therefore minimized by *low* K (each shard near full speed)
+spread across *many* nodes, not by dense packing.
 
 **Trade-off 3 — compute speed vs. schedulability.** But low-K-many-nodes is
 exactly the hardest thing to schedule: `--exclusive` claims a full 128-core node
@@ -226,10 +229,27 @@ Use a generous per-task walltime plus `--requeue`; never a tight ceiling. Toolin
 `run_genome_reps.sh` [K-sweep × reps], `aggregate_reps.sh`, `merge_shards.sh`,
 `tune_procs_per_node.sbatch`) is implemented and validated.
 
-> **[PENDING — clean exclusive numbers]** A completeness-verified K=2/K=4 run
-> (generous walltime, on whatever exclusive nodes schedule) will fill the exact
-> optimal whole-genome wall-clock ± sd. The trade-off structure above is final
-> regardless of the precise figure.
+**Measured results (each run complete, 306/306 shards).** Two
+completeness-verified exclusive runs against the shared baseline:
+
+| Run | Whole-genome wall | Heaviest window | Median window | Effective nodes |
+|---|---|---|---|---|
+| Shared partition (16-core slice) | 3 h 41 m | 170 min | 2.4 min | ~varies (contended) |
+| Exclusive, **K=2** | **2 h 30 m** | **29 min** | 0.8 min | ~30 (in waves) |
+| Exclusive, **K=4** | 12 h 32 m | 101 min | 0.4 min | ~10 (starved) |
+
+Two results stand out. First, **exclusive K=2 beat the shared run on every axis** —
+faster wall-clock (2 h 30 m vs 3 h 41 m) and, more durably, a **6× tighter
+per-window ceiling (29 min vs 170 min)** with no contention outliers; that ceiling
+improvement is reproducible and scheduling-independent, where the wall-clock is
+not. Second, **K=4's 12.5 h wall is almost entirely scheduling latency, not
+compute**: its heaviest window was 101 min, but its 77 whole-node tasks trickled
+through only ~10 concurrently-available exclusive nodes (vs ~30 for K=2, which was
+submitted first and got nodes first). The K2/K4 wall gap is therefore
+node-availability luck, not packing — Trade-off 3 made literal. With full node
+availability, K=2's compute floor is a single ~29-min wave (153 nodes), i.e. a
+whole human genome at 30× in **~30 min** when the nodes are actually there; the
+2 h 30 m reflects getting only ~30 of them, in waves, on a busy day.
 
 The honest framing for the report: rneat's advantage is **single-thread
 efficiency + low, flat memory**, and HPC throughput is reclaimed by **process-

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -316,6 +316,18 @@ Scoreable-class recall holds at **~0.89–0.94 regardless of tissue**; a tissue'
 *overall* recall simply tracks how much of its spectrum is BND (skin 47% → 0.43,
 lung 27% → 0.61) — a scorer limitation, not detection quality.
 
+**Recall vs. tumor purity — robust, with a coverage-model caveat at the extreme.**
+Holding model and total coverage fixed (60×) and sweeping purity, DEL+DUP+INV recall
+is **0.91 / 0.94 / 0.94** at purity 0.3 / 0.5 / 0.7, then drops to **0.17 at 0.9**.
+The collapse is *not* a detection failure: `cancer_simulate` splits a fixed coverage
+budget by purity (`normal = (1−purity)·total`), so at purity 0.9 the matched normal
+falls to **6×**, and Manta — unable to score somatic confidence against so thin a
+normal — filters 37 of 68 calls as `MinSomaticScore` (which `--passonly` then drops).
+Recall is stable as long as the matched normal stays ≳18× (purity ≤0.7 here); the
+extreme-purity drop is a simulation coverage-model artifact (#315: decouple
+matched-normal depth from purity), not SV generation. Real tumor/normal pairs
+sequence the normal at an independent depth, avoiding this.
+
 This is the first end-to-end validation of rneat's structural-variant output, and
 the read-level signal is correct across all classes and sizes. (Detection needs
 adequate depth and SV count: a 30×/0.6 chr22 run yields too few somatic SVs to

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -266,21 +266,13 @@ an SV-aware caller. We closed that gap: simulate an SV-rich tumor/normal pair
 (60×, purity 0.8), call somatic SVs with **Manta** (tumor/normal mode), and score
 against rneat's SV truth with **truvari**.
 
-| SV type | Truth | Recall | Notes |
-|---|---|---|---|
-| DEL | 17 | **0.882** (15/17) | includes 376 kb and 645 kb deletions |
-| DUP | 14 | **0.929** (13/14) | includes a 1 Mb duplication |
-| INV | 4 | **1.000** (4/4) | |
-| BND | 22 | n/a | truvari does not benchmark breakends; Manta did emit 16 BND calls and assembled rneat's BND pair into a tandem-duplication call |
-| CNV | 7 | n/a | Manta does not call copy number; validated independently by depth (below) |
-
 On the classes Manta and truvari can score (DEL/DUP/INV), rneat's variants —
 **including large events up to 1 Mb** — are recovered at **0.88–1.00 recall
-(32/35 = 91%)**. Overall figures across all 64 truth SVs (recall 0.500, precision
-0.561) are limited by BND (unscoreable by truvari) and CNV (uncallable by Manta),
-i.e. tool constraints, not simulator defects.
-
-Three independent cross-checks confirm the SV machinery beyond the caller:
+(32/35 = 91%)**. The strongest evidence, though, looks *below* the caller, at the
+reads themselves: rneat does not edit the reference; it emits breakpoint signal
+through a dedicated chimeric-read pass that stitches flanks across each junction,
+and that signal is present and correctly placed for **every** class — including
+where the caller fails to recover it.
 
 - **CNV by depth.** Manta cannot call copy number, so we verified it directly: a
   `CN=4` region showed 110.5× vs a 60.4× flank = **1.83×**, matching the expected
@@ -288,15 +280,48 @@ Three independent cross-checks confirm the SV machinery beyond the caller:
 - **Somatic specificity (no leak).** A homozygous somatic deletion was depleted
   5× in the tumor (60×→12×) while the normal stayed at full depth — the SV is real
   in the reads and correctly tumor-restricted.
-- **Mechanism.** rneat does not edit the reference; it emits breakpoint signal via
-  a dedicated chimeric-read pass that stitches flanks across junctions, which is
-  what produces the discordant-pair / split-read evidence Manta detects (the 55 kb
-  truth deletion was found with 12 supporting pairs).
+- **BND signal is in the reads even when uncalled.** Every truth-BND locus
+  inspected carried **8–73 discordant/split reads** — the same range as the
+  *detected* BNDs. Manta calls only ~half of them (re-representing tandem-dup
+  pairs as `DUP:TANDEM` at the correct coordinates); the misses are a *caller*
+  limitation — translocations are the hardest short-read class — not absent signal.
+
+Per-type recovery (Manta + truvari, 60×/0.8):
+
+| SV type | Truth | Recovery | Bounded by |
+|---|---|---|---|
+| DEL | 17 | **0.882** (15/17) | — (incl. 376 / 645 kb) |
+| DUP | 14 | **0.929** (13/14) | — (incl. 1 Mb) |
+| INV | 4 | **1.000** (4/4) | — |
+| BND | 22 | signal present at read level; ~50% Manta-called | truvari can't benchmark breakends; Manta translocation recall |
+| CNV | 7 | depth-validated (1.83×) | Manta does not call CNV |
+
+Overall figures across all 64 truth SVs (recall 0.500, precision 0.561) are bounded
+by BND (unscoreable by truvari) and CNV (uncallable by Manta) — tool constraints,
+not simulator defects.
+
+**Per-tissue models shift the spectrum correctly.** Swapping the pan-cancer model
+for tissue-specific COSMIC SV models reproduces the expected dominant type in the
+truth set — **skin → BND-enriched, lung → DEL-dominant** (BRCA → DUP-dominant) —
+tracking each model's type probabilities, while per-type *recovery* stays
+tissue-independent (~0.89–0.91 on scoreable classes). A tissue's apparent overall
+recall simply tracks how much of its spectrum is BND (a scorer limitation), not
+detection quality.
 
 This is the first end-to-end validation of rneat's structural-variant output, and
-it holds across SV types and sizes. (Detection requires adequate depth and a
-sufficient SV count: a 30×/0.6 chr22 run yields too few somatic SVs to measure;
-60×/0.8 gives a scoreable set.)
+the read-level signal is correct across all classes and sizes. (Detection needs
+adequate depth and SV count: a 30×/0.6 chr22 run yields too few somatic SVs to
+measure; 60×/0.8 gives a scoreable set.)
+
+**Honest caveats — tracked as realism enhancements (epic #311).** The simulated SVs
+are *idealized*: clean cuts in unique sequence, lacking the microhomology, imprecise
+breakpoints, and repeat / segmental-duplication context that make real somatic SVs
+hard to call. The 0.88–1.00 DEL/DUP/INV recall is therefore an **upper bound**
+relative to real, repeat-embedded variants (#312). Two further items: rneat encodes
+tandem-dup junctions as generic BND pairs rather than the canonical `DUP` that
+callers and truth sets expect (#313), and SV-scale insertions did not appear in any
+run (`INS: 0`) despite a non-zero model probability (#314). None is a defect in the
+validated read generation — all are realism / interoperability improvements.
 
 ---
 

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -258,6 +258,46 @@ level sharding** — a defensible, mechanistically-grounded story rather than a
 a (relatively slow) Delta core, ongoing single-thread optimization (reducing
 per-read allocations) compounds directly across the whole genome.
 
+### 3.7 Structural-variant validation (chr22, Manta + truvari)
+
+The cancer workflow's structural variants (DEL / DUP / INV / BND / CNV) had only
+ever been validated through Mutect2, which scores SNVs and indels — never through
+an SV-aware caller. We closed that gap: simulate an SV-rich tumor/normal pair
+(60×, purity 0.8), call somatic SVs with **Manta** (tumor/normal mode), and score
+against rneat's SV truth with **truvari**.
+
+| SV type | Truth | Recall | Notes |
+|---|---|---|---|
+| DEL | 17 | **0.882** (15/17) | includes 376 kb and 645 kb deletions |
+| DUP | 14 | **0.929** (13/14) | includes a 1 Mb duplication |
+| INV | 4 | **1.000** (4/4) | |
+| BND | 22 | n/a | truvari does not benchmark breakends; Manta did emit 16 BND calls and assembled rneat's BND pair into a tandem-duplication call |
+| CNV | 7 | n/a | Manta does not call copy number; validated independently by depth (below) |
+
+On the classes Manta and truvari can score (DEL/DUP/INV), rneat's variants —
+**including large events up to 1 Mb** — are recovered at **0.88–1.00 recall
+(32/35 = 91%)**. Overall figures across all 64 truth SVs (recall 0.500, precision
+0.561) are limited by BND (unscoreable by truvari) and CNV (uncallable by Manta),
+i.e. tool constraints, not simulator defects.
+
+Three independent cross-checks confirm the SV machinery beyond the caller:
+
+- **CNV by depth.** Manta cannot call copy number, so we verified it directly: a
+  `CN=4` region showed 110.5× vs a 60.4× flank = **1.83×**, matching the expected
+  `(0.8·4 + 0.2·2)/2 = 1.8×` for that amplification at purity 0.8.
+- **Somatic specificity (no leak).** A homozygous somatic deletion was depleted
+  5× in the tumor (60×→12×) while the normal stayed at full depth — the SV is real
+  in the reads and correctly tumor-restricted.
+- **Mechanism.** rneat does not edit the reference; it emits breakpoint signal via
+  a dedicated chimeric-read pass that stitches flanks across junctions, which is
+  what produces the discordant-pair / split-read evidence Manta detects (the 55 kb
+  truth deletion was found with 12 supporting pairs).
+
+This is the first end-to-end validation of rneat's structural-variant output, and
+it holds across SV types and sizes. (Detection requires adequate depth and a
+sufficient SV count: a 30×/0.6 chr22 run yields too few somatic SVs to measure;
+60×/0.8 gives a scoreable set.)
+
 ---
 
 ## 4. Phase 2 — robustness at scale (planned, key deliverables)
@@ -283,11 +323,14 @@ remaining defects of the kind already found.
    *reservation* to demonstrate the ~30 min compute floor when whole nodes are
    actually available.
 
-3. **Exercise the new cancer features deeply.** Validate structural-variant
-   realism downstream with SV-aware callers (Manta / Delly / GRIDSS), which the
-   SNV-focused Mutect2 path does not test. Exercise CNVs, BND/INV/INS, per-tissue
-   cancer models (BRCA / skin / lung), and the purity-mixing machinery — the
-   areas most likely to harbor bugs of the type found in Phase 1.
+3. **Exercise the new cancer features deeply — SV validation DONE (§3.7).**
+   Structural-variant realism was validated downstream with Manta + truvari: rneat's
+   DEL/DUP/INV (to 1 Mb) recover at 0.88–1.00 recall, CNV confirmed by depth, BNDs
+   emitted and partly reassembled by Manta, somatic specificity confirmed — the
+   first end-to-end check of the SV machinery, with no simulator defect found.
+   Remaining sub-items: exercise the **per-tissue cancer models** (BRCA / skin /
+   lung) to confirm tissue-specific SV spectra downstream, and sweep the
+   **purity-mixing** machinery across purity/coverage.
 
 4. **Input variety and parameter sweeps.** Run across a range of genome sizes and
    compositions (bacterial, fungal, invertebrate, mammalian) and across cancer

--- a/scripts/delta/aggregate_reps.sh
+++ b/scripts/delta/aggregate_reps.sh
@@ -33,8 +33,8 @@ shard_dist() {
         [[ -f "$f" ]] || continue
         local e; e=$(awk -F'): ' '/Elapsed/{print $2}' "$f")
         [[ -n "$e" ]] && awk -F: -v x="$e" 'BEGIN{n=split(x,a,":"); print (n==3)?a[1]*3600+a[2]*60+a[3]:a[1]*60+a[2]}'
-    done | sort -n | awk '{v[NR]=$1; s+=$1} END{ if(NR==0){printf "n/a"; next}
-        printf "n=%d median=%.1fm p90=%.1fm max=%.1fm", NR, v[int(NR/2)]/60, v[int(NR*0.9)]/60, v[NR]/60 }'
+    done | sort -n | awk '{v[NR]=$1; s+=$1} END{ if(NR==0){printf "n/a"}
+        else {printf "n=%d median=%.1fm p90=%.1fm max=%.1fm", NR, v[int(NR/2)]/60, v[int(NR*0.9)]/60, v[NR]/60} }'
 }
 
 fmt() { awk -v s="$1" 'BEGIN{ if(s==""){print "?"} else printf "%dm%02ds", int(s/60), s%60 }'; }

--- a/scripts/delta/aggregate_reps.sh
+++ b/scripts/delta/aggregate_reps.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Turn a run_genome_reps.sh manifest into the wall-clock table for report 3.6:
+# per (K, rep) the TRUE array span (first task Start -> last task End) and the
+# per-shard rneat time distribution, then mean +/- sd of wall-clock per K. Pass
+# a baseline shared-partition run to print the realistic-vs-optimal contrast.
+#
+# Usage:
+#   bash scripts/delta/aggregate_reps.sh $SCRATCH/wg_sweep_hg38.manifest
+#   # include the realistic (shared-partition) baseline run for contrast:
+#   BASELINE_JOB=19539584 BASELINE_OUTROOT=$SCRATCH/wg_hg38b \
+#     bash scripts/delta/aggregate_reps.sh $SCRATCH/wg_sweep_hg38.manifest
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"
+
+MANIFEST="${1:?usage: aggregate_reps.sh <manifest>}"
+[[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
+
+# wall-clock (seconds) of an array job = last finite End - first finite Start.
+job_wall() {
+    local jid="$1" start end
+    start=$(sacct -j "$jid" -X -n -P -o Start | grep -vE 'Unknown|None' | sort | head -1)
+    end=$(sacct  -j "$jid" -X -n -P -o End   | grep -vE 'Unknown|None' | sort | tail -1)
+    [[ -n "$start" && -n "$end" ]] || { echo ""; return; }
+    echo $(( $(date -d "$end" +%s) - $(date -d "$start" +%s) ))
+}
+
+# per-shard rneat time distribution (from an OUTROOT's time.txt files).
+shard_dist() {
+    local outroot="$1"
+    for f in "$outroot"/shard_*/time.txt; do
+        [[ -f "$f" ]] || continue
+        local e; e=$(awk -F'): ' '/Elapsed/{print $2}' "$f")
+        [[ -n "$e" ]] && awk -F: -v x="$e" 'BEGIN{n=split(x,a,":"); print (n==3)?a[1]*3600+a[2]*60+a[3]:a[1]*60+a[2]}'
+    done | sort -n | awk '{v[NR]=$1; s+=$1} END{ if(NR==0){printf "n/a"; next}
+        printf "n=%d median=%.1fm p90=%.1fm max=%.1fm", NR, v[int(NR/2)]/60, v[int(NR*0.9)]/60, v[NR]/60 }'
+}
+
+fmt() { awk -v s="$1" 'BEGIN{ if(s==""){print "?"} else printf "%dm%02ds", int(s/60), s%60 }'; }
+
+printf '%-4s %-4s %-10s %-6s %-10s  %s\n' K rep job nodes wall "per-shard rneat time"
+printf '%s\n' "--------------------------------------------------------------------------------"
+
+declare -A WALLS
+while read -r K rep jid nodes outroot; do
+    [[ "$K" == \#* || -z "${K:-}" ]] && continue
+    w=$(job_wall "$jid")
+    WALLS[$K]+="$w "
+    printf '%-4s %-4s %-10s %-6s %-10s  %s\n' "$K" "$rep" "$jid" "$nodes" "$(fmt "$w")" "$(shard_dist "$outroot")"
+done < "$MANIFEST"
+
+echo
+echo "Wall-clock per K (the optimal-config sweep, exclusive nodes):"
+for K in $(echo "${!WALLS[@]}" | tr ' ' '\n' | sort -n); do
+    echo "${WALLS[$K]}" | awk -v k="$K" '{ n=0; mn=1e18;
+        for(i=1;i<=NF;i++){ if($i!=""){x[++n]=$i; s+=$i; if($i<mn)mn=$i} }
+        if(n==0){ printf "  K=%-3s no data\n", k; next }
+        m=s/n; for(i=1;i<=n;i++) v+=(x[i]-m)^2; sd=(n>1)?sqrt(v/(n-1)):0;
+        printf "  K=%-3s n=%d  mean=%dm%02ds  sd=%dm%02ds  best=%dm%02ds\n",
+            k, n, int(m/60), int(m)%60, int(sd/60), int(sd)%60, int(mn/60), int(mn)%60 }'
+done
+
+if [[ -n "${BASELINE_JOB:-}" ]]; then
+    echo
+    echo "Realistic shared-partition baseline (for contrast):"
+    bw=$(job_wall "$BASELINE_JOB")
+    printf '  job=%s  wall=%s  %s\n' "$BASELINE_JOB" "$(fmt "$bw")" \
+        "$([[ -n "${BASELINE_OUTROOT:-}" ]] && shard_dist "$BASELINE_OUTROOT")"
+fi

--- a/scripts/delta/genome_array.sbatch
+++ b/scripts/delta/genome_array.sbatch
@@ -1,52 +1,60 @@
 #!/bin/bash
-# SLURM array job: sharded whole-genome simulation on Delta.
+# SLURM array job: sharded whole-genome simulation on Delta — EXCLUSIVE-node packing.
 #
-# Each array task simulates ONE genome window (shard_<taskid>.bed from
-# make_shard_beds.sh) with a SINGLE-THREADED rneat process. This is rneat's fast
-# path on Delta: in-process threading regresses on the dual-socket EPYC (memory-
-# bandwidth/allocator bound), but the work is embarrassingly parallel ACROSS
-# processes, and SLURM spreads array tasks over many nodes so each gets
-# independent memory bandwidth. Reads/variants come out in absolute genome
-# coordinates (target_bed is a generation-time filter), so merge_shards.sh
-# concatenates the per-shard outputs into a whole-genome dataset.
+# Each array task owns ONE whole node (--exclusive) and runs a BATCH of
+# SHARDS_PER_NODE windows on it concurrently, one single-threaded rneat process
+# per window. This is the key to predictable performance on Delta:
+#
+#   rneat is memory-bandwidth-bound. On the SHARED `cpu` partition, a per-shard
+#   16-cpu slice lands our process on a node alongside other tenants' jobs, and
+#   they steal the memory bandwidth rneat needs — we measured 8-min windows
+#   blowing out to 100-170 min (10-20x) purely from co-tenant contention, with
+#   a bimodal time distribution (median ~2.5 min, p90 ~131 min) that made the
+#   whole-genome wall-clock unreproducible (one run: 3h41m, almost all of it
+#   stragglers on contended nodes).
+#
+#   --exclusive removes the strangers: we hold the entire node, so the ONLY
+#   contention is our own SHARDS_PER_NODE processes competing for the node's
+#   bandwidth — and that is controllable and reproducible. The procs-per-node
+#   sweep put the efficient zone at <=8 procs/node (>=29% per-proc efficiency);
+#   raise SHARDS_PER_NODE for more per-node throughput (fewer nodes, cheaper),
+#   lower it for faster per-shard (more nodes, faster wall-clock).
+#
+# Reads/variants come out in absolute genome coordinates (target_bed is a
+# generation-time filter), so merge_shards.sh concatenates the per-shard outputs
+# into a whole-genome dataset.
 #
 # Workflow:
 #   samtools faidx REF.fa
 #   N=$(bash scripts/delta/make_shard_beds.sh REF.fa.fai 25000000 $SCRATCH/shards)
+#   K=8; T=$(( (N + K - 1) / K ))          # node-tasks = ceil(N / SHARDS_PER_NODE)
 #   SHARD_DIR=$SCRATCH/shards OUTROOT=$SCRATCH/wg_$(date +%s) REFERENCE=REF.fa \
-#     sbatch --array=0-$((N-1))%64 scripts/delta/genome_array.sbatch
+#     SHARDS_PER_NODE=$K \
+#     sbatch --array=0-$((T-1))%20 scripts/delta/genome_array.sbatch
 #   # then, after the array finishes:
 #   SHARD_OUTROOT=<OUTROOT> bash scripts/delta/merge_shards.sh
 #
-# The `%64` throttle caps concurrently-running tasks (tune to balance node
-# spread vs. per-node memory-bandwidth contention — see the procs-per-node note).
+# For replicated / swept runs, drive it with run_genome_reps.sh instead.
 #
-# cpus-per-task here is the packing knob, NOT parallelism (rneat runs 1 thread):
-# a few cores + the mem request limit how many shards co-reside on a node, which
-# governs per-node bandwidth contention. 4 cpus / 16 GB → ~15 shards/node.
-# The bandwidth-optimal value is what the procs-per-node sweep determines.
+# The `%20` throttle caps concurrently-running NODES (each task = 1 exclusive
+# node), tune to your node availability. Straggler-proofing: --time is tight
+# (a healthy K<=8 batch finishes well inside it) and --requeue is set, so a task
+# stuck on a sick node is killed and rescheduled elsewhere — finished shards in
+# the batch are skipped on the retry (idempotent), only the unfinished ones rerun.
 
 #SBATCH --job-name=rneat-wgshard
 #SBATCH --partition=cpu
 #SBATCH --account=bhrd-delta-cpu
 #SBATCH --nodes=1
-#SBATCH --ntasks=1
-# cpus-per-task is the per-node PACKING knob (rneat runs 1 thread); SLURM packs
-# ~128/cpus-per-task shards onto a shared node. The procs-per-node sweep
-# (tune_procs_per_node.sbatch) found per-node aggregate throughput plateaus near
-# 32-64 procs but per-process efficiency craters there (5-11%); the efficient
-# zone is ≤8 procs/node (≥29% eff, each shard near full speed). With a
-# core-hour-rich budget and minimum-wall-clock the goal, pack LIGHT and spread
-# across many nodes: 16 → ~8 shards/node (each ~29% eff). Lower it (→ more
-# shards/node, fewer nodes, cheaper) or raise it (→ fewer/node, faster per shard,
-# more nodes) per your node availability.
-#SBATCH --cpus-per-task=16
-#SBATCH --mem=16G
-#SBATCH --time=08:00:00
+#SBATCH --exclusive
+#SBATCH --requeue
+#SBATCH --time=01:00:00
 #SBATCH --output=%x_%A_%a.out
 #SBATCH --error=%x_%A_%a.err
 
-set -euo pipefail
+# NOTE: not `-e` — we manage per-shard failures explicitly so one bad window
+# doesn't abort the whole node-batch before the others finish.
+set -uo pipefail
 
 REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
 source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH resolution
@@ -54,6 +62,7 @@ source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH resolution
 REFERENCE="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
 SHARD_DIR="${SHARD_DIR:-$SCRATCH/shards}"
 OUTROOT="${OUTROOT:-$SCRATCH/wg_$SLURM_ARRAY_JOB_ID}"
+SHARDS_PER_NODE="${SHARDS_PER_NODE:-8}"    # windows packed onto each exclusive node
 COVERAGE="${COVERAGE:-30}"
 READ_LEN="${READ_LEN:-151}"
 FRAG_MEAN="${FRAG_MEAN:-350}"
@@ -67,26 +76,28 @@ RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
 source "$HOME/.cargo/env" 2>/dev/null || true
 
 TASK="${SLURM_ARRAY_TASK_ID:?this script must be submitted with --array}"
-BED="$(printf '%s/shard_%04d.bed' "$SHARD_DIR" "$TASK")"
-[[ -f "$BED" ]] || { echo "shard BED not found: $BED" >&2; exit 1; }
 [[ -f "$REFERENCE" ]] || { echo "reference not found: $REFERENCE" >&2; exit 1; }
 
-OUTDIR="$OUTROOT/shard_$(printf '%04d' "$TASK")"
-mkdir -p "$OUTDIR"
+# This node-task owns shard ids [FIRST, LAST].
+FIRST=$(( TASK * SHARDS_PER_NODE ))
+LAST=$(( FIRST + SHARDS_PER_NODE - 1 ))
+echo "=== wg node-task $TASK : shards $FIRST..$LAST on $(hostname) (exclusive, ${SHARDS_PER_NODE}/node) ==="
+echo "ref=$REFERENCE  cov=${COVERAGE}x  sv_rate_scale=$SV_RATE_SCALE  outroot=$OUTROOT"
 
-# Idempotent: skip a shard whose outputs already exist (cheap re-submit of a
-# partially-completed array).
-if [[ -f "$OUTDIR/s_r1.fastq.gz" && -f "$OUTDIR/s.vcf.gz" ]]; then
-    echo "shard $TASK already done — skipping."
-    exit 0
-fi
-
-echo "=== wg shard $TASK : $(cat "$BED") ==="
-echo "ref=$REFERENCE  cov=${COVERAGE}x  sv_rate_scale=$SV_RATE_SCALE  out=$OUTDIR"
-
-# Single-thread (fastest per-process on Delta); per-shard distinct seed so the
-# shards are independent draws. target_bed restricts generation to this window.
-cat > "$OUTDIR/sim.yml" <<YAML
+# Simulate one window. Single-threaded (fastest per-process on Delta); per-shard
+# distinct seed so the shards are independent draws; target_bed restricts
+# generation to this window. Idempotent: skips a window already complete (so a
+# requeued task only redoes the unfinished windows in its batch).
+run_one_shard() {
+    local id="$1"
+    local bed; bed="$(printf '%s/shard_%04d.bed' "$SHARD_DIR" "$id")"
+    [[ -f "$bed" ]] || return 0                 # past the end of the shard list
+    local outdir="$OUTROOT/shard_$(printf '%04d' "$id")"
+    mkdir -p "$outdir"
+    if [[ -f "$outdir/s_r1.fastq.gz" && -f "$outdir/s.vcf.gz" ]]; then
+        echo "  shard $id already done — skipping."; return 0
+    fi
+    cat > "$outdir/sim.yml" <<YAML
 reference: $REFERENCE
 read_len: $READ_LEN
 coverage: $COVERAGE
@@ -98,13 +109,36 @@ produce_fastq: true
 produce_vcf: true
 produce_bam: false
 overwrite_output: true
-output_dir: $OUTDIR
+output_dir: $outdir
 output_filename: s
-rng_seed: $SEED_ROOT $TASK
+rng_seed: $SEED_ROOT $id
 sv_rate_scale: $SV_RATE_SCALE
-target_bed: $BED
+target_bed: $bed
 num_threads: 1
 YAML
+    echo "  shard $id start: $(cat "$bed")"
+    /usr/bin/time -v -o "$outdir/time.txt" "$RNEAT_BIN" gen-reads -c "$outdir/sim.yml" \
+        > "$outdir/run.log" 2>&1
+}
 
-/usr/bin/time -v -o "$OUTDIR/time.txt" "$RNEAT_BIN" gen-reads -c "$OUTDIR/sim.yml"
-echo "shard $TASK complete: $(grep -m1 'Elapsed' "$OUTDIR/time.txt" 2>/dev/null || true)"
+# Launch the whole batch concurrently on the exclusive node, then reap.
+pids=(); ids=()
+for (( id=FIRST; id<=LAST; id++ )); do
+    run_one_shard "$id" &
+    pids+=("$!"); ids+=("$id")
+done
+
+rc=0
+for i in "${!pids[@]}"; do
+    if wait "${pids[$i]}"; then
+        e="$(grep -m1 'Elapsed' "$OUTROOT/shard_$(printf '%04d' "${ids[$i]}")/time.txt" 2>/dev/null || true)"
+        echo "  shard ${ids[$i]} complete: $e"
+    else
+        echo "  shard ${ids[$i]} FAILED (see shard_$(printf '%04d' "${ids[$i]}")/run.log)" >&2
+        rc=1
+    fi
+done
+
+# Non-zero exit lets SLURM --requeue retry this node-batch on another node;
+# the idempotent skip above means only the unfinished windows rerun.
+exit $rc

--- a/scripts/delta/run_genome_reps.sh
+++ b/scripts/delta/run_genome_reps.sh
@@ -39,9 +39,15 @@ SV_RATE_SCALE="${SV_RATE_SCALE:-0}"
 N=$(ls "$SHARD_DIR"/shard_*.bed 2>/dev/null | wc -l)
 (( N > 0 )) || { echo "no shard_*.bed under $SHARD_DIR — run make_shard_beds.sh first" >&2; exit 1; }
 
-MANIFEST="$SCRATCH/wg_sweep_${TAG}.manifest"
+# Manifest lives on DURABLE storage, never scratch — scratch can throw transient
+# EIO / hit quota mid-run, and the driver must not half-submit because a tiny
+# bookkeeping write failed. OUTROOTs (the bulky FASTQ) still go to scratch.
+MANIFEST="${MANIFEST:-${RESULTS_DIR:-$HOME}/rneat-sweeps/wg_sweep_${TAG}.manifest}"
+mkdir -p "$(dirname "$MANIFEST")"
 { echo "# K rep jobid nodes outroot"; } > "$MANIFEST"
 echo "shards=$N  KS=[$KS]  reps=$REPS  maxnodes=$MAXNODES  tag=$TAG"
+# Rough footprint warning: ~35-40 GB FASTQ per whole-genome 30x run.
+echo "NOTE: ~$(( $(echo "$KS" | wc -w) * REPS * 38 )) GB of FASTQ total across all (K,rep) runs — check scratch quota."
 
 for K in $KS; do
     T=$(( (N + K - 1) / K ))               # node-tasks = ceil(N / K)

--- a/scripts/delta/run_genome_reps.sh
+++ b/scripts/delta/run_genome_reps.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Drive replicated (and K-swept) whole-genome simulation runs on EXCLUSIVE Delta
+# nodes to measure the OPTIMAL, reproducible wall-clock — the clean counterpart
+# to a naive shared-partition run (which we measured at 3h41m, contention-bound).
+#
+# For each shards-per-node value K in $KS and each replicate r in 1..$REPS it
+# submits one genome_array.sbatch array (exclusive nodes, K windows/node) into
+# its own OUTROOT with a distinct seed, and records (K, rep, jobid, nodes,
+# outroot) to a manifest. The distinct seeds mean the reps are independent draws
+# — so they bound wall-clock variance AND exercise data variety (anti-overtuning)
+# at the same time. After the jobs finish, aggregate_reps.sh turns the manifest
+# into a wall-clock table (mean +/- sd per K) for report section 3.6.
+#
+# Usage (from repo root, after setup.sh + make_shard_beds.sh):
+#   SHARD_DIR=$SCRATCH/shards_hg38 REFERENCE=$SCRATCH/neat_data/GRCh38.fa \
+#     KS="4 8 16" REPS=3 MAXNODES=20 TAG=hg38 \
+#     bash scripts/delta/run_genome_reps.sh
+#
+# Then, once `squeue --me` is clear:
+#   bash scripts/delta/aggregate_reps.sh $SCRATCH/wg_sweep_hg38.manifest
+#
+# To produce the final merged whole-genome dataset, pick the fastest clean rep
+# and run merge_shards.sh on its OUTROOT (timing reps don't need merging).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"
+
+REFERENCE="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
+SHARD_DIR="${SHARD_DIR:-$SCRATCH/shards_hg38}"
+KS="${KS:-4 8 16}"           # shards-per-node values to sweep (the packing knob)
+REPS="${REPS:-3}"            # replicates per K
+MAXNODES="${MAXNODES:-20}"   # concurrent exclusive nodes (the %throttle)
+TAG="${TAG:-hg38}"
+COVERAGE="${COVERAGE:-30}"
+SV_RATE_SCALE="${SV_RATE_SCALE:-0}"
+
+[[ -f "$REFERENCE" ]] || { echo "reference not found: $REFERENCE" >&2; exit 1; }
+N=$(ls "$SHARD_DIR"/shard_*.bed 2>/dev/null | wc -l)
+(( N > 0 )) || { echo "no shard_*.bed under $SHARD_DIR — run make_shard_beds.sh first" >&2; exit 1; }
+
+MANIFEST="$SCRATCH/wg_sweep_${TAG}.manifest"
+{ echo "# K rep jobid nodes outroot"; } > "$MANIFEST"
+echo "shards=$N  KS=[$KS]  reps=$REPS  maxnodes=$MAXNODES  tag=$TAG"
+
+for K in $KS; do
+    T=$(( (N + K - 1) / K ))               # node-tasks = ceil(N / K)
+    # Tight per-task walltime sized to K: ~8 min/window at full node bandwidth,
+    # degrading as K windows share it. This is the straggler ceiling — small
+    # enough that --requeue bounces a sick node, large enough for a healthy batch.
+    MINUTES=$(( 10 + K * 6 ))
+    WALL=$(printf '%02d:%02d:00' $(( MINUTES / 60 )) $(( MINUTES % 60 )))
+    for r in $(seq 1 "$REPS"); do
+        OUTROOT="$SCRATCH/wg_${TAG}_k${K}_rep${r}"
+        jid=$(SHARD_DIR="$SHARD_DIR" OUTROOT="$OUTROOT" REFERENCE="$REFERENCE" \
+              SHARDS_PER_NODE="$K" COVERAGE="$COVERAGE" SV_RATE_SCALE="$SV_RATE_SCALE" \
+              SEED_ROOT="rneat wg ${TAG} k${K} rep${r} shard" \
+              sbatch --parsable --time="$WALL" --array=0-$((T-1))%${MAXNODES} \
+                     "$REPO_ROOT/scripts/delta/genome_array.sbatch")
+        echo "$K $r $jid $T $OUTROOT" >> "$MANIFEST"
+        echo "  K=$K rep=$r -> job $jid  ($T node-tasks, walltime $WALL)  $OUTROOT"
+    done
+done
+
+echo
+echo "Manifest: $MANIFEST"
+echo "Watch:    squeue --me"
+echo "Aggregate when clear: bash scripts/delta/aggregate_reps.sh $MANIFEST"

--- a/scripts/delta/run_genome_reps.sh
+++ b/scripts/delta/run_genome_reps.sh
@@ -51,10 +51,13 @@ echo "NOTE: ~$(( $(echo "$KS" | wc -w) * REPS * 38 )) GB of FASTQ total across a
 
 for K in $KS; do
     T=$(( (N + K - 1) / K ))               # node-tasks = ceil(N / K)
-    # Tight per-task walltime sized to K: ~8 min/window at full node bandwidth,
-    # degrading as K windows share it. This is the straggler ceiling — small
-    # enough that --requeue bounces a sick node, large enough for a healthy batch.
-    MINUTES=$(( 10 + K * 6 ))
+    # Per-task walltime. --exclusive already removes the cross-tenant straggler
+    # that motivated a tight ceiling, so this must be GENEROUS: a heavy 25 Mb
+    # window runs ~8 min alone but slows ~linearly under packing (~0.8*K), and a
+    # ceiling below that silently kills legitimate slow shards (the first sweep
+    # capped every heavy window exactly at a 10+6K ceiling -> incomplete runs).
+    # Override with WALL_MINUTES if needed.
+    MINUTES="${WALL_MINUTES:-$(( 30 + K * 20 ))}"
     WALL=$(printf '%02d:%02d:00' $(( MINUTES / 60 )) $(( MINUTES % 60 )))
     for r in $(seq 1 "$REPS"); do
         OUTROOT="$SCRATCH/wg_${TAG}_k${K}_rep${r}"

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -193,7 +193,7 @@ fi
 # Pre-generate per-type truth subsets NOW, while bcftools (bioinf) is active, so
 # the truvari scoring stage needs only truvari on its PATH (no bcftools in that
 # env). Empty types are removed so the scoring loop skips them.
-for svt in DEL DUP INV INS BND; do
+for svt in DEL DUP INV INS BND CNV; do
     typed="$OUTDIR/truth_sv_${svt}.vcf.gz"
     bcftools view -i "INFO/SVTYPE=\"$svt\"" -O z -o "$typed" "$TRUTH_SV" 2>/dev/null || continue
     bcftools index -f -t "$typed" 2>/dev/null || true
@@ -254,8 +254,10 @@ run_truvari() {  # <truth.vcf.gz> <out-subdir-name>
         python3 - "$out/summary.json" "$name" <<'PY'
 import json, sys
 s = json.load(open(sys.argv[1])); name = sys.argv[2]
-print(f"  {name:<8} recall={s.get('recall',0):.3f}  precision={s.get('precision',0):.3f}  "
-      f"f1={s.get('f1',0):.3f}  TP={s.get('TP-base',0)}  FN={s.get('FN',0)}  FP={s.get('FP',0)}")
+# truvari writes null (None) for metrics when a subset has no comparisons;
+# `or 0` coerces None -> 0 (s.get(k, 0) only defaults a MISSING key, not a null one).
+print(f"  {name:<8} recall={(s.get('recall') or 0):.3f}  precision={(s.get('precision') or 0):.3f}  "
+      f"f1={(s.get('f1') or 0):.3f}  TP={s.get('TP-base') or 0}  FN={s.get('FN') or 0}  FP={s.get('FP') or 0}")
 PY
     else
         echo "  $name: truvari produced no summary.json (see $out)"

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -302,5 +302,15 @@ a simulator bug — inspect the pre-flight schema dump. Uniformly low recall for
 type rneat emitted heavily = candidate SV-generation bug (the Phase-2 target).
 EOF
 
+# Reclaim scratch once scoring is done: FASTQ is the bulk (~GBs/run at 60x) and
+# isn't needed afterward — BAMs, Manta calls, the truth VCFs, and the truvari
+# summaries are kept, so re-scoring and re-calling still work. This keeps a
+# parameter sweep (per-tissue / purity) from exhausting the shared project quota.
+# Set PRUNE_FASTQ=0 to retain the reads.
+if [[ "${PRUNE_FASTQ:-1}" == "1" ]]; then
+    echo "[prune] removing FASTQ intermediates (set PRUNE_FASTQ=0 to keep)..."
+    rm -f "$OUTDIR"/sample_*_r1.fastq.gz "$OUTDIR"/sample_*_r2.fastq.gz
+fi
+
 # Persist report artifacts off scratch + record provenance/resources.
 archive_run sv "$OUTDIR" truvari_overall/summary.json

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -70,6 +70,9 @@ TUMOR_MODEL="${TUMOR_MODEL:-$REPO_ROOT/tools/cosmic_v104_pancancer_model.json.gz
 
 MANTA_ENV="${MANTA_ENV:-manta}"
 TRUVARI_ENV="${TRUVARI_ENV:-truvari}"
+# rneat SVs reach ~1 Mb; truvari's default --sizemax is 50 kb, which would silently
+# EXCLUDE most large rneat SVs from scoring. Raise it to cover the full range.
+TRUVARI_SIZEMAX="${TRUVARI_SIZEMAX:-5000000}"
 
 THREADS=$SLURM_CPUS_PER_TASK
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
@@ -249,7 +252,8 @@ run_truvari() {  # <truth.vcf.gz> <out-subdir-name>
     local name="$2"
     local out="$OUTDIR/truvari_$name"
     rm -rf "$out"   # truvari requires the output dir not pre-exist
-    truvari bench -b "$truth" -c "$MANTA_SV" -f "$REFERENCE" -o "$out" --passonly 2>&1 | tail -3 || true
+    truvari bench -b "$truth" -c "$MANTA_SV" -f "$REFERENCE" -o "$out" \
+        --passonly --sizemax "$TRUVARI_SIZEMAX" 2>&1 | tail -3 || true
     if [[ -f "$out/summary.json" ]]; then
         python3 - "$out/summary.json" "$name" <<'PY'
 import json, sys

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -1,0 +1,280 @@
+#!/bin/bash
+# SLURM job: structural-variant (SV) validation pipeline on Delta.
+#
+# WHY THIS EXISTS: gen-cancer-reads emits structural variants (DEL/DUP/INV/INS/BND
+# and CNVs) into the tumor truth VCF, but every validation so far ran through
+# Mutect2 + som.py, which score SNVs/indels ONLY. The SV machinery has therefore
+# never been checked against a real SV caller. This pipeline closes that gap: it
+# simulates an SV-rich tumor/normal pair, calls somatic SVs with Manta, and scores
+# recall/precision against rneat's own SV truth with truvari — the same
+# "align + call + compare" loop that surfaced the strand bugs (#285/#287) for SNVs.
+#
+# Stages:
+#   1. Simulate tumor/normal FASTQ + SV-tagged truth VCF (cancer_simulate.sh,
+#      SV_RATE_SCALE > 0).
+#   2-3. Align normal + merged-tumor to reference with BWA-MEM2; sort + index.
+#   3b. PRE-FLIGHT: inspect rneat's SV truth records (SVTYPE/SVLEN/END/symbolic
+#      ALT) and extract a somatic-SV-only truth set; abort early if it's empty or
+#      malformed so we don't waste a Manta run. (First-run sanity for VCF
+#      compatibility — adjust the SV filter below to match the schema it prints.)
+#   4. Call somatic SVs with Manta (tumor/normal mode).
+#   5. Score Manta calls vs the SV truth with truvari (overall + per SV type).
+#
+# Each stage is idempotent — existing outputs are skipped, so a re-run resumes.
+#
+# PREREQUISITES (one-time; Manta needs python2, truvari python3 — separate envs):
+#   bash scripts/delta/setup.sh              # reference build + bioinf env
+#   conda create -y -n manta   -c bioconda -c conda-forge manta
+#   conda create -y -n truvari -c bioconda -c conda-forge truvari
+#   (override env names with MANTA_ENV / TRUVARI_ENV if you named them differently)
+#
+# Usage:
+#   sbatch scripts/delta/sv_pipeline.sbatch
+#   REFERENCE=/path/ref.fa SV_RATE_SCALE=2.0 TUMOR_MODEL=/path/model.json.gz \
+#     sbatch scripts/delta/sv_pipeline.sbatch
+#   # per-tissue SV spectrum check (BRCA DUP-dominant / skin BND / lung DEL):
+#   TUMOR_MODEL=$REPO_ROOT/tools/cosmic_pancancer_sv_BRCA.json.gz sbatch ...
+
+#SBATCH --job-name=rneat-sv
+#SBATCH --partition=cpu
+#SBATCH --account=bhrd-delta-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=64
+#SBATCH --mem=240G
+#SBATCH --time=12:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+# ── Parameters ───────────────────────────────────────────────────────────
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # archive_run() + Delta path resolution
+
+REFERENCE="${REFERENCE:-$SCRATCH/neat_data/chr22.fa}"
+OUTDIR="${OUTDIR:-$SCRATCH/sv_$SLURM_JOB_ID}"
+
+TOTAL_COVERAGE="${TOTAL_COVERAGE:-30}"
+PURITY="${PURITY:-0.6}"
+READ_LEN="${READ_LEN:-151}"
+PAIRED="${PAIRED:-true}"
+FRAG_MEAN="${FRAG_MEAN:-350}"
+FRAG_SD="${FRAG_SD:-50}"
+# SVs are the whole point — must be > 0. Scale up to enrich the truth set.
+SV_RATE_SCALE="${SV_RATE_SCALE:-1.0}"
+
+# Tumor model: pan-cancer SV model by default; swap a per-tissue SV model
+# (cosmic_pancancer_sv_{BRCA,skin,lung}.json.gz) to check tissue-specific spectra.
+TUMOR_MODEL="${TUMOR_MODEL:-$REPO_ROOT/tools/cosmic_v104_pancancer_model.json.gz}"
+
+MANTA_ENV="${MANTA_ENV:-manta}"
+TRUVARI_ENV="${TRUVARI_ENV:-truvari}"
+
+THREADS=$SLURM_CPUS_PER_TASK
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
+RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
+PREFIX="$OUTDIR/sample"
+
+if awk "BEGIN{exit !($SV_RATE_SCALE <= 0)}"; then
+    echo "ERROR: SV_RATE_SCALE must be > 0 for the SV pipeline (got $SV_RATE_SCALE)." >&2
+    exit 1
+fi
+
+# ── Environment ─────────────────────────────────────────────────────────
+source "$HOME/.cargo/env"
+module load samtools/1.22-cce19.0.0
+module load htslib/1.22-gcc13.3.1
+setup_conda
+
+mkdir -p "$OUTDIR"
+REF_NAME="$(basename "$REFERENCE")"
+
+echo "=== rneat SV validation pipeline: $SLURM_JOB_ID ==="
+echo "Reference:  $REFERENCE"
+echo "Output:     $OUTDIR"
+echo "Coverage:   ${TOTAL_COVERAGE}x  Purity: $PURITY  SV scale: $SV_RATE_SCALE"
+echo "Tumor model:$TUMOR_MODEL"
+echo "Threads:    $THREADS"
+
+# ── Stage 1: Simulate (SV-rich tumor/normal) ─────────────────────────────
+conda_activate bioinf   # bwa-mem2, bcftools (samtools via module)
+MERGED_R1="${PREFIX}_merged_r1.fastq.gz"
+NORMAL_R1="${PREFIX}_normal_r1.fastq.gz"
+TRUTH_VCF="${PREFIX}_merged_truth.vcf.gz"
+
+if [[ -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then
+    echo "[1/5] Simulation outputs already present — skipping."
+else
+    echo "[1/5] Simulating SV-rich tumor/normal reads..."
+    PAIRED_FLAG=""
+    [[ "$PAIRED" == "true" ]] && PAIRED_FLAG="--paired-ended --fragment-mean $FRAG_MEAN --fragment-st-dev $FRAG_SD"
+    RNG_SEED_ROOT="${RNG_SEED_ROOT:-sv-validate}${SLURM_ARRAY_TASK_ID:+-rep$SLURM_ARRAY_TASK_ID}"
+    bash "$REPO_ROOT/tools/cancer_simulate.sh" \
+        --reference "$REFERENCE" \
+        --output-prefix "$PREFIX" \
+        --total-coverage "$TOTAL_COVERAGE" \
+        --purity "$PURITY" \
+        --read-len "$READ_LEN" \
+        --tumor-model "$TUMOR_MODEL" \
+        --sv-rate-scale "$SV_RATE_SCALE" \
+        --rng-seed "$RNG_SEED_ROOT" \
+        --rneat-bin "$RNEAT_BIN" \
+        $PAIRED_FLAG
+    echo "[1/5] Simulation complete."
+fi
+
+# ── Stage 2 & 3: Index reference, align ──────────────────────────────────
+NORMAL_BAM="$OUTDIR/normal.bam"
+TUMOR_BAM="$OUTDIR/tumor.bam"
+
+index_and_align() {
+    local in_fq="$1" out_bam="$2" sample="$3"
+    if [[ -f "$out_bam" && -f "${out_bam}.bai" ]]; then
+        echo "  $sample BAM already present — skipping."; return 0
+    fi
+    if [[ ! -f "${REFERENCE}.bwt.2bit.64" ]] && [[ ! -f "${REFERENCE}.bwt" ]]; then
+        echo "  Indexing reference for BWA-MEM2 (one-time)..."
+        bwa-mem2 index "$REFERENCE" 2>&1 | tail -3
+    fi
+    [[ -f "${REFERENCE}.fai" ]] || samtools faidx "$REFERENCE"
+    echo "  Aligning $sample..."
+    local rg="@RG\tID:${sample}\tSM:${sample}\tLB:${sample}\tPL:ILLUMINA"
+    if [[ "$PAIRED" == "true" ]]; then
+        local in_r2="${in_fq/_r1./_r2.}"
+        bwa-mem2 mem -t "$THREADS" -R "$rg" "$REFERENCE" "$in_fq" "$in_r2" 2>"$OUTDIR/${sample}_bwa.log" \
+            | samtools sort -@ "$THREADS" -o "$out_bam"
+    else
+        bwa-mem2 mem -t "$THREADS" -R "$rg" "$REFERENCE" "$in_fq" 2>"$OUTDIR/${sample}_bwa.log" \
+            | samtools sort -@ "$THREADS" -o "$out_bam"
+    fi
+    samtools index "$out_bam"
+    echo "  $sample BAM ready: $out_bam"
+}
+
+echo "[2/5] Aligning normal reads..."
+index_and_align "$NORMAL_R1" "$NORMAL_BAM" "NORMAL"
+echo "[3/5] Aligning tumor (merged) reads..."
+index_and_align "${PREFIX}_merged_r1.fastq.gz" "$TUMOR_BAM" "TUMOR"
+
+# ── Stage 3b: PRE-FLIGHT — inspect + extract the somatic SV truth ────────
+# rneat's SVs are symbolic records (ALT like <DEL>/<DUP>/<INV>, INFO SVTYPE/
+# SVLEN/END). Print a sample so we can confirm the schema, then extract the
+# somatic SV subset truvari will score. NEAT_ORIGIN=somatic drops germline
+# carry-through; the symbolic-ALT test keeps only SVs (not SNVs/indels).
+TRUTH_SV="$OUTDIR/truth_sv.vcf.gz"
+echo "[3b/5] Inspecting rneat SV truth..."
+echo "  --- SV INFO header lines ---"
+bcftools view -h "$TRUTH_VCF" | grep -iE 'INFO=<ID=(SVTYPE|SVLEN|END|NEAT_ORIGIN)' || \
+    echo "  (no SVTYPE/SVLEN/END/NEAT_ORIGIN INFO headers found — schema may differ!)"
+echo "  --- first symbolic-ALT (SV) records ---"
+bcftools view -H "$TRUTH_VCF" | awk '$5 ~ /^</' | head -5 || true
+echo "  --- SVTYPE counts in truth (all origins) ---"
+bcftools view -H "$TRUTH_VCF" | grep -oE 'SVTYPE=[A-Z]+' | sort | uniq -c || true
+
+if [[ -f "$TRUTH_SV" ]]; then
+    echo "  somatic SV truth already extracted — skipping."
+else
+    # Permissive SV selector: symbolic ALT OR an SVTYPE INFO tag, AND somatic.
+    # If the pre-flight above shows a different schema, adjust this -i expression.
+    bcftools view -i '(ALT[0]~"<" || INFO/SVTYPE!=".") && INFO/NEAT_ORIGIN="somatic"' \
+        -O z -o "$TRUTH_SV" "$TRUTH_VCF"
+    bcftools sort -O z -o "$TRUTH_SV" "$TRUTH_SV" 2>/dev/null || true
+    bcftools index -f -t "$TRUTH_SV"
+fi
+SV_TRUTH_N=$(bcftools view -H "$TRUTH_SV" 2>/dev/null | wc -l)
+echo "  somatic SV truth records: $SV_TRUTH_N"
+if [[ "$SV_TRUTH_N" -eq 0 ]]; then
+    echo "ERROR: no somatic SV records extracted. Check the pre-flight schema dump" >&2
+    echo "       above and adjust the SV selector. Raising SV_RATE_SCALE also helps." >&2
+    exit 1
+fi
+
+# Pre-generate per-type truth subsets NOW, while bcftools (bioinf) is active, so
+# the truvari scoring stage needs only truvari on its PATH (no bcftools in that
+# env). Empty types are removed so the scoring loop skips them.
+for svt in DEL DUP INV INS BND; do
+    typed="$OUTDIR/truth_sv_${svt}.vcf.gz"
+    bcftools view -i "INFO/SVTYPE=\"$svt\"" -O z -o "$typed" "$TRUTH_SV" 2>/dev/null || continue
+    bcftools index -f -t "$typed" 2>/dev/null || true
+    n=$(bcftools view -H "$typed" 2>/dev/null | wc -l)
+    echo "  truth $svt: $n"
+    [[ "$n" -eq 0 ]] && rm -f "$typed" "${typed}.tbi"
+done
+
+# ── Stage 4: Manta somatic SV calling ────────────────────────────────────
+MANTA_DIR="$OUTDIR/manta"
+MANTA_SV="$MANTA_DIR/results/variants/somaticSV.vcf.gz"
+if [[ -f "$MANTA_SV" ]]; then
+    echo "[4/5] Manta somaticSV already present — skipping."
+else
+    echo "[4/5] Running Manta (tumor/normal somatic SV)..."
+    conda_activate "$MANTA_ENV"
+    rm -rf "$MANTA_DIR"
+    # Manta wants a bgzipped+faidx'd reference and indexed BAMs (we have both).
+    configManta.py \
+        --normalBam "$NORMAL_BAM" \
+        --tumorBam  "$TUMOR_BAM" \
+        --referenceFasta "$REFERENCE" \
+        --runDir "$MANTA_DIR" 2>&1 | tail -5
+    "$MANTA_DIR/runWorkflow.py" -j "$THREADS" 2>&1 | tail -10
+    [[ -f "$MANTA_SV" ]] || { echo "ERROR: Manta produced no somaticSV.vcf.gz" >&2; exit 1; }
+    echo "[4/5] Manta complete: $(bcftools view -H "$MANTA_SV" | wc -l) somatic SV calls."
+fi
+
+# ── Stage 5: Score with truvari (overall + per SV type) ──────────────────
+echo "[5/5] Scoring SVs with truvari..."
+conda_activate "$TRUVARI_ENV"
+
+run_truvari() {  # <truth.vcf.gz> <out-subdir-name>
+    local truth="$1" name="$2" out="$OUTDIR/truvari_$name"
+    rm -rf "$out"   # truvari requires the output dir not pre-exist
+    truvari bench -b "$truth" -c "$MANTA_SV" -f "$REFERENCE" -o "$out" --passonly 2>&1 | tail -3 || true
+    if [[ -f "$out/summary.json" ]]; then
+        python - "$out/summary.json" "$name" <<'PY'
+import json, sys
+s = json.load(open(sys.argv[1])); name = sys.argv[2]
+print(f"  {name:<8} recall={s.get('recall',0):.3f}  precision={s.get('precision',0):.3f}  "
+      f"f1={s.get('f1',0):.3f}  TP={s.get('TP-base',0)}  FN={s.get('FN',0)}  FP={s.get('FP',0)}")
+PY
+    else
+        echo "  $name: truvari produced no summary.json (see $out)"
+    fi
+}
+
+echo "  --- overall ---"
+run_truvari "$TRUTH_SV" overall
+
+echo "  --- per SV type (recall: did Manta recover each type rneat emitted?) ---"
+# Score the per-type truth subsets pre-generated in stage 3b (bcftools not needed
+# here — the truvari env may not have it).
+for typed in "$OUTDIR"/truth_sv_*.vcf.gz; do
+    [[ -f "$typed" ]] || continue            # no typed files matched
+    svt=$(basename "$typed" .vcf.gz); svt=${svt#truth_sv_}
+    run_truvari "$typed" "$svt"
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────
+cat <<EOF
+
+════════════════════════════════════════════════════════════════
+SV validation pipeline complete — Job $SLURM_JOB_ID
+
+Inputs:
+  Reference:    $REFERENCE
+  Coverage:     ${TOTAL_COVERAGE}x  Purity: $PURITY  SV scale: $SV_RATE_SCALE
+  Tumor model:  $TUMOR_MODEL
+
+Key outputs in $OUTDIR:
+  SV truth:     truth_sv.vcf.gz            ($SV_TRUTH_N somatic SVs)
+  Manta calls:  manta/results/variants/somaticSV.vcf.gz
+  Scores:       truvari_overall/summary.json + truvari_<TYPE>/
+
+Interpretation: low overall recall with high per-type recall for some types =
+a representation/format mismatch (truvari SVTYPE/SVLEN matching), not necessarily
+a simulator bug — inspect the pre-flight schema dump. Uniformly low recall for a
+type rneat emitted heavily = candidate SV-generation bug (the Phase-2 target).
+EOF
+
+# Persist report artifacts off scratch + record provenance/resources.
+archive_run sv "$OUTDIR" truvari_overall/summary.json

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -219,7 +219,8 @@ else
         --runDir "$MANTA_DIR" 2>&1 | tail -5
     "$MANTA_DIR/runWorkflow.py" -j "$THREADS" 2>&1 | tail -10
     [[ -f "$MANTA_SV" ]] || { echo "ERROR: Manta produced no somaticSV.vcf.gz" >&2; exit 1; }
-    echo "[4/5] Manta complete: $(bcftools view -H "$MANTA_SV" | wc -l) somatic SV calls."
+    # Count without bcftools — the manta env doesn't have it; zcat/grep are env-independent.
+    echo "[4/5] Manta complete: $(zcat "$MANTA_SV" | grep -vc '^#' || true) somatic SV calls."
 fi
 
 # ── Stage 5: Score with truvari (overall + per SV type) ──────────────────
@@ -227,11 +228,15 @@ echo "[5/5] Scoring SVs with truvari..."
 conda_activate "$TRUVARI_ENV"
 
 run_truvari() {  # <truth.vcf.gz> <out-subdir-name>
-    local truth="$1" name="$2" out="$OUTDIR/truvari_$name"
+    # Separate `local`s on purpose: a combined `local a=$1 b=$2 c=...$b` expands
+    # $b before it's assigned, which trips `set -u` (unbound variable).
+    local truth="$1"
+    local name="$2"
+    local out="$OUTDIR/truvari_$name"
     rm -rf "$out"   # truvari requires the output dir not pre-exist
     truvari bench -b "$truth" -c "$MANTA_SV" -f "$REFERENCE" -o "$out" --passonly 2>&1 | tail -3 || true
     if [[ -f "$out/summary.json" ]]; then
-        python - "$out/summary.json" "$name" <<'PY'
+        python3 - "$out/summary.json" "$name" <<'PY'
 import json, sys
 s = json.load(open(sys.argv[1])); name = sys.argv[2]
 print(f"  {name:<8} recall={s.get('recall',0):.3f}  precision={s.get('precision',0):.3f}  "

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -223,6 +223,21 @@ else
     echo "[4/5] Manta complete: $(zcat "$MANTA_SV" | grep -vc '^#' || true) somatic SV calls."
 fi
 
+# Diagnostic: compare PRE-filter candidates vs POST-filter somatic calls. This
+# separates "reads carry no SV signal" (simulator/coverage issue) from "signal
+# present but somatic-classified away" (support/purity issue) when recall is low.
+CAND_SV="$MANTA_DIR/results/variants/candidateSV.vcf.gz"
+SOM_N=$(zcat "$MANTA_SV" | grep -vc '^#' || true)
+CAND_N=0; [[ -f "$CAND_SV" ]] && CAND_N=$(zcat "$CAND_SV" | grep -vc '^#' || true)
+echo "  Manta SV signal: $CAND_N candidate(s) (pre-filter) -> $SOM_N somatic (post-filter)"
+if [[ "$CAND_N" -eq 0 ]]; then
+    echo "  NOTE: 0 candidates -> reads present NO detectable SV signal to the aligner"
+    echo "        (coverage too low, too few truth SVs, or an rneat SV-read-emission gap)."
+elif [[ "$SOM_N" -eq 0 ]]; then
+    echo "  NOTE: candidates exist but 0 somatic -> signal IS there; Manta's somatic"
+    echo "        classifier dropped them (low support at this coverage/purity)."
+fi
+
 # ── Stage 5: Score with truvari (overall + per SV type) ──────────────────
 echo "[5/5] Scoring SVs with truvari..."
 conda_activate "$TRUVARI_ENV"


### PR DESCRIPTION
## Summary

Phase-2 HPC scaling **and** structural-variant validation for the ACCESS report, with the
report sections that document them. **No rneat source changes** — entirely `scripts/delta/`
tooling and `docs/access_report_draft.md` (5 files, +749 / −70).

This branch delivers two self-contained bodies of work that share the Delta harness:

---

### 1. HPC whole-genome scaling — exclusive-node region-sharding (report §3.6)

rneat is memory-bandwidth-bound, so whole-genome speed comes from multi-process region
sharding, not threads. This makes that reproducible and contention-free:

- **`genome_array.sbatch`** — rewritten to `--exclusive` whole-node packing
  (`SHARDS_PER_NODE` single-thread windows/node), generous per-task walltime + `--requeue`
  straggler-proofing, idempotent per-shard skip.
- **`run_genome_reps.sh`** — K-sweep × reps driver, manifest on durable storage.
- **`aggregate_reps.sh`** — true wall-clock span + per-shard distribution + mean±sd, with a
  shared-partition baseline row.

**Findings (measured on GRCh38):** a naive shared-partition run hit **3 h 41 m** with bimodal
per-shard times (median 2.5 m, p90 131 m, max 170 m) caused by *cross-tenant* memory-bandwidth
contention. On exclusive nodes, **K=2 completed in 2 h 30 m with a 6× tighter per-window
ceiling**; the packing penalty is superlinear (8→29→101 min/window at K=1/2/4). Resolves to a
three-regime trade-off and an "always exclusive, match packing density to node availability"
recommendation.

### 2. Structural-variant validation — new (report §3.7)

The cancer workflow's SVs had only ever been validated through Mutect2 (SNV/indel-only) — never
through an SV-aware caller. **`sv_pipeline.sbatch`** closes that: SV-rich tumor/normal →
BWA-MEM2 → **Manta** somatic SV → **truvari** scoring, with a pre-flight SV-truth schema check,
candidate-vs-somatic diagnostics, per-type + per-tissue breakdown, and FASTQ pruning to respect
the shared scratch quota.

**Result (60×/0.8 chr22):** read-level breakpoint signal is correct for **every** SV class.
DEL 0.882 / DUP 0.929 / INV 1.000 recall (91% on scoreable classes, incl. a 1 Mb DUP); CNV
validated by depth (1.83×); BND signal present in the reads (8–73 discordant/split reads/locus)
even where Manta doesn't call it; somatic specificity confirmed (no leak). Per-tissue models
shift the truth spectrum correctly (BRCA→DUP, skin→BND, lung→DEL) with tissue-independent
recovery; a purity sweep shows recall robust 0.3→0.7 and a coverage-model dip at 0.9
(matched-normal starvation, not detection). **No simulator defect found.**

The realism/interoperability gaps surfaced (idealized breakpoints, BND-vs-DUP representation,
SV-insertion generation, normal-coverage decoupling, panel-of-normals) are tracked under
**epic #311** (tickets #312–#316), each to be re-validated via this pipeline.

---

## Report
- §3.6 — HPC trade-offs + measured shared-vs-exclusive numbers.
- §3.7 — SV validation (read-level signal, per-type/per-tissue recovery, purity response, caveats).
- §4 — items 2 & 3 marked complete.

## Testing
- All scripts `bash -n` clean; awk/truvari reporting glue validated locally.
- All runs executed on NCSA Delta; job IDs cited inline in §3.6 / §3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
