### PR TITLE
Delta: broaden somatic-caller coverage (Delly/Strelka2/GATK-CNV/signatures) + at-scale validation (report §3.8/§3.9)

### DIFF
--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -366,6 +366,45 @@ without interval scatter).
 Ensembl-named reference (GRCh38: `1/2/3`) needs a chr-prefixed copy for scoring —
 now handled automatically by the cancer pipeline.
 
+### 3.9 Cross-caller coverage and mutational-signature fidelity
+
+To avoid judging rneat's cancer features by a single caller, second callers were
+added across classes on the existing Delta harnesses — **Delly** (somatic SV, vs
+Manta), **Strelka2** (somatic SNV/indel, vs Mutect2), and **GATK somatic-CNV** (vs
+the depth check of §3.7) — plus a **mutational-signature** check
+(SigProfilerAssignment). Cross-caller *agreement* is the strongest anti-overfit
+signal; the signature check probes something variant-recall cannot: does rneat
+reproduce the COSMIC mutational *signature* its tumor model encodes?
+
+**At the signature level, it does not — a real fidelity limitation.** Fitting
+COSMIC signatures to 6,225 simulated somatic SNVs (chr1–3) assigned them entirely
+to flat, clock-like signatures (SBS5 45 %, SBS3 31 %, SBS41 17 %, SBS12 7 %), with
+**no SBS1** — the near-universal C>T-at-CpG signature present in essentially every
+real tumor. The 96-context spectrum confirms it: the four CpG `[C>T]G` contexts are
+the *lowest* C>T contexts (16–23 counts vs ~65 average).
+
+**Root cause (verified both ends).** The bundled COSMIC model is faithful — its
+per-context substitution model encodes strong CpG C>T enrichment (conditional
+0.78–0.88 at CpG vs 0.39–0.62 elsewhere). But rneat places mutations at a
+**context-independent rate** and conditions only the *alt allele* on trinucleotide
+context. The realized spectrum is therefore *(genome trinucleotide frequency) ×
+(conditional alt)*, not the COSMIC signature; because CpG dinucleotides are ~10×
+genome-depleted, the CpG C>T peak never forms. COSMIC signatures are **rate
+patterns** (mutations-per-context), which a uniform-placement model cannot
+represent.
+
+**Interpretation.** rneat faithfully reproduces the substitution-*type*
+distribution and transition bias (Ts/Tv 2.34, §3.1/3.3) and recovers variants well
+across independent callers and at scale (§3.3/3.4/3.7/3.8) — but simulated somatic
+SNVs do not reconstruct the input COSMIC *signature* under signature extraction.
+This is a limitation of the underlying NEAT trinucleotide approach (the germline
+default model shares it), and the fix is to weight mutation *placement* by the
+signature's per-context probability rather than placing uniformly (tracked: #320).
+It is exactly the class of gap recall-based metrics cannot surface — and the reason
+the signature check was added. The broadened SV/SNV/CNV caller coverage (#317) is
+implemented and validating on Delta; cross-caller agreement results will be added
+as the runs complete.
+
 ---
 
 ## 4. Phase 2 — robustness at scale (planned, key deliverables)

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -409,9 +409,19 @@ This is a limitation of the underlying NEAT trinucleotide approach (the germline
 default model shares it), and the fix is to weight mutation *placement* by the
 signature's per-context probability rather than placing uniformly (tracked: #320).
 It is exactly the class of gap recall-based metrics cannot surface — and the reason
-the signature check was added. The broadened SV/SNV/CNV caller coverage (#317) is
-implemented and validating on Delta; cross-caller agreement results will be added
-as the runs complete.
+the signature check was added.
+
+**Cross-caller results (#317).** The broadened coverage reinforces the anti-overfit
+picture across independent callers. **SVs:** Delly reproduces Manta's per-type recall
+*exactly* (DEL 0.882 / DUP 0.929 / INV 1.000; §3.7). **SNV/indel:** VarScan2 — a
+different statistical model from Mutect2 — calls rneat's somatic variants at high
+**precision** (0.93 SNV / 0.94 indel, vs Mutect2's 0.87 / 0.84): the calls it makes
+*match the truth*, so the data is not a Mutect2-specific artifact. Its lower recall
+(0.63 / 0.53 vs Mutect2's 0.93 / 0.90) reflects VarScan2's more conservative model
+and the high-confidence (`Somatic.hc`) filter, not a simulator property — Mutect2
+(sensitive) and VarScan2 (precise) bracket the truth as expected for two callers.
+(Strelka2 was dropped — its 2018 build SIGSEGVs on Delta's stack. GATK somatic-CNV
+is the remaining cross-check, pending.)
 
 ---
 

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -300,6 +300,14 @@ Overall figures across all 64 truth SVs (recall 0.500, precision 0.561) are boun
 by BND (unscoreable by truvari) and CNV (uncallable by Manta) — tool constraints,
 not simulator defects.
 
+**Confirmed by an independent second caller.** Delly (read-pair/split/depth-based,
+no assembly) recovers the same SVs at the *same* rates — **DEL 0.882, DUP 0.929,
+INV 1.000, identical to Manta** — with slightly higher precision (0.667 vs 0.561),
+and likewise scores 0/22 BND and 0/7 CNV. Two independent callers agreeing this
+closely is strong evidence rneat's SV data is not tuned to one tool, and that the
+BND/CNV gaps are scorer/caller limitations (truvari cannot benchmark breakends;
+neither caller emits truvari-matchable CNV) rather than simulator defects.
+
 **Per-tissue models shift the spectrum correctly.** Swapping the pan-cancer model
 for tissue-specific COSMIC SV models reproduces each tissue's dominant SV type in
 the truth set, tracking the model's type probabilities, while per-type *recovery*

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -343,6 +343,29 @@ callers and truth sets expect (#313), and SV-scale insertions did not appear in 
 run (`INS: 0`) despite a non-zero model probability (#314). None is a defect in the
 validated read generation — all are realism / interoperability improvements.
 
+### 3.8 At-scale validation (chr1–3 subset, ~690 Mb)
+
+To confirm the chr22 metrics are not overfit to one chromosome, both pipelines were
+re-run on a **chr1–chr3 subset of GRCh38** — ~690 Mb, ~13× chr22, entirely different
+sequence. Every metric held or slightly improved:
+
+| Pipeline | Metric | chr1–3 | chr22 |
+|---|---|---|---|
+| Germline (rneat) | SNP recall / precision | **0.990 / 0.9997** | 0.989 / 0.9996 |
+| Germline (rneat) | INDEL recall / precision | **0.988 / 0.990** | 0.982 / 0.989 |
+| Cancer (Mutect2 T/N) | somatic SNV recall / precision | **0.944 / 0.910** | 0.925 / 0.872 |
+| Cancer (Mutect2 T/N) | somatic INDEL recall / precision | **0.908 / 0.885** | 0.900 / 0.844 |
+
+Germline Ts/Tv held at 2.34 (truth = query). rneat's fidelity is therefore not an
+artifact of chr22 — it holds at 13× the scale on different sequence. Whole-genome
+runs were not pursued (no divergence to investigate); the Mutect2 tumor/normal step
+is the practical scale ceiling (~3.2 h on chr1–3, and ≫48 h projected genome-wide
+without interval scatter).
+
+*Tooling note:* hap.py/som.py hardcodes UCSC chr-prefixing of input VCFs, so an
+Ensembl-named reference (GRCh38: `1/2/3`) needs a chr-prefixed copy for scoring —
+now handled automatically by the cancer pipeline.
+
 ---
 
 ## 4. Phase 2 — robustness at scale (planned, key deliverables)
@@ -353,10 +376,12 @@ cover, with an explicit goal of **avoiding over-tuning to chr22**: exercise rnea
 on substantial and *varied* inputs to confirm robustness and surface any
 remaining defects of the kind already found.
 
-1. **Whole-genome scale.** Run the full germline and cancer pipelines on GRCh38
-   (whole genome and large chromosome subsets), not just chr22. Confirms the
-   Phase 1 metrics hold at genome scale and that nothing was overfit to one
-   chromosome.
+1. **Whole-genome scale — done at chr1–3 (§3.8).** Germline and cancer pipelines
+   re-run on a ~690 Mb chr1–3 subset of GRCh38 (~13× chr22): all metrics held or
+   slightly improved (germline SNP 0.990 / indel 0.988; cancer somatic SNV 0.944 /
+   indel 0.908), confirming nothing was overfit to chr22. Full whole-genome not
+   pursued — no divergence to investigate, and Mutect2 T/N is the scale ceiling
+   (≫48 h genome-wide without interval scatter).
 
 2. **Multicore scaling / HPC tuning — COMPLETE (§3.6).** The thread regression
    was characterized (memory-bandwidth-bound, allocator- and NUMA-independent) and

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -422,7 +422,7 @@ remaining defects of the kind already found.
 
 ## 5. Phase 3 — stretch goals (time permitting)
 
-- **Long-read simulation (ONT / PacBio-style).** Validate rneat against the
+- **Long-read simulation (ONT / PacBio-style)** (tracked: #319). Validate rneat against the
   long-read paradigm: simulate single-molecule reads (kb-scale lengths and the
   higher, indel-dominated, homopolymer-dependent error profile characteristic of
   nanopore / HiFi data, unpaired), align with **minimap2**, and score recall with

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -274,9 +274,13 @@ through a dedicated chimeric-read pass that stitches flanks across each junction
 and that signal is present and correctly placed for **every** class — including
 where the caller fails to recover it.
 
-- **CNV by depth.** Manta cannot call copy number, so we verified it directly: a
-  `CN=4` region showed 110.5× vs a 60.4× flank = **1.83×**, matching the expected
-  `(0.8·4 + 0.2·2)/2 = 1.8×` for that amplification at purity 0.8.
+- **CNV — two ways.** Manta cannot call copy number. (i) *By depth:* a `CN=4`
+  region showed 110.5× vs a 60.4× flank = **1.83×**, matching the expected
+  `(0.8·4 + 0.2·2)/2 = 1.8×` at purity 0.8. (ii) *By a copy-number caller:* GATK
+  `DenoiseReadCounts`→`ModelSegments`→`CallCopyRatioSegments` recovered **4/7 truth
+  CNVs with the correct gain/loss direction** (the misses are the small/low-amplitude
+  het CNVs — kb-scale events near the read-depth segmentation limit). Both confirm
+  rneat's CNVs carry correct, caller-detectable copy-ratio signal.
 - **Somatic specificity (no leak).** A homozygous somatic deletion was depleted
   5× in the tumor (60×→12×) while the normal stayed at full depth — the SV is real
   in the reads and correctly tumor-restricted.
@@ -294,7 +298,7 @@ Per-type recovery (Manta + truvari, 60×/0.8):
 | DUP | 14 | **0.929** (13/14) | — (incl. 1 Mb) |
 | INV | 4 | **1.000** (4/4) | — |
 | BND | 22 | signal present at read level; ~50% Manta-called | truvari can't benchmark breakends; Manta translocation recall |
-| CNV | 7 | depth-validated (1.83×) | Manta does not call CNV |
+| CNV | 7 | depth 1.83× + GATK caller 4/7 by direction | Manta does not call CNV |
 
 Overall figures across all 64 truth SVs (recall 0.500, precision 0.561) are bounded
 by BND (unscoreable by truvari) and CNV (uncallable by Manta) — tool constraints,
@@ -421,7 +425,8 @@ different statistical model from Mutect2 — calls rneat's somatic variants at h
 and the high-confidence (`Somatic.hc`) filter, not a simulator property — Mutect2
 (sensitive) and VarScan2 (precise) bracket the truth as expected for two callers.
 (Strelka2 was dropped — its 2018 build SIGSEGVs on Delta's stack. GATK somatic-CNV
-is the remaining cross-check, pending.)
+recovered **4/7 CNVs by direction** — no-PoN, since its panel step is a Spark tool
+incompatible with the env's Java 25 — corroborating the depth check, §3.7.)
 
 ---
 

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -422,9 +422,19 @@ remaining defects of the kind already found.
 
 ## 5. Phase 3 — stretch goals (time permitting)
 
-- **Long-read simulation.** Extend testing to long-read-style data
-  (longer fragments / single-molecule profiles) and validate against long-read
-  aligners/callers.
+- **Long-read simulation (ONT / PacBio-style).** Validate rneat against the
+  long-read paradigm: simulate single-molecule reads (kb-scale lengths and the
+  higher, indel-dominated, homopolymer-dependent error profile characteristic of
+  nanopore / HiFi data, unpaired), align with **minimap2**, and score recall with
+  long-read callers — **Clair3 / DeepVariant** for SNV/indel and **Sniffles2 /
+  cuteSV** for SVs (truvari for SV scoring, as in §3.7). Because a single long read
+  spans an SV breakpoint, this is the natural complement to the short-read SV
+  validation: it stresses the SV machinery from the other side and would exercise
+  the breakpoint-realism work in epic #311 directly. *Prerequisite:* a long-read
+  mode in rneat (read-length distribution + long-read error model) — today rneat
+  targets short paired-end Illumina data, so this is feature work gated ahead of
+  the validation, mirroring the short-read harnesses already built
+  (`germline_e2e` / `cancer_pipeline` / `sv_pipeline`).
 - **Plant genomes and polyploidy.** Exercise large, repetitive plant genomes and
   scope tuning for polyploid simulation (rneat's `ploidy` parameter and the
   allele-dosage work tracked separately), where structural variation and high

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -67,8 +67,13 @@ TUMOR_MODEL="$REPO_ROOT/tools/cosmic_v104_pancancer_model.json.gz"
 # Path to the hap.py Apptainer SIF (built by setup.sh).
 HAPPY_SIF="${HAPPY_SIF:-$SCRATCH/sif/happy_v0.3.12.sif}"
 
-# Run Strelka2 as a 2nd somatic SNV/indel caller alongside Mutect2 (cross-validation).
-RUN_STRELKA="${RUN_STRELKA:-1}"
+# Secondary somatic SNV/indel callers for cross-validation vs Mutect2. VarScan2 is
+# the working cross-check; Strelka2 2.9.10 SIGSEGVs on Delta's stack so it's OFF by
+# default (set RUN_STRELKA=1 to attempt it). Both are non-fatal — a failure never
+# aborts the primary Mutect2 result.
+RUN_VARSCAN="${RUN_VARSCAN:-1}"
+VARSCAN_ENV="${VARSCAN_ENV:-varscan}"
+RUN_STRELKA="${RUN_STRELKA:-0}"
 STRELKA_ENV="${STRELKA_ENV:-strelka}"
 
 THREADS=$SLURM_CPUS_PER_TASK
@@ -239,6 +244,47 @@ if [[ "$RUN_STRELKA" == "1" ]]; then
     fi
 fi
 
+# ── Stage 5c: VarScan2 somatic SNV/indel (robust 2nd caller vs Mutect2) ──
+# The working SNV/indel cross-check (Strelka2 is broken on Delta). Combined
+# normal+tumor mpileup -> varscan somatic -> processSomatic (high-confidence
+# somatic) -> merge SNP+indel -> scored vs the same somatic truth. Guarded:
+# never aborts the run. RUN_VARSCAN=0 to skip.
+VARSCAN_VCF=""
+if [[ "$RUN_VARSCAN" == "1" ]]; then
+    VARSCAN_VCF="$OUTDIR/varscan.somatic.vcf.gz"
+    if [[ -f "$VARSCAN_VCF" ]]; then
+        echo "[5c] VarScan2 somatic VCF already present — skipping."
+    else
+        echo "[5c] Running VarScan2 (tumor/normal somatic SNV/indel)..."
+        run_varscan() {
+            conda_activate "$VARSCAN_ENV"   # varscan (samtools comes from the module)
+            # Combined mpileup, NORMAL first then TUMOR (--mpileup 1 expects this order).
+            samtools mpileup -B -q 1 -f "$REFERENCE" "$NORMAL_BAM" "$TUMOR_BAM" \
+                > "$OUTDIR/varscan.mpileup" 2>"$OUTDIR/varscan_mpileup.log" || return 1
+            varscan somatic "$OUTDIR/varscan.mpileup" "$OUTDIR/varscan" \
+                --mpileup 1 --output-vcf 1 > "$OUTDIR/varscan_run.log" 2>&1 || return 1
+            varscan processSomatic "$OUTDIR/varscan.snp.vcf"   >> "$OUTDIR/varscan_run.log" 2>&1 || return 1
+            varscan processSomatic "$OUTDIR/varscan.indel.vcf" >> "$OUTDIR/varscan_run.log" 2>&1 || return 1
+        }
+        if run_varscan; then
+            conda_activate bioinf   # bcftools
+            for v in snp indel; do
+                bcftools sort -Oz -o "$OUTDIR/varscan.$v.somatic.vcf.gz" \
+                    "$OUTDIR/varscan.$v.Somatic.hc.vcf"
+                bcftools index -f -t "$OUTDIR/varscan.$v.somatic.vcf.gz"
+            done
+            bcftools concat -a "$OUTDIR/varscan.snp.somatic.vcf.gz" "$OUTDIR/varscan.indel.somatic.vcf.gz" \
+                | bcftools sort -Oz -o "$VARSCAN_VCF"
+            bcftools index -f -t "$VARSCAN_VCF"
+            rm -f "$OUTDIR/varscan.mpileup"   # large intermediate — reclaim space
+            echo "[5c] VarScan2 complete: $(zcat "$VARSCAN_VCF" | grep -vc '^#' || true) somatic calls."
+        else
+            echo "[5c] WARNING: VarScan2 failed (see $OUTDIR/varscan_run.log) — continuing without it; Mutect2 unaffected." >&2
+            VARSCAN_VCF=""
+        fi
+    fi
+fi
+
 # ── Stage 6: Score each caller with hap.py som.py ───────────────────────
 # Somatic-only truth (NEAT_ORIGIN=somatic); germline carry-through (shared) is
 # correctly ignored by T/N callers, so scoring against it would be meaningless.
@@ -298,7 +344,8 @@ som_score() {
 }
 
 som_score "$FILTERED_VCF" scored                                    # Mutect2
-[[ -n "$STRELKA_VCF" ]] && som_score "$STRELKA_VCF" scored_strelka   # Strelka2
+[[ -n "$VARSCAN_VCF" ]] && som_score "$VARSCAN_VCF" scored_varscan   # VarScan2 (2nd caller)
+[[ -n "$STRELKA_VCF" ]] && som_score "$STRELKA_VCF" scored_strelka   # Strelka2 (opt-in)
 echo "[6/6] Scoring complete."
 
 # ── Summary ──────────────────────────────────────────────────────────────
@@ -317,11 +364,16 @@ Key outputs in $OUTDIR:
   Truth VCF:      sample_merged_truth.vcf.gz  (NEAT_ORIGIN-tagged)
   Somatic truth:  scoring_truth.vcf.gz         (somatic only)
   Mutect2 calls:  mutect2.filtered.vcf.gz   -> scored.stats.csv
-  Strelka2 calls: strelka.somatic.vcf.gz    -> scored_strelka.stats.csv  (RUN_STRELKA=1)
+  VarScan2 calls: varscan.somatic.vcf.gz    -> scored_varscan.stats.csv  (RUN_VARSCAN=1)
+  Strelka2 calls: strelka.somatic.vcf.gz    -> scored_strelka.stats.csv  (RUN_STRELKA=1, opt-in)
 
 Top-line results (Mutect2):
 EOF
 [[ -f "$OUTDIR/scored.stats.csv" ]] && column -t -s',' "$OUTDIR/scored.stats.csv" || echo "  (Mutect2 score not found)"
+if [[ -n "$VARSCAN_VCF" && -f "$OUTDIR/scored_varscan.stats.csv" ]]; then
+    echo; echo "Top-line results (VarScan2):"
+    column -t -s',' "$OUTDIR/scored_varscan.stats.csv"
+fi
 if [[ -n "$STRELKA_VCF" && -f "$OUTDIR/scored_strelka.stats.csv" ]]; then
     echo; echo "Top-line results (Strelka2):"
     column -t -s',' "$OUTDIR/scored_strelka.stats.csv"

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -256,27 +256,33 @@ if [[ "$RUN_VARSCAN" == "1" ]]; then
         echo "[5c] VarScan2 somatic VCF already present — skipping."
     else
         echo "[5c] Running VarScan2 (tumor/normal somatic SNV/indel)..."
+        # Everything (calling AND bcftools post-processing) is inside the guard so
+        # a VarScan-VCF quirk can't abort the run. VarScan VCFs lack ##contig lines,
+        # which makes bcftools sort fail on the undefined contig — add them from the
+        # reference .fai via `reheader --fai` before sorting.
         run_varscan() {
+            local vlog="$OUTDIR/varscan_run.log"
             conda_activate "$VARSCAN_ENV"   # varscan (samtools comes from the module)
             # Combined mpileup, NORMAL first then TUMOR (--mpileup 1 expects this order).
             samtools mpileup -B -q 1 -f "$REFERENCE" "$NORMAL_BAM" "$TUMOR_BAM" \
                 > "$OUTDIR/varscan.mpileup" 2>"$OUTDIR/varscan_mpileup.log" || return 1
             varscan somatic "$OUTDIR/varscan.mpileup" "$OUTDIR/varscan" \
-                --mpileup 1 --output-vcf 1 > "$OUTDIR/varscan_run.log" 2>&1 || return 1
-            varscan processSomatic "$OUTDIR/varscan.snp.vcf"   >> "$OUTDIR/varscan_run.log" 2>&1 || return 1
-            varscan processSomatic "$OUTDIR/varscan.indel.vcf" >> "$OUTDIR/varscan_run.log" 2>&1 || return 1
+                --mpileup 1 --output-vcf 1 > "$vlog" 2>&1 || return 1
+            varscan processSomatic "$OUTDIR/varscan.snp.vcf"   >> "$vlog" 2>&1 || return 1
+            varscan processSomatic "$OUTDIR/varscan.indel.vcf" >> "$vlog" 2>&1 || return 1
+            conda_activate bioinf   # bcftools
+            local v
+            for v in snp indel; do
+                bcftools reheader --fai "${REFERENCE}.fai" "$OUTDIR/varscan.$v.Somatic.hc.vcf" 2>>"$vlog" \
+                    | bcftools sort -Oz -o "$OUTDIR/varscan.$v.somatic.vcf.gz" 2>>"$vlog" || return 1
+                bcftools index -f -t "$OUTDIR/varscan.$v.somatic.vcf.gz" 2>>"$vlog" || return 1
+            done
+            bcftools concat -a "$OUTDIR/varscan.snp.somatic.vcf.gz" "$OUTDIR/varscan.indel.somatic.vcf.gz" 2>>"$vlog" \
+                | bcftools sort -Oz -o "$VARSCAN_VCF" 2>>"$vlog" || return 1
+            bcftools index -f -t "$VARSCAN_VCF" 2>>"$vlog" || return 1
+            rm -f "$OUTDIR/varscan.mpileup"   # large intermediate — reclaim space
         }
         if run_varscan; then
-            conda_activate bioinf   # bcftools
-            for v in snp indel; do
-                bcftools sort -Oz -o "$OUTDIR/varscan.$v.somatic.vcf.gz" \
-                    "$OUTDIR/varscan.$v.Somatic.hc.vcf"
-                bcftools index -f -t "$OUTDIR/varscan.$v.somatic.vcf.gz"
-            done
-            bcftools concat -a "$OUTDIR/varscan.snp.somatic.vcf.gz" "$OUTDIR/varscan.indel.somatic.vcf.gz" \
-                | bcftools sort -Oz -o "$VARSCAN_VCF"
-            bcftools index -f -t "$VARSCAN_VCF"
-            rm -f "$OUTDIR/varscan.mpileup"   # large intermediate — reclaim space
             echo "[5c] VarScan2 complete: $(zcat "$VARSCAN_VCF" | grep -vc '^#' || true) somatic calls."
         else
             echo "[5c] WARNING: VarScan2 failed (see $OUTDIR/varscan_run.log) — continuing without it; Mutect2 unaffected." >&2

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -242,6 +242,9 @@ fi
 # ── Stage 6: Score each caller with hap.py som.py ───────────────────────
 # Somatic-only truth (NEAT_ORIGIN=somatic); germline carry-through (shared) is
 # correctly ignored by T/N callers, so scoring against it would be meaningless.
+# Strelka (5b) may leave us in its conda env (especially on its failure path);
+# scoring needs bioinf (bcftools) + apptainer, so re-activate it here.
+conda_activate bioinf
 SCORE_TRUTH="$OUTDIR/scoring_truth.vcf.gz"
 if [[ ! -f "$SCORE_TRUTH" ]]; then
     echo "[6/6] Filtering truth to somatic records..."

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -210,22 +210,32 @@ if [[ "$RUN_STRELKA" == "1" ]]; then
         echo "[5b] Strelka2 somatic VCF already present — skipping."
     else
         echo "[5b] Running Strelka2 (tumor/normal somatic SNV/indel)..."
-        conda_activate "$STRELKA_ENV"
-        rm -rf "$STRELKA_DIR"
-        configureStrelkaSomaticWorkflow.py \
-            --normalBam "$NORMAL_BAM" \
-            --tumorBam  "$TUMOR_BAM" \
-            --referenceFasta "$REFERENCE" \
-            --runDir "$STRELKA_DIR" 2>&1 | tail -5
-        "$STRELKA_DIR/runWorkflow.py" -m local -j "$THREADS" 2>&1 | tail -5
-        # Strelka emits SNVs + indels in separate files; concat into one query.
-        conda_activate bioinf
-        bcftools concat -a \
-            "$STRELKA_DIR/results/variants/somatic.snvs.vcf.gz" \
-            "$STRELKA_DIR/results/variants/somatic.indels.vcf.gz" \
-            | bcftools sort -Oz -o "$STRELKA_VCF"
-        bcftools index -f -t "$STRELKA_VCF"
-        echo "[5b] Strelka2 complete: $(zcat "$STRELKA_VCF" | grep -vc '^#' || true) somatic calls."
+        # Strelka2 is a SECONDARY cross-check and must NEVER abort the run: the
+        # bioconda strelka 2.9.10 binary SIGSEGVs on some HPC glibc/CPU combos.
+        # Run it guarded — on failure, warn and continue so the primary Mutect2
+        # result is still scored (Stage 6).
+        run_strelka() {
+            conda_activate "$STRELKA_ENV"
+            rm -rf "$STRELKA_DIR"
+            configureStrelkaSomaticWorkflow.py \
+                --normalBam "$NORMAL_BAM" --tumorBam "$TUMOR_BAM" \
+                --referenceFasta "$REFERENCE" --runDir "$STRELKA_DIR" \
+                > "$OUTDIR/strelka_config.log" 2>&1 || return 1
+            "$STRELKA_DIR/runWorkflow.py" -m local -j "$THREADS" \
+                > "$OUTDIR/strelka_run.log" 2>&1 || return 1
+        }
+        if run_strelka; then
+            conda_activate bioinf   # Strelka emits SNVs + indels separately; merge.
+            bcftools concat -a \
+                "$STRELKA_DIR/results/variants/somatic.snvs.vcf.gz" \
+                "$STRELKA_DIR/results/variants/somatic.indels.vcf.gz" \
+                | bcftools sort -Oz -o "$STRELKA_VCF"
+            bcftools index -f -t "$STRELKA_VCF"
+            echo "[5b] Strelka2 complete: $(zcat "$STRELKA_VCF" | grep -vc '^#' || true) somatic calls."
+        else
+            echo "[5b] WARNING: Strelka2 failed (see $OUTDIR/strelka_run.log) — continuing without it; Mutect2 unaffected." >&2
+            STRELKA_VCF=""
+        fi
     fi
 fi
 

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -243,6 +243,23 @@ echo "      Somatic truth records: $somatic_count"
 [[ "$somatic_count" -eq 0 ]] && echo "WARNING: no somatic truth records — check NEAT_ORIGIN." >&2
 [[ -f "$HAPPY_SIF" ]] || { echo "hap.py SIF not found: $HAPPY_SIF — run setup.sh first" >&2; exit 1; }
 
+# hap.py/som.py hardcodes UCSC chr-prefixing of input VCFs (perl s/^([0-9XYM])/chr/),
+# then bcftools-norm's against the reference. With an Ensembl-named reference (1/2/3)
+# the renamed VCFs (chr1) no longer match the reference (1) and som.py dies
+# ("sequence chr1 not found"). If the reference isn't chr-prefixed, build a
+# chr-prefixed copy for scoring so the renamed VCFs match. (chr22.fa etc. pass
+# through unchanged.) Alignment/Mutect2 already used $REFERENCE as-is — unaffected.
+SCORE_REF_DIR="$REF_DIR"; SCORE_REF_NAME="$REF_NAME"
+if ! head -1 "${REFERENCE}.fai" 2>/dev/null | grep -q '^chr'; then
+    SCORE_REF="${REFERENCE%.fa}.chr.fa"
+    if [[ ! -f "$SCORE_REF" ]]; then
+        echo "[6/6] Reference is Ensembl-named; building chr-prefixed copy for som.py..."
+        sed '/^>/ s/^>/>chr/' "$REFERENCE" > "$SCORE_REF"
+        samtools faidx "$SCORE_REF"
+    fi
+    SCORE_REF_DIR="$(dirname "$SCORE_REF")"; SCORE_REF_NAME="$(basename "$SCORE_REF")"
+fi
+
 # som_score <query.vcf.gz> <out-label>. -N (--normalize-all) runs bcftools norm on
 # BOTH truth and query — essential for indels (representation/left-align mismatch
 # otherwise double-counts FN+FP). HGREF resolves som.py's reference lookup.
@@ -254,14 +271,14 @@ som_score() {
     fi
     echo "[6/6] Scoring $label with som.py (Apptainer)..."
     apptainer exec \
-        --env "HGREF=/refs/$REF_NAME" \
-        --bind "$REF_DIR:/refs:ro" \
+        --env "HGREF=/refs/$SCORE_REF_NAME" \
+        --bind "$SCORE_REF_DIR:/refs:ro" \
         --bind "$OUTDIR:/work" \
         "$HAPPY_SIF" \
         /opt/hap.py/bin/som.py \
             "/work/$(basename "$SCORE_TRUTH")" \
             "/work/$(basename "$query")" \
-            -r "/refs/$REF_NAME" \
+            -r "/refs/$SCORE_REF_NAME" \
             -o "/work/$label" \
             -N \
             --feature-table generic

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -67,6 +67,10 @@ TUMOR_MODEL="$REPO_ROOT/tools/cosmic_v104_pancancer_model.json.gz"
 # Path to the hap.py Apptainer SIF (built by setup.sh).
 HAPPY_SIF="${HAPPY_SIF:-$SCRATCH/sif/happy_v0.3.12.sif}"
 
+# Run Strelka2 as a 2nd somatic SNV/indel caller alongside Mutect2 (cross-validation).
+RUN_STRELKA="${RUN_STRELKA:-1}"
+STRELKA_ENV="${STRELKA_ENV:-strelka}"
+
 THREADS=$SLURM_CPUS_PER_TASK
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
 RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
@@ -194,37 +198,61 @@ else
     echo "[5/6] Filtering complete."
 fi
 
-# ── Stage 6: Score with hap.py som.py ───────────────────────────────────
-# Filter the truth VCF to somatic-only records before scoring.
-# The rneat truth carries germline-carry-through (NEAT_ORIGIN=shared) which
-# Mutect2 in tumor/normal mode correctly ignores — counting those as FN
-# would make the recall number meaningless.
-SCORE_TRUTH="$OUTDIR/scoring_truth.vcf.gz"
-SCORE_PREFIX="$OUTDIR/scored"
+# ── Stage 5b: Strelka2 somatic SNV/indel (2nd caller vs Mutect2) ─────────
+# Cross-validation: a second, independently-modeled somatic caller confirms
+# rneat's somatic SNV/indel data isn't recovered only by Mutect2. Reuses the same
+# tumor/normal BAMs. RUN_STRELKA=0 to skip.
+STRELKA_VCF=""
+if [[ "$RUN_STRELKA" == "1" ]]; then
+    STRELKA_DIR="$OUTDIR/strelka"
+    STRELKA_VCF="$OUTDIR/strelka.somatic.vcf.gz"
+    if [[ -f "$STRELKA_VCF" ]]; then
+        echo "[5b] Strelka2 somatic VCF already present — skipping."
+    else
+        echo "[5b] Running Strelka2 (tumor/normal somatic SNV/indel)..."
+        conda_activate "$STRELKA_ENV"
+        rm -rf "$STRELKA_DIR"
+        configureStrelkaSomaticWorkflow.py \
+            --normalBam "$NORMAL_BAM" \
+            --tumorBam  "$TUMOR_BAM" \
+            --referenceFasta "$REFERENCE" \
+            --runDir "$STRELKA_DIR" 2>&1 | tail -5
+        "$STRELKA_DIR/runWorkflow.py" -m local -j "$THREADS" 2>&1 | tail -5
+        # Strelka emits SNVs + indels in separate files; concat into one query.
+        conda_activate bioinf
+        bcftools concat -a \
+            "$STRELKA_DIR/results/variants/somatic.snvs.vcf.gz" \
+            "$STRELKA_DIR/results/variants/somatic.indels.vcf.gz" \
+            | bcftools sort -Oz -o "$STRELKA_VCF"
+        bcftools index -f -t "$STRELKA_VCF"
+        echo "[5b] Strelka2 complete: $(zcat "$STRELKA_VCF" | grep -vc '^#' || true) somatic calls."
+    fi
+fi
 
-if [[ -f "${SCORE_PREFIX}.stats.csv" ]]; then
-    echo "[6/6] Scoring output already present — skipping."
-else
+# ── Stage 6: Score each caller with hap.py som.py ───────────────────────
+# Somatic-only truth (NEAT_ORIGIN=somatic); germline carry-through (shared) is
+# correctly ignored by T/N callers, so scoring against it would be meaningless.
+SCORE_TRUTH="$OUTDIR/scoring_truth.vcf.gz"
+if [[ ! -f "$SCORE_TRUTH" ]]; then
     echo "[6/6] Filtering truth to somatic records..."
     bcftools view -i 'INFO/NEAT_ORIGIN="somatic"' -O z -o "$SCORE_TRUTH" "$TRUTH_VCF"
     bcftools index -f -t "$SCORE_TRUTH"
+fi
+somatic_count=$(bcftools view -H "$SCORE_TRUTH" | wc -l)
+echo "      Somatic truth records: $somatic_count"
+[[ "$somatic_count" -eq 0 ]] && echo "WARNING: no somatic truth records — check NEAT_ORIGIN." >&2
+[[ -f "$HAPPY_SIF" ]] || { echo "hap.py SIF not found: $HAPPY_SIF — run setup.sh first" >&2; exit 1; }
 
-    somatic_count=$(bcftools view -H "$SCORE_TRUTH" | wc -l)
-    echo "      Somatic truth records: $somatic_count"
-
-    if [[ "$somatic_count" -eq 0 ]]; then
-        echo "WARNING: no somatic records in truth VCF — check that NEAT_ORIGIN is present." >&2
+# som_score <query.vcf.gz> <out-label>. -N (--normalize-all) runs bcftools norm on
+# BOTH truth and query — essential for indels (representation/left-align mismatch
+# otherwise double-counts FN+FP). HGREF resolves som.py's reference lookup.
+som_score() {
+    local query="$1" label="$2"
+    [[ -f "$query" ]] || { echo "  ($label: no query VCF to score)"; return 0; }
+    if [[ -f "$OUTDIR/${label}.stats.csv" ]]; then
+        echo "[6/6] $label score already present — skipping."; return 0
     fi
-
-    echo "[6/6] Scoring with hap.py som.py (Apptainer)..."
-    [[ -f "$HAPPY_SIF" ]] || { echo "hap.py SIF not found: $HAPPY_SIF — run setup.sh first" >&2; exit 1; }
-
-    # -N (--normalize-all) runs `bcftools norm` on BOTH truth and query before
-    # comparison — essential for indels: without it, a truth indel and Mutect2's
-    # call for the same event can be left-aligned to different positions and get
-    # double-counted as FN + FP, deflating indel recall AND precision. SNVs are
-    # unaffected. HGREF is set so som.py's reference lookup resolves (silences the
-    # "No reference file found" warning) in addition to the explicit -r.
+    echo "[6/6] Scoring $label with som.py (Apptainer)..."
     apptainer exec \
         --env "HGREF=/refs/$REF_NAME" \
         --bind "$REF_DIR:/refs:ro" \
@@ -232,13 +260,16 @@ else
         "$HAPPY_SIF" \
         /opt/hap.py/bin/som.py \
             "/work/$(basename "$SCORE_TRUTH")" \
-            "/work/$(basename "$FILTERED_VCF")" \
+            "/work/$(basename "$query")" \
             -r "/refs/$REF_NAME" \
-            -o "/work/scored" \
+            -o "/work/$label" \
             -N \
             --feature-table generic
-    echo "[6/6] Scoring complete."
-fi
+}
+
+som_score "$FILTERED_VCF" scored                                    # Mutect2
+[[ -n "$STRELKA_VCF" ]] && som_score "$STRELKA_VCF" scored_strelka   # Strelka2
+echo "[6/6] Scoring complete."
 
 # ── Summary ──────────────────────────────────────────────────────────────
 cat <<EOF
@@ -255,12 +286,16 @@ Key outputs in $OUTDIR:
   Simulation:     sample_merged_{r1,r2}.fastq.gz
   Truth VCF:      sample_merged_truth.vcf.gz  (NEAT_ORIGIN-tagged)
   Somatic truth:  scoring_truth.vcf.gz         (somatic only)
-  Mutect2 calls:  mutect2.filtered.vcf.gz
-  Score summary:  scored.stats.csv             ← recall / precision / F1
+  Mutect2 calls:  mutect2.filtered.vcf.gz   -> scored.stats.csv
+  Strelka2 calls: strelka.somatic.vcf.gz    -> scored_strelka.stats.csv  (RUN_STRELKA=1)
 
-Top-line results:
+Top-line results (Mutect2):
 EOF
-[[ -f "${SCORE_PREFIX}.stats.csv" ]] && column -t -s',' "${SCORE_PREFIX}.stats.csv" || echo "  (score file not found)"
+[[ -f "$OUTDIR/scored.stats.csv" ]] && column -t -s',' "$OUTDIR/scored.stats.csv" || echo "  (Mutect2 score not found)"
+if [[ -n "$STRELKA_VCF" && -f "$OUTDIR/scored_strelka.stats.csv" ]]; then
+    echo; echo "Top-line results (Strelka2):"
+    column -t -s',' "$OUTDIR/scored_strelka.stats.csv"
+fi
 
 # Persist report artifacts off scratch + record provenance/resources.
 archive_run cancer "$OUTDIR" scored.stats.csv

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -102,6 +102,30 @@ else
     conda run -n "$BIOINF_ENV_NAME" gatk      --version 2>&1 | head -1 || true
 fi
 
+# ── 3b. Somatic-caller coverage envs (cross-validation) ──────────────────
+# Independent second callers to confirm rneat's cancer features aren't tuned to a
+# single tool, plus a mutational-signature fidelity check. Each gets its own env
+# (strelka2 is python2, sigprofiler python3, delly a static binary), so they don't
+# clash with bioinf or each other. GATK somatic CNV needs NO new env (gatk4 is in
+# bioinf); Manta + truvari already have their own envs (see sv_pipeline.sbatch).
+#   delly       — somatic SV, 2nd caller vs Manta (esp. the BND recovery question)
+#   strelka     — somatic SNV/indel, 2nd caller vs Mutect2
+#   sigprofiler — SigProfilerAssignment, COSMIC-signature fidelity of the model
+# NOTE: sigprofiler downloads a reference genome on first use
+# (SigProfilerMatrixGenerator); the signature_check helper installs GRCh38 once.
+for env_spec in \
+    "delly:-c bioconda -c conda-forge delly" \
+    "strelka:-c bioconda -c conda-forge strelka" \
+    "sigprofiler:-c bioconda -c conda-forge sigprofilerassignment"; do
+    env_name="${env_spec%%:*}"; env_pkgs="${env_spec#*:}"
+    if conda env list | grep -q "^${env_name} "; then
+        echo "[3b/4] Conda env '$env_name' already present — skipping."
+    else
+        echo "[3b/4] Creating conda env '$env_name' ($env_pkgs)..."
+        conda create -y -n "$env_name" $env_pkgs
+    fi
+done
+
 # ── 4. hap.py Apptainer image ───────────────────────────────────────────
 mkdir -p "$SIF_DIR"
 HAPPY_SIF="$SIF_DIR/happy_v0.3.12.sif"

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -113,9 +113,12 @@ fi
 #   sigprofiler — SigProfilerAssignment, COSMIC-signature fidelity of the model
 # NOTE: sigprofiler downloads a reference genome on first use
 # (SigProfilerMatrixGenerator); the signature_check helper installs GRCh38 once.
+#   varscan     — somatic SNV/indel, robust 2nd caller vs Mutect2 (Strelka2 2.9.10
+#                 SIGSEGVs on Delta's stack, so it's the working cross-check)
 for env_spec in \
     "delly:-c bioconda -c conda-forge delly" \
     "strelka:-c bioconda -c conda-forge strelka" \
+    "varscan:-c bioconda -c conda-forge varscan" \
     "sigprofiler:-c bioconda -c conda-forge sigprofilerassignment"; do
     env_name="${env_spec%%:*}"; env_pkgs="${env_spec#*:}"
     if conda env list | grep -q "^${env_name} "; then

--- a/scripts/delta/signature_check.sh
+++ b/scripts/delta/signature_check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Mutational-signature fidelity check (ticket #317, realism epic #311).
+#
+# Does rneat reconstruct the COSMIC signature its tumor model encodes? This runs on
+# the *truth* somatic SNVs (what rneat generated) — so it validates the simulator's
+# trinucleotide/signature machinery directly, independent of any variant caller.
+# Extracts somatic SNVs from an rneat truth VCF and fits COSMIC SBS signatures with
+# SigProfilerAssignment; the assigned profile should reflect the model, not a
+# flat/random spectrum.
+#
+# Usage (from repo root; needs the `sigprofiler` env from setup.sh):
+#   TRUTH_VCF=$SCRATCH/cancer_<id>/sample_merged_truth.vcf.gz \
+#   OUTDIR=$SCRATCH/sigcheck_<id> bash scripts/delta/signature_check.sh
+#
+# Run via a compute node for the first invocation — it installs the SigProfiler
+# reference genome (~3 GB, one-time, slow):
+#   srun -A bhrd-delta-cpu -p cpu -N1 -n1 -c8 --mem=32G -t 02:00:00 \
+#     bash -lc 'TRUTH_VCF=... OUTDIR=... bash scripts/delta/signature_check.sh'
+#
+# NOTE: this is a first-draft harness — SigProfiler's API/genome-naming may need a
+# tweak on the first real run (like sv_pipeline did). SigProfiler GRCh38 uses
+# Ensembl-style contig names (1/2/3); a chr-prefixed truth VCF (chr22.fa runs) may
+# need `bcftools annotate --rename-chrs` first.
+set -euo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"
+
+TRUTH_VCF="${TRUTH_VCF:?set TRUTH_VCF to an rneat truth VCF (INFO/NEAT_ORIGIN-tagged)}"
+OUTDIR="${OUTDIR:-$SCRATCH/sigcheck_$(basename "$(dirname "$TRUTH_VCF")")}"
+GENOME="${GENOME:-GRCh38}"
+SIGPROFILER_ENV="${SIGPROFILER_ENV:-sigprofiler}"
+
+setup_conda
+mkdir -p "$OUTDIR/vcf"
+
+# 1. Extract somatic SNVs only (SigProfiler SBS works on single-base substitutions).
+conda_activate bioinf   # bcftools
+bcftools view -v snps -i 'INFO/NEAT_ORIGIN="somatic"' \
+    -O v -o "$OUTDIR/vcf/rneat_somatic_snvs.vcf" "$TRUTH_VCF"
+n=$(grep -vc '^#' "$OUTDIR/vcf/rneat_somatic_snvs.vcf" || true)
+echo "Somatic SNVs for signature fitting: $n"
+[[ "$n" -ge 50 ]] || echo "WARNING: few SNVs ($n) — fit will be noisy; use a larger/higher-coverage run." >&2
+
+# 2. SigProfiler: install the reference genome once (no-op if present), then fit.
+conda_activate "$SIGPROFILER_ENV"
+python3 - "$GENOME" <<'PY'
+import sys
+genome = sys.argv[1]
+try:
+    from SigProfilerMatrixGenerator import install as genInstall
+    genInstall.install(genome, rsync=False, bash=True)   # no-op if already installed
+except Exception as e:
+    print(f"(genome install note: {e})")
+PY
+
+python3 - "$OUTDIR" "$GENOME" <<'PY'
+import sys
+outdir, genome = sys.argv[1], sys.argv[2]
+from SigProfilerAssignment import Analyzer as Analyze
+Analyze.cosmic_fit(samples=f"{outdir}/vcf",
+                   output=f"{outdir}/sigprofiler",
+                   input_type="vcf",
+                   genome_build=genome,
+                   collapse_to_SBS96=True)
+print("SigProfilerAssignment cosmic_fit complete.")
+PY
+
+# 3. Report assigned signatures.
+echo
+echo "════════════════════════════════════════════════════════════════"
+echo "Signature fidelity check — $OUTDIR  ($n somatic SNVs)"
+echo "Assigned COSMIC signature activities:"
+act=$(find "$OUTDIR/sigprofiler" -name '*Activities*.txt' 2>/dev/null | head -1)
+[[ -f "$act" ]] && column -t "$act" || echo "  (activities table not found — see $OUTDIR/sigprofiler)"
+cat <<'EOF'
+
+Interpretation: the dominant assigned signature(s) should reflect the tumor model's
+COSMIC composition, not a flat/uniform spectrum. A sensible COSMIC fit = rneat
+reproduces the signature it was given (trinucleotide machinery faithful). Per-tissue
+SNV signature is pan-cancer in the current models (only the SV side is tissue-
+specific), so expect a pan-cancer-like profile rather than tissue-defining SBS.
+EOF

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -282,25 +282,33 @@ fi
 CNV_TRUTH="$OUTDIR/truth_sv_CNV.vcf.gz"
 if [[ "$RUN_CNV" == "1" && -f "$CNV_TRUTH" ]]; then
     conda_activate bioinf
-    if [[ -f "$OUTDIR/cnv_called.seg" ]]; then
-        echo "[4c] GATK CNV segments already present — skipping call."
-    else
-        echo "[4c] Running GATK somatic CNV (denoise -> segment -> call)..."
-        [[ -f "${REFERENCE%.fa}.dict" ]] || gatk CreateSequenceDictionary -R "$REFERENCE" 2>&1 | tail -2
+    # GATK CNV is a SECONDARY validation — never let it abort the run (truvari
+    # scoring of Manta/Delly must still happen). Guarded; full GATK output -> cnv_gatk.log.
+    run_gatk_cnv() {
+        local log="$OUTDIR/cnv_gatk.log"; : > "$log"
+        [[ -f "${REFERENCE%.fa}.dict" ]] || gatk CreateSequenceDictionary -R "$REFERENCE" >>"$log" 2>&1 || return 1
         gatk PreprocessIntervals -R "$REFERENCE" --bin-length 1000 --padding 0 \
-            --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/cnv.intervals" 2>&1 | tail -2
+            --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/cnv.intervals" >>"$log" 2>&1 || return 1
+        local s
         for s in tumor normal; do
             gatk CollectReadCounts -I "$OUTDIR/$s.bam" -L "$OUTDIR/cnv.intervals" \
-                --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/$s.counts.hdf5" 2>&1 | tail -2
+                --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/$s.counts.hdf5" >>"$log" 2>&1 || return 1
         done
         gatk CreateReadCountPanelOfNormals -I "$OUTDIR/normal.counts.hdf5" \
-            -O "$OUTDIR/cnv.pon.hdf5" 2>&1 | tail -2
+            -O "$OUTDIR/cnv.pon.hdf5" >>"$log" 2>&1 || return 1
         gatk DenoiseReadCounts -I "$OUTDIR/tumor.counts.hdf5" --count-panel-of-normals "$OUTDIR/cnv.pon.hdf5" \
             --standardized-copy-ratios "$OUTDIR/tumor.stdCR.tsv" \
-            --denoised-copy-ratios "$OUTDIR/tumor.denoisedCR.tsv" 2>&1 | tail -2
+            --denoised-copy-ratios "$OUTDIR/tumor.denoisedCR.tsv" >>"$log" 2>&1 || return 1
         gatk ModelSegments --denoised-copy-ratios "$OUTDIR/tumor.denoisedCR.tsv" \
-            -O "$OUTDIR" --output-prefix cnv 2>&1 | tail -2
-        gatk CallCopyRatioSegments -I "$OUTDIR/cnv.cr.seg" -O "$OUTDIR/cnv_called.seg" 2>&1 | tail -2
+            -O "$OUTDIR" --output-prefix cnv >>"$log" 2>&1 || return 1
+        gatk CallCopyRatioSegments -I "$OUTDIR/cnv.cr.seg" -O "$OUTDIR/cnv_called.seg" >>"$log" 2>&1 || return 1
+    }
+    if [[ -f "$OUTDIR/cnv_called.seg" ]]; then
+        echo "[4c] GATK CNV segments already present — skipping call."
+    elif run_gatk_cnv; then
+        echo "[4c] GATK CNV calling complete."
+    else
+        echo "[4c] WARNING: GATK CNV failed (see $OUTDIR/cnv_gatk.log) — continuing without CNV validation." >&2
     fi
     # Score: does a called gain/loss segment overlap each truth CNV with the right
     # direction? (CN>2 -> gain '+', CN<2 -> loss '-'.) Manta/truvari can't score CNV,

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -74,6 +74,10 @@ TRUVARI_ENV="${TRUVARI_ENV:-truvari}"
 # Run Delly as a 2nd somatic SV caller alongside Manta (cross-validation; the
 # BND-recovery question). Set RUN_DELLY=0 to skip.
 RUN_DELLY="${RUN_DELLY:-1}"
+# Run GATK somatic CNV to validate the CNV machinery through a real copy-number
+# caller (rneat's CNVs were previously only depth-validated). No new env (gatk4 in
+# bioinf). Set RUN_CNV=0 to skip.
+RUN_CNV="${RUN_CNV:-1}"
 # rneat SVs reach ~1 Mb; truvari's default --sizemax is 50 kb, which would silently
 # EXCLUDE most large rneat SVs from scoring. Raise it to cover the full range.
 TRUVARI_SIZEMAX="${TRUVARI_SIZEMAX:-5000000}"
@@ -270,6 +274,50 @@ if [[ "$RUN_DELLY" == "1" ]]; then
         bcftools index -f -t "$DELLY_SV"
         echo "[4b] Delly complete: $(zcat "$DELLY_SV" | grep -vc '^#' || true) somatic SV calls."
     fi
+fi
+
+# ── Stage 4c: GATK somatic CNV (validate the CNV machinery via a caller) ─
+# rneat's CNVs were only depth-validated; here a real copy-number caller must
+# recover them. GATK4 (bioinf) — no new env. RUN_CNV=0 to skip.
+CNV_TRUTH="$OUTDIR/truth_sv_CNV.vcf.gz"
+if [[ "$RUN_CNV" == "1" && -f "$CNV_TRUTH" ]]; then
+    conda_activate bioinf
+    if [[ -f "$OUTDIR/cnv_called.seg" ]]; then
+        echo "[4c] GATK CNV segments already present — skipping call."
+    else
+        echo "[4c] Running GATK somatic CNV (denoise -> segment -> call)..."
+        [[ -f "${REFERENCE%.fa}.dict" ]] || gatk CreateSequenceDictionary -R "$REFERENCE" 2>&1 | tail -2
+        gatk PreprocessIntervals -R "$REFERENCE" --bin-length 1000 --padding 0 \
+            --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/cnv.intervals" 2>&1 | tail -2
+        for s in tumor normal; do
+            gatk CollectReadCounts -I "$OUTDIR/$s.bam" -L "$OUTDIR/cnv.intervals" \
+                --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/$s.counts.hdf5" 2>&1 | tail -2
+        done
+        gatk CreateReadCountPanelOfNormals -I "$OUTDIR/normal.counts.hdf5" \
+            -O "$OUTDIR/cnv.pon.hdf5" 2>&1 | tail -2
+        gatk DenoiseReadCounts -I "$OUTDIR/tumor.counts.hdf5" --count-panel-of-normals "$OUTDIR/cnv.pon.hdf5" \
+            --standardized-copy-ratios "$OUTDIR/tumor.stdCR.tsv" \
+            --denoised-copy-ratios "$OUTDIR/tumor.denoisedCR.tsv" 2>&1 | tail -2
+        gatk ModelSegments --denoised-copy-ratios "$OUTDIR/tumor.denoisedCR.tsv" \
+            -O "$OUTDIR" --output-prefix cnv 2>&1 | tail -2
+        gatk CallCopyRatioSegments -I "$OUTDIR/cnv.cr.seg" -O "$OUTDIR/cnv_called.seg" 2>&1 | tail -2
+    fi
+    # Score: does a called gain/loss segment overlap each truth CNV with the right
+    # direction? (CN>2 -> gain '+', CN<2 -> loss '-'.) Manta/truvari can't score CNV,
+    # so this is the CNV feature's caller-level validation.
+    if [[ -f "$OUTDIR/cnv_called.seg" ]]; then
+        bcftools query -f '%CHROM\t%POS\t%INFO/END\t%INFO/CN\n' "$CNV_TRUTH" \
+            | awk 'BEGIN{OFS="\t"}{print $1,$2,$3,($4>2?"+":($4<2?"-":"0"))}' > "$OUTDIR/cnv_truth.bed"
+        awk '!/^@/ && $1!="CONTIG" && ($6=="+"||$6=="-"){print $1,$2,$3,$6}' \
+            "$OUTDIR/cnv_called.seg" > "$OUTDIR/cnv_called.bed"
+        awk 'NR==FNR{n++;c[n]=$1;st[n]=$2;e[n]=$3;d[n]=$4;next}
+             {for(i=1;i<=n;i++) if($1==c[i] && $2<=e[i] && $3>=st[i] && $4==d[i]) hit[i]=1}
+             END{tp=0; for(i=1;i<=n;i++) tp+=hit[i];
+                 printf "[4c] CNV recovery: %d/%d truth CNVs called with matching direction\n", tp+0, n+0}' \
+             "$OUTDIR/cnv_truth.bed" "$OUTDIR/cnv_called.bed"
+    fi
+elif [[ "$RUN_CNV" == "1" ]]; then
+    echo "[4c] no CNV truth (truth_sv_CNV.vcf.gz) — skipping CNV validation (raise SV_RATE_SCALE / coverage)."
 fi
 
 # ── Stage 5: Score each caller with truvari (overall + per SV type) ──────

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -69,7 +69,11 @@ SV_RATE_SCALE="${SV_RATE_SCALE:-1.0}"
 TUMOR_MODEL="${TUMOR_MODEL:-$REPO_ROOT/tools/cosmic_v104_pancancer_model.json.gz}"
 
 MANTA_ENV="${MANTA_ENV:-manta}"
+DELLY_ENV="${DELLY_ENV:-delly}"
 TRUVARI_ENV="${TRUVARI_ENV:-truvari}"
+# Run Delly as a 2nd somatic SV caller alongside Manta (cross-validation; the
+# BND-recovery question). Set RUN_DELLY=0 to skip.
+RUN_DELLY="${RUN_DELLY:-1}"
 # rneat SVs reach ~1 Mb; truvari's default --sizemax is 50 kb, which would silently
 # EXCLUDE most large rneat SVs from scoring. Raise it to cover the full range.
 TRUVARI_SIZEMAX="${TRUVARI_SIZEMAX:-5000000}"
@@ -241,44 +245,78 @@ elif [[ "$SOM_N" -eq 0 ]]; then
     echo "        classifier dropped them (low support at this coverage/purity)."
 fi
 
-# ── Stage 5: Score with truvari (overall + per SV type) ──────────────────
+# ── Stage 4b: Delly somatic SV calling (2nd caller vs Manta) ─────────────
+# Cross-validation: an independent caller confirms rneat's SVs aren't recovered
+# only by Manta — and is the direct test of the BND-recovery question (does Delly
+# recover the translocations Manta re-represents/misses?). RUN_DELLY=0 to skip.
+DELLY_SV=""
+if [[ "$RUN_DELLY" == "1" ]]; then
+    DELLY_SV="$OUTDIR/delly.somatic.vcf.gz"
+    if [[ -f "$DELLY_SV" ]]; then
+        echo "[4b] Delly somatic SV already present — skipping."
+    else
+        echo "[4b] Running Delly (tumor/normal somatic SV)..."
+        conda_activate "$DELLY_ENV"
+        # delly call takes both BAMs (indexed) + a faidx'd reference (we have both).
+        delly call -g "$REFERENCE" -o "$OUTDIR/delly.bcf" "$TUMOR_BAM" "$NORMAL_BAM" 2>&1 | tail -3
+        # Somatic filter needs a sample->{tumor,control} TSV; our @RG SM tags are
+        # TUMOR / NORMAL (set in index_and_align).
+        printf 'TUMOR\ttumor\nNORMAL\tcontrol\n' > "$OUTDIR/delly_samples.tsv"
+        delly filter -f somatic -s "$OUTDIR/delly_samples.tsv" \
+            -o "$OUTDIR/delly.somatic.bcf" "$OUTDIR/delly.bcf" 2>&1 | tail -3
+        # Convert BCF->VCF.gz for truvari (bcftools lives in bioinf, not the delly env).
+        conda_activate bioinf
+        bcftools view "$OUTDIR/delly.somatic.bcf" -O z -o "$DELLY_SV"
+        bcftools index -f -t "$DELLY_SV"
+        echo "[4b] Delly complete: $(zcat "$DELLY_SV" | grep -vc '^#' || true) somatic SV calls."
+    fi
+fi
+
+# ── Stage 5: Score each caller with truvari (overall + per SV type) ──────
 echo "[5/5] Scoring SVs with truvari..."
 conda_activate "$TRUVARI_ENV"
 
-run_truvari() {  # <truth.vcf.gz> <out-subdir-name>
+run_truvari() {  # <truth.vcf.gz> <out-label> <comp.vcf.gz>
     # Separate `local`s on purpose: a combined `local a=$1 b=$2 c=...$b` expands
     # $b before it's assigned, which trips `set -u` (unbound variable).
     local truth="$1"
-    local name="$2"
-    local out="$OUTDIR/truvari_$name"
+    local label="$2"
+    local comp="$3"
+    local out="$OUTDIR/truvari_$label"
     rm -rf "$out"   # truvari requires the output dir not pre-exist
-    truvari bench -b "$truth" -c "$MANTA_SV" -f "$REFERENCE" -o "$out" \
+    truvari bench -b "$truth" -c "$comp" -f "$REFERENCE" -o "$out" \
         --passonly --sizemax "$TRUVARI_SIZEMAX" 2>&1 | tail -3 || true
     if [[ -f "$out/summary.json" ]]; then
-        python3 - "$out/summary.json" "$name" <<'PY'
+        python3 - "$out/summary.json" "$label" <<'PY'
 import json, sys
 s = json.load(open(sys.argv[1])); name = sys.argv[2]
 # truvari writes null (None) for metrics when a subset has no comparisons;
 # `or 0` coerces None -> 0 (s.get(k, 0) only defaults a MISSING key, not a null one).
-print(f"  {name:<8} recall={(s.get('recall') or 0):.3f}  precision={(s.get('precision') or 0):.3f}  "
+print(f"  {name:<18} recall={(s.get('recall') or 0):.3f}  precision={(s.get('precision') or 0):.3f}  "
       f"f1={(s.get('f1') or 0):.3f}  TP={s.get('TP-base') or 0}  FN={s.get('FN') or 0}  FP={s.get('FP') or 0}")
 PY
     else
-        echo "  $name: truvari produced no summary.json (see $out)"
+        echo "  $label: truvari produced no summary.json (see $out)"
     fi
 }
 
-echo "  --- overall ---"
-run_truvari "$TRUTH_SV" overall
+# Score one caller's VCF against the truth — overall + each per-type subset.
+# Outputs land under truvari_<caller>_<overall|TYPE>/, so Manta vs Delly is a
+# direct side-by-side (esp. for BND).
+score_caller() {  # <caller> <comp.vcf.gz>
+    local caller="$1" comp="$2"
+    [[ -f "$comp" ]] || { echo "  ($caller: no calls to score)"; return 0; }
+    echo "  === $caller ==="
+    run_truvari "$TRUTH_SV" "${caller}_overall" "$comp"
+    for typed in "$OUTDIR"/truth_sv_*.vcf.gz; do
+        [[ -f "$typed" ]] || continue
+        local svt; svt=$(basename "$typed" .vcf.gz); svt=${svt#truth_sv_}
+        run_truvari "$typed" "${caller}_${svt}" "$comp"
+    done
+}
 
-echo "  --- per SV type (recall: did Manta recover each type rneat emitted?) ---"
-# Score the per-type truth subsets pre-generated in stage 3b (bcftools not needed
-# here — the truvari env may not have it).
-for typed in "$OUTDIR"/truth_sv_*.vcf.gz; do
-    [[ -f "$typed" ]] || continue            # no typed files matched
-    svt=$(basename "$typed" .vcf.gz); svt=${svt#truth_sv_}
-    run_truvari "$typed" "$svt"
-done
+score_caller manta "$MANTA_SV"
+[[ -n "$DELLY_SV" ]] && score_caller delly "$DELLY_SV"
 
 # ── Summary ──────────────────────────────────────────────────────────────
 cat <<EOF
@@ -294,12 +332,14 @@ Inputs:
 Key outputs in $OUTDIR:
   SV truth:     truth_sv.vcf.gz            ($SV_TRUTH_N somatic SVs)
   Manta calls:  manta/results/variants/somaticSV.vcf.gz
-  Scores:       truvari_overall/summary.json + truvari_<TYPE>/
+  Delly calls:  delly.somatic.vcf.gz       (RUN_DELLY=1)
+  Scores:       truvari_<caller>_<overall|TYPE>/summary.json   (manta + delly)
 
-Interpretation: low overall recall with high per-type recall for some types =
-a representation/format mismatch (truvari SVTYPE/SVLEN matching), not necessarily
-a simulator bug — inspect the pre-flight schema dump. Uniformly low recall for a
-type rneat emitted heavily = candidate SV-generation bug (the Phase-2 target).
+Interpretation: compare the two callers side-by-side. A type rneat emitted heavily
+that BOTH callers miss = candidate SV-generation issue; one caller recovering what
+the other misses (especially BND) = a caller limitation, not a simulator defect.
+Low overall with high per-type recall = truvari SVTYPE/SVLEN representation
+mismatch (inspect the pre-flight schema dump).
 EOF
 
 # Reclaim scratch once scoring is done: FASTQ is the bulk (~GBs/run at 60x) and
@@ -313,4 +353,5 @@ if [[ "${PRUNE_FASTQ:-1}" == "1" ]]; then
 fi
 
 # Persist report artifacts off scratch + record provenance/resources.
-archive_run sv "$OUTDIR" truvari_overall/summary.json
+# (manta overall always exists; delly summaries remain under $OUTDIR/truvari_delly_*)
+archive_run sv "$OUTDIR" truvari_manta_overall/summary.json

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -289,14 +289,14 @@ if [[ "$RUN_CNV" == "1" && -f "$CNV_TRUTH" ]]; then
         [[ -f "${REFERENCE%.fa}.dict" ]] || gatk CreateSequenceDictionary -R "$REFERENCE" >>"$log" 2>&1 || return 1
         gatk PreprocessIntervals -R "$REFERENCE" --bin-length 1000 --padding 0 \
             --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/cnv.interval_list" >>"$log" 2>&1 || return 1
-        local s
-        for s in tumor normal; do
-            gatk CollectReadCounts -I "$OUTDIR/$s.bam" -L "$OUTDIR/cnv.interval_list" \
-                --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/$s.counts.hdf5" >>"$log" 2>&1 || return 1
-        done
-        gatk CreateReadCountPanelOfNormals -I "$OUTDIR/normal.counts.hdf5" \
-            -O "$OUTDIR/cnv.pon.hdf5" >>"$log" 2>&1 || return 1
-        gatk DenoiseReadCounts -I "$OUTDIR/tumor.counts.hdf5" --count-panel-of-normals "$OUTDIR/cnv.pon.hdf5" \
+        gatk CollectReadCounts -I "$OUTDIR/tumor.bam" -L "$OUTDIR/cnv.interval_list" \
+            --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/tumor.counts.hdf5" >>"$log" 2>&1 || return 1
+        # No panel-of-normals: CreateReadCountPanelOfNormals is a Spark tool and
+        # Spark 3.5 fails on the env's Java 25 (Subject.getSubject removed). With a
+        # single matched normal a PoN is overkill anyway — DenoiseReadCounts without
+        # one standardizes the tumor against its own median, which still surfaces the
+        # copy-ratio deviations at rneat's CNV loci.
+        gatk DenoiseReadCounts -I "$OUTDIR/tumor.counts.hdf5" \
             --standardized-copy-ratios "$OUTDIR/tumor.stdCR.tsv" \
             --denoised-copy-ratios "$OUTDIR/tumor.denoisedCR.tsv" >>"$log" 2>&1 || return 1
         gatk ModelSegments --denoised-copy-ratios "$OUTDIR/tumor.denoisedCR.tsv" \

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -288,10 +288,10 @@ if [[ "$RUN_CNV" == "1" && -f "$CNV_TRUTH" ]]; then
         local log="$OUTDIR/cnv_gatk.log"; : > "$log"
         [[ -f "${REFERENCE%.fa}.dict" ]] || gatk CreateSequenceDictionary -R "$REFERENCE" >>"$log" 2>&1 || return 1
         gatk PreprocessIntervals -R "$REFERENCE" --bin-length 1000 --padding 0 \
-            --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/cnv.intervals" >>"$log" 2>&1 || return 1
+            --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/cnv.interval_list" >>"$log" 2>&1 || return 1
         local s
         for s in tumor normal; do
-            gatk CollectReadCounts -I "$OUTDIR/$s.bam" -L "$OUTDIR/cnv.intervals" \
+            gatk CollectReadCounts -I "$OUTDIR/$s.bam" -L "$OUTDIR/cnv.interval_list" \
                 --interval-merging-rule OVERLAPPING_ONLY -O "$OUTDIR/$s.counts.hdf5" >>"$log" 2>&1 || return 1
         done
         gatk CreateReadCountPanelOfNormals -I "$OUTDIR/normal.counts.hdf5" \


### PR DESCRIPTION
## Summary

Broadens rneat's cancer validation from one caller per class to **independent second callers** (anti-overfit cross-validation), adds the **mutational-signature** probe, and lands the **at-scale (chr1–3)** validation results — plus the report sections documenting them. All `scripts/delta/` tooling + `docs/access_report_draft.md` (5 files, +390 / −68); **no rneat source changes**.

Stacks on the merged #310; ready for `develop`.

### Broadened somatic-caller coverage (#317)
- **`sv_pipeline.sbatch`** — adds **Delly** (`RUN_DELLY=1`) as a 2nd somatic SV caller scored side-by-side with Manta per type (the BND-recovery cross-check), and **GATK somatic-CNV** (`RUN_CNV=1`, no new env) validating CNVs through a real copy-number caller (was depth-only). `run_truvari`/`score_caller` generalized for per-caller output.
- **`cancer_pipeline.sbatch`** — adds **Strelka2** (`RUN_STRELKA=1`) as a 2nd somatic SNV/indel caller, scored with som.py against the same somatic truth as Mutect2 (`som_score` helper). Also **fixes som.py contig-naming** for Ensembl-named references (auto chr-prefixed copy for scoring) — without it, GRCh38-derived references fail scoring.
- **`signature_check.sh`** (new) — SigProfilerAssignment `cosmic_fit` on the *truth* somatic SNVs: does rneat reconstruct the COSMIC signature its model encodes?
- **`setup.sh`** — adds `delly` / `strelka` / `sigprofiler` conda envs (idempotent).

### Validation results (report)
- **§3.8 At-scale (chr1–3, ~13× chr22):** germline (SNP 0.990/0.9997, indel 0.988/0.990) and cancer (somatic SNV 0.944/0.910, indel 0.908/0.885) **hold or slightly improve** vs chr22 → not overfit.
- **§3.9 Signature fidelity — a verified finding (#320):** simulated somatic SNVs fit only flat COSMIC signatures (SBS5/3/41/12), **no SBS1**; SBS96 shows CpG `[C>T]G` suppressed. Root cause verified both ends: the COSMIC model encodes CpG C>T (0.78–0.88), but rneat places mutations at a **context-independent rate** and conditions only the alt on context → the realized spectrum is `genome-freq × conditional-alt`, not the signature. rneat reproduces substitution-type/Ts/Tv but **not rate-pattern COSMIC signatures**; fix = signature-weighted placement (#320).
- **§5** — concrete long-read testing plan (#319).

### Status
- **Signature check: validated** (ran end-to-end, surfaced #320).
- **Delly / Strelka2 / GATK-CNV: code-complete, validation runs in flight on Delta** (chr22 smoketests). Cross-caller agreement results to follow.
- CNV + signature are first-draft harnesses; bin-length / SigProfiler specifics may need minor shakeout.

## Testing
- All scripts `bash -n` clean; truvari/awk/CNV-overlap logic validated locally.
- `signature_check.sh` executed on Delta (chr1–3 cancer somatic SNVs); at-scale germline/cancer runs executed on Delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
