### PR TITLE
fix(delta): rebuild BWA index on empty stub (-s guard, not -f)

### DIFF
--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -140,8 +140,10 @@ index_and_align() {
         return 0
     fi
 
-    # Index reference once (idempotent — bwa-mem2 skips if already present).
-    if [[ ! -f "${REFERENCE}.bwt.2bit.64" ]] && [[ ! -f "${REFERENCE}.bwt" ]]; then
+    # Index reference once (idempotent). Guard on -s, not -f: a build killed
+    # mid-write leaves a 0-byte .bwt.2bit.64 that -f treats as present, poisoning
+    # every later run (bwa-mem2: "Unexpected end of file"). -s rebuilds on empty.
+    if [[ ! -s "${REFERENCE}.bwt.2bit.64" ]] && [[ ! -s "${REFERENCE}.bwt" ]]; then
         echo "  Indexing reference for BWA-MEM2 (one-time, ~2 min)..."
         bwa-mem2 index "$REFERENCE" 2>&1 | tail -3
     fi

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -91,8 +91,11 @@ echo "Tools:     $TOOLS"
 echo "Output:    $OUTDIR"
 
 # ── Shared one-time reference indexing ───────────────────────────────────
+# Guard on -s (exists AND non-empty), not -f: an index build killed mid-write
+# leaves a 0-byte .bwt.2bit.64 that -f treats as "present", so every later run
+# skips indexing and bwa-mem2 dies with "Unexpected end of file". -s rebuilds it.
 [[ -f "${REFERENCE}.fai" ]] || samtools faidx "$REFERENCE"
-if [[ ! -f "${REFERENCE}.bwt.2bit.64" && ! -f "${REFERENCE}.bwt" ]]; then
+if [[ ! -s "${REFERENCE}.bwt.2bit.64" && ! -s "${REFERENCE}.bwt" ]]; then
     echo "Indexing reference for BWA-MEM2 (one-time)..."
     bwa-mem2 index "$REFERENCE"
 fi

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -144,7 +144,10 @@ index_and_align() {
     if [[ -f "$out_bam" && -f "${out_bam}.bai" ]]; then
         echo "  $sample BAM already present — skipping."; return 0
     fi
-    if [[ ! -f "${REFERENCE}.bwt.2bit.64" ]] && [[ ! -f "${REFERENCE}.bwt" ]]; then
+    # Guard on -s, not -f: a build killed mid-write leaves a 0-byte .bwt.2bit.64
+    # that -f treats as present, poisoning every later run (bwa-mem2: "Unexpected
+    # end of file"). -s rebuilds on empty/missing.
+    if [[ ! -s "${REFERENCE}.bwt.2bit.64" ]] && [[ ! -s "${REFERENCE}.bwt" ]]; then
         echo "  Indexing reference for BWA-MEM2 (one-time)..."
         bwa-mem2 index "$REFERENCE" 2>&1 | tail -3
     fi


### PR DESCRIPTION
## Problem

A `bwa-mem2 index` build killed mid-write (node kill, OOM, walltime, disk) leaves a **0-byte `.bwt.2bit.64`**. The three Delta pipeline index guards tested `-f` (file *exists*), so every subsequent run treated the empty stub as a valid index, **skipped rebuilding**, and `bwa-mem2` then died loading it:

```
* Index file found. Loading index from …/c_elegans.fa.bwt.2bit.64
[fread] Unexpected end of file
```

which surfaces downstream as the cryptic `samtools sort: failed to read header from "-"` (bwa wrote nothing to the pipe). The reference is poisoned **forever** — no re-run recovers without manual `rm`.

## Fix

Switch all three index guards from `-f` to `-s` (exists **and** non-empty), so an interrupted index self-heals on the next run:

- `scripts/delta/germline_e2e.sbatch`
- `scripts/delta/cancer_pipeline.sbatch`
- `scripts/delta/sv_pipeline.sbatch`

## Found via

The C. elegans input-variety run (job 19742857): simulation produced ~1 GB of valid reads, but alignment failed on a 0-byte index stub left by an earlier interrupted build.

## Test

- `bash -n` clean on all three scripts.
- Verified each guard now reads `! -s "${REFERENCE}.bwt.2bit.64"`.
- No behavior change when a valid (non-empty) index is present — still skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)