### PR TITLE
feat(delta): cancer parameter-sweep harness (#2)

### DIFF
--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -55,6 +55,10 @@ OUTDIR="${OUTDIR:-$SCRATCH/cancer_$SLURM_JOB_ID}"
 # Simulation parameters.
 TOTAL_COVERAGE="${TOTAL_COVERAGE:-30}"
 PURITY="${PURITY:-0.6}"          # tumor cell fraction
+# Tumor somatic per-base mutation rate. Empty → cancer_simulate.sh's default
+# (1e-5, a typical solid tumor). Set to sweep tumor burden, or "model" to defer
+# to the tumor model's fitted (corpus-aggregated) rate.
+TUMOR_MUTATION_RATE="${TUMOR_MUTATION_RATE:-}"
 READ_LEN="${READ_LEN:-151}"
 PAIRED="${PAIRED:-true}"
 FRAG_MEAN="${FRAG_MEAN:-350}"
@@ -110,6 +114,8 @@ else
     echo "[1/6] Simulating tumor/normal reads..."
     PAIRED_FLAG=""
     [[ "$PAIRED" == "true" ]] && PAIRED_FLAG="--paired-ended --fragment-mean $FRAG_MEAN --fragment-st-dev $FRAG_SD"
+    TMR_FLAG=""
+    [[ -n "$TUMOR_MUTATION_RATE" ]] && TMR_FLAG="--tumor-mutation-rate $TUMOR_MUTATION_RATE"
     # Under `sbatch --array=1-3` (triplicate), each replicate uses a distinct
     # seed root (independent draw); SLURM spreads tasks across nodes. Plain
     # submit uses the default root.
@@ -124,6 +130,7 @@ else
         --sv-rate-scale "$SV_RATE_SCALE" \
         --rng-seed "$RNG_SEED_ROOT" \
         --rneat-bin "$RNEAT_BIN" \
+        $TMR_FLAG \
         $PAIRED_FLAG
     echo "[1/6] Simulation complete."
 fi

--- a/scripts/delta/collect_cancer_sweeps.sh
+++ b/scripts/delta/collect_cancer_sweeps.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Tabulate a cancer-sweep manifest (from run_cancer_sweeps.sh) into a TSV for charting.
+#
+#   purity/coverage/tmr : per point, som.py somatic SNV + indel recall/precision
+#                         (Mutect2, $outdir/scored.stats.csv) + derived normal cov.
+#   tissue              : per tissue, per-type SV recall from truvari summaries
+#                         ($outdir/truvari_<caller>_<TYPE>/summary.json), Manta + Delly.
+#
+# Best-effort + defensive: a missing/locked output yields NA rather than aborting.
+# Usage: bash scripts/delta/collect_cancer_sweeps.sh <axis manifest>
+set -euo pipefail
+
+MANIFEST="${1:?usage: collect_cancer_sweeps.sh <manifest>}"
+[[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
+axis=$(awk '!/^#/ && NF {print $1; exit}' "$MANIFEST")
+
+if [[ "$axis" == "tissue" ]]; then
+    printf 'tissue\tcaller\tDEL_recall\tDUP_recall\tINV_recall\tBND_recall\n'
+    while read -r ax point jid outdir total purity tmr model; do
+        [[ "$ax" == \#* || -z "${ax:-}" ]] && continue
+        for caller in manta delly; do
+            python3 - "$outdir" "$point" "$caller" <<'PY'
+import json, sys, os
+outdir, tissue, caller = sys.argv[1:4]
+def rec(t):
+    p = os.path.join(outdir, f"truvari_{caller}_{t}", "summary.json")
+    try:
+        d = json.load(open(p))
+        v = d.get("recall")
+        return f"{float(v):.3f}" if v is not None else "NA"
+    except Exception:
+        return "NA"
+print("\t".join([tissue, caller, rec("DEL"), rec("DUP"), rec("INV"), rec("BND")]))
+PY
+        done
+    done < "$MANIFEST"
+else
+    printf 'point\ttotal_cov\tpurity\tnormal_cov\tSNV_recall\tSNV_prec\tINDEL_recall\tINDEL_prec\n'
+    while read -r ax point jid outdir total purity tmr model; do
+        [[ "$ax" == \#* || -z "${ax:-}" ]] && continue
+        f="$outdir/scored.stats.csv"
+        if [[ ! -f "$f" ]]; then
+            printf '%s\t%s\t%s\tNA\tNA\tNA\tNA\tNA\n' "$point" "$total" "$purity"; continue
+        fi
+        python3 - "$f" "$point" "$total" "$purity" <<'PY'
+import csv, sys
+f, point, total, purity = sys.argv[1:5]
+try: nc = f"{float(total)*(1-float(purity)):.0f}"
+except Exception: nc = "NA"
+rows = {}
+for r in csv.DictReader(open(f)):
+    rows[(r.get("type") or "").strip().lower()] = r
+def cell(type_aliases, metric):
+    for t in type_aliases:
+        r = rows.get(t)
+        if not r: continue
+        for c in r:
+            if c.strip().lower() == metric:
+                try: return f"{float(r[c]):.4f}"
+                except Exception: return "NA"
+    return "NA"
+print("\t".join([point, total, purity, nc,
+                 cell(("snvs","snp","snps"), "recall"),
+                 cell(("snvs","snp","snps"), "precision"),
+                 cell(("indels","indel"),    "recall"),
+                 cell(("indels","indel"),    "precision")]))
+PY
+    done < "$MANIFEST"
+fi

--- a/scripts/delta/run_cancer_sweeps.sh
+++ b/scripts/delta/run_cancer_sweeps.sh
@@ -42,16 +42,30 @@ echo "# axis point jobid outdir total_cov purity tmr model" > "$MANIFEST"
 
 case "$AXIS" in
   purity)
-    NORMAL_FIX="${NORMAL_FIX:-30}"               # matched-normal coverage, held constant
-    PURITIES="${PURITIES:-0.3 0.5 0.7 0.9}"      # matches the §3.9 sweep for direct comparison
+    NORMAL_FIX="${NORMAL_FIX:-30}"               # matched-normal coverage, held constant (pinned mode)
+    FIXED_TOTAL="${FIXED_TOTAL:-}"               # if set: §3.7-style FIXED budget (normal shrinks) — the
+                                                 # same-caller "before" arm for an SNV collapse-vs-fix overlay
+    PURITIES="${PURITIES:-0.3 0.5 0.7 0.9}"
+    if [[ -n "$FIXED_TOTAL" ]]; then             # distinct manifest so it never clobbers the pinned run
+        MANIFEST="${MANIFEST%.manifest}_fixed.manifest"
+        echo "# axis point jobid outdir total_cov purity tmr model" > "$MANIFEST"
+    fi
     for p in $PURITIES; do
-        total=$(awk -v n="$NORMAL_FIX" -v p="$p" 'BEGIN{printf "%d", (n/(1-p))+0.5}')
-        out="$SCRATCH/sweep_purity_p${p}_n${NORMAL_FIX}"
+        if [[ -n "$FIXED_TOTAL" ]]; then
+            total="$FIXED_TOTAL"; out="$SCRATCH/sweep_purity_p${p}_fixed${FIXED_TOTAL}"
+        else
+            total=$(awk -v n="$NORMAL_FIX" -v p="$p" 'BEGIN{printf "%d", (n/(1-p))+0.5}')
+            out="$SCRATCH/sweep_purity_p${p}_n${NORMAL_FIX}"
+        fi
         jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$total" PURITY="$p" OUTDIR="$out" \
               sbatch --parsable "$CANCER")
         echo "purity $p $jid $out $total $p - pancancer" | tee -a "$MANIFEST"
     done
-    echo "NOTE: matched normal pinned at ${NORMAL_FIX}× (total=NORMAL_FIX/(1-purity)); compare to §3.9 fixed-budget sweep."
+    if [[ -n "$FIXED_TOTAL" ]]; then
+        echo "NOTE: FIXED budget ${FIXED_TOTAL}× (normal=(1-purity)·total, shrinks) — the §3.7-style 'before' arm."
+    else
+        echo "NOTE: matched normal pinned at ${NORMAL_FIX}× (total=NORMAL_FIX/(1-purity)) — the 'after' arm."
+    fi
     ;;
   coverage)
     PURITY="${PURITY:-0.6}"

--- a/scripts/delta/run_cancer_sweeps.sh
+++ b/scripts/delta/run_cancer_sweeps.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Cancer parameter sweeps (report §4 item "#2") — drive the cancer pipelines across
+# ONE axis at a time and write a per-axis manifest for collect_cancer_sweeps.sh.
+#
+# Axes (set AXIS=...):
+#   purity    Somatic recall vs tumor purity, with the matched normal PINNED at a
+#             fixed coverage (NORMAL_FIX) via total = NORMAL_FIX/(1-purity). This is
+#             the clean re-run of the §3.9 finding: the earlier collapse at purity
+#             0.9 came from splitting a FIXED budget, which starved the normal to
+#             ~6×. Pinning the normal removes that confound, so if recall no longer
+#             collapses, the collapse was experimental design, not rneat. (Tumor-
+#             sample depth then rises with purity, which only reinforces this.)
+#   coverage  Somatic recall vs total tumor depth, at fixed purity.
+#   tmr       Somatic recall/precision + truth count vs tumor somatic mutation rate.
+#   tissue    Per-tissue SV spectra (BRCA/skin/lung) via sv_pipeline.sbatch + the
+#             bundled per-tissue SV models — do tissue-specific spectra (BRCA DUP-,
+#             skin BND-, lung DEL-leaning) survive downstream to Manta/Delly calls?
+#
+# cancer_pipeline.sbatch / sv_pipeline.sbatch are idempotent, so re-running an axis
+# only does the unfinished points. Each point is its own SLURM job.
+#
+# Usage (from repo root):
+#   AXIS=purity   bash scripts/delta/run_cancer_sweeps.sh        # start here
+#   AXIS=coverage bash scripts/delta/run_cancer_sweeps.sh
+#   AXIS=tmr      bash scripts/delta/run_cancer_sweeps.sh
+#   AXIS=tissue   bash scripts/delta/run_cancer_sweeps.sh
+#   # overridable: PURITIES, COVERAGES, TMRS, TISSUES, NORMAL_FIX, REFERENCE, PURITY, TOTAL_COVERAGE
+# When an axis's jobs finish:
+#   bash scripts/delta/collect_cancer_sweeps.sh <printed manifest path>
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH + RESULTS_DIR resolution
+
+AXIS="${AXIS:?set AXIS=purity|coverage|tmr|tissue}"
+REFERENCE="${REFERENCE:-$SCRATCH/neat_data/chr22.fa}"
+MANIFEST="${MANIFEST:-${RESULTS_DIR:-$HOME}/cancer_sweep_${AXIS}.manifest}"
+CANCER="$REPO_ROOT/scripts/delta/cancer_pipeline.sbatch"
+SVPIPE="$REPO_ROOT/scripts/delta/sv_pipeline.sbatch"
+mkdir -p "$(dirname "$MANIFEST")"
+echo "# axis point jobid outdir total_cov purity tmr model" > "$MANIFEST"
+
+case "$AXIS" in
+  purity)
+    NORMAL_FIX="${NORMAL_FIX:-30}"               # matched-normal coverage, held constant
+    PURITIES="${PURITIES:-0.3 0.5 0.7 0.9}"      # matches the §3.9 sweep for direct comparison
+    for p in $PURITIES; do
+        total=$(awk -v n="$NORMAL_FIX" -v p="$p" 'BEGIN{printf "%d", (n/(1-p))+0.5}')
+        out="$SCRATCH/sweep_purity_p${p}_n${NORMAL_FIX}"
+        jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$total" PURITY="$p" OUTDIR="$out" \
+              sbatch --parsable "$CANCER")
+        echo "purity $p $jid $out $total $p - pancancer" | tee -a "$MANIFEST"
+    done
+    echo "NOTE: matched normal pinned at ${NORMAL_FIX}× (total=NORMAL_FIX/(1-purity)); compare to §3.9 fixed-budget sweep."
+    ;;
+  coverage)
+    PURITY="${PURITY:-0.6}"
+    COVERAGES="${COVERAGES:-30 60 100 200}"
+    for c in $COVERAGES; do
+        out="$SCRATCH/sweep_cov_c${c}_p${PURITY}"
+        jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$c" PURITY="$PURITY" OUTDIR="$out" \
+              sbatch --parsable "$CANCER")
+        echo "coverage $c $jid $out $c $PURITY - pancancer" | tee -a "$MANIFEST"
+    done
+    ;;
+  tmr)
+    PURITY="${PURITY:-0.6}"; TOTAL_COVERAGE="${TOTAL_COVERAGE:-60}"
+    TMRS="${TMRS:-1e-6 1e-5 5e-5 1e-4}"
+    for r in $TMRS; do
+        out="$SCRATCH/sweep_tmr_r${r}_c${TOTAL_COVERAGE}_p${PURITY}"
+        jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$TOTAL_COVERAGE" PURITY="$PURITY" \
+              TUMOR_MUTATION_RATE="$r" OUTDIR="$out" sbatch --parsable "$CANCER")
+        echo "tmr $r $jid $out $TOTAL_COVERAGE $PURITY $r pancancer" | tee -a "$MANIFEST"
+    done
+    ;;
+  tissue)
+    PURITY="${PURITY:-0.8}"; TOTAL_COVERAGE="${TOTAL_COVERAGE:-60}"
+    SV_RATE_SCALE="${SV_RATE_SCALE:-1.5}"
+    TISSUES="${TISSUES:-BRCA skin lung}"
+    for t in $TISSUES; do
+        model="$REPO_ROOT/tools/cosmic_pancancer_sv_${t}.json.gz"
+        [[ -f "$model" ]] || { echo "missing model: $model — skipping $t" >&2; continue; }
+        out="$SCRATCH/sweep_tissue_${t}"
+        jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$TOTAL_COVERAGE" PURITY="$PURITY" \
+              SV_RATE_SCALE="$SV_RATE_SCALE" TUMOR_MODEL="$model" OUTDIR="$out" \
+              RUN_DELLY=1 RUN_CNV=1 sbatch --parsable "$SVPIPE")
+        echo "tissue $t $jid $out $TOTAL_COVERAGE $PURITY - $model" | tee -a "$MANIFEST"
+    done
+    ;;
+  *) echo "unknown AXIS=$AXIS (expected purity|coverage|tmr|tissue)" >&2; exit 1 ;;
+esac
+
+echo
+echo "Manifest: $MANIFEST   (watch: squeue --me)"
+echo "When jobs finish: bash scripts/delta/collect_cancer_sweeps.sh $MANIFEST"


### PR DESCRIPTION
## What

`run_cancer_sweeps.sh` (driver) + `collect_cancer_sweeps.sh` (tabulator), one axis at a time:

- **purity** — clean re-run of the §3.9 collapse: matched normal **pinned** at `NORMAL_FIX` via `total = NORMAL_FIX/(1-purity)`, removing the fixed-budget normal-starvation confound.
- **coverage** — somatic recall vs total tumor depth.
- **tmr** — recall/precision + truth count vs tumor somatic mutation rate.
- **tissue** — per-tissue SV spectra (BRCA/skin/lung) via `sv_pipeline.sbatch` + bundled `cosmic_pancancer_sv_<tissue>` models, scored by Manta/Delly truvari.

Per-axis manifests (no cross-axis clobber). Also adds a `TUMOR_MUTATION_RATE` passthrough to `cancer_pipeline.sbatch` (previously hardcoded to `cancer_simulate.sh`'s default).

Note: touches `cancer_pipeline.sbatch` (TMR passthrough); #323 touches its index guard — different regions, expected to merge clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)