### PR TITLE
Replication audit + REPS support (and figures/§3.7 missed by the #324 merge)

### DIFF
--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -363,9 +363,13 @@ plateaus at the detection ceiling for purity ≥ 0.7, dipping at 0.3 only becaus
 the pinned-normal design leaves less tumor depth (13×) there. This confirms the
 extreme-purity drop is matched-normal starvation common to any tumor/normal
 caller (Manta or Mutect2 losing the germline reference it subtracts) — the #315
-coverage-model artifact — not rneat's variant generation. (A same-caller
-fixed-budget SNV arm, the direct "before" to this "after", is a one-command
-follow-up: `AXIS=purity FIXED_TOTAL=60 run_cancer_sweeps.sh`.)
+coverage-model artifact — not rneat's variant generation. The same-caller
+fixed-budget SNV arm (the direct "before" to this "after") makes it airtight:
+splitting a fixed 60× budget, SNV recall is **0.88 / 0.97 / 0.96** at purity
+0.3 / 0.5 / 0.7 and then **collapses to 0.003 at 0.9** (normal 6×) — a near-total
+loss, *even more severe than the SV path's 0.17*, because Mutect2 is more
+normal-dependent than Manta. Same caller, same metric, only the budget policy
+differs: the collapse is entirely matched-normal starvation.
 
 This is the first end-to-end validation of rneat's structural-variant output, and
 the read-level signal is correct across all classes and sizes. (Detection needs

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -376,6 +376,19 @@ the read-level signal is correct across all classes and sizes. (Detection needs
 adequate depth and SV count: a 30×/0.6 chr22 run yields too few somatic SVs to
 measure; 60×/0.8 gives a scoreable set.)
 
+**Per-tissue SV spectra reproduce at scale (§4).** Exercising the three bundled
+per-tissue SV models (BRCA / skin / lung) on chr22 at the default SV rate yields
+only ~3 somatic SVs per run — far too few to express a type distribution. Forcing
+the SV rate up to ~200–280 events per tissue makes the signatures clear: **skin is
+the most BND-enriched (59 %), lung the most DEL-leaning (40 %), and BRCA the most
+DUP-enriched (24 %, ~2× the others)** — the last exactly the expected BRCA1/2
+tandem-duplicator phenotype, and all three consistent with the PCAWG-derived models
+(#202 / #237). Two caveats: differentiation requires enough events (a scale
+requirement, not a defect — a small target won't show it), and BND is elevated
+across all tissues (a generation tendency, and unscored downstream since truvari
+does not benchmark breakends), so the tissue signal lives in the *relative*
+enrichments rather than the absolute mode.
+
 **Honest caveats — tracked as realism enhancements (epic #311).** The simulated SVs
 are *idealized*: clean cuts in unique sequence, lacking the microhomology, imprecise
 breakpoints, and repeat / segmental-duplication context that make real somatic SVs

--- a/docs/figures/chart_coverage_saturation.html
+++ b/docs/figures/chart_coverage_saturation.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Somatic recall/precision vs coverage</title>
+<style>
+  :root{--ink:#0f172a;--muted:#64748b;--line:#e2e8f0;}
+  *{box-sizing:border-box}
+  body{margin:0;background:#f8fafc;color:var(--ink);
+       font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{max-width:820px;margin:0 auto;padding:28px 20px 48px}
+  h1{font-size:22px;margin:0 0 2px}.sub{color:var(--muted);margin:0 0 14px}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;margin:0 0 12px;font-size:12.5px}
+  .sw{display:inline-block;width:20px;height:3px;border-radius:2px;margin-right:6px;vertical-align:3px}
+  .panel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:16px;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+  svg{width:100%;height:auto;display:block;overflow:visible}
+  .cap{color:var(--muted);font-size:13px;margin-top:16px;border-top:1px solid var(--line);padding-top:14px}
+  .cap b{color:var(--ink)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Somatic sensitivity saturates by 60×</h1>
+  <p class="sub">Mutect2 recovery of rneat somatic truth (chr22, purity 0.6), sweeping total tumor depth.</p>
+  <div class="legend">
+    <span><span class="sw" style="background:#2563eb"></span>SNV recall</span>
+    <span><span class="sw" style="background:#60a5fa"></span>SNV precision</span>
+    <span><span class="sw" style="background:#16a34a"></span>INDEL recall</span>
+    <span><span class="sw" style="background:#86efac"></span>INDEL precision</span>
+  </div>
+  <div class="panel"><svg id="c" viewBox="0 0 720 330" role="img" aria-label="recall/precision vs coverage"></svg></div>
+  <p class="cap"><b>Recall plateaus at ~0.97 (SNV) / ~0.93 (indel) by 60×, and precision jumps from 0.87 at
+  30× to 1.00 at ≥60×</b> — 30× is somewhat under-powered for somatic calling (more false positives on the
+  thin tumor signal), while 60× is the sweet spot and 100–200× add nothing. The flat top end confirms rneat
+  isn't bottlenecking sensitivity: the caller, not the simulator, sets the ceiling. Source: ACCESS report §4 (coverage sweep).</p>
+</div>
+<script>
+const NS="http://www.w3.org/2000/svg";
+const el=(t,a)=>{const e=document.createElementNS(NS,t);for(const k in a)e.setAttribute(k,a[k]);return e;};
+const txt=(x,y,s,o={})=>{const e=el("text",{x,y,"font-size":o.size||10,fill:o.fill||"#475569",
+  "text-anchor":o.anchor||"middle","font-weight":o.w||400});e.textContent=s;return e;};
+const COV=["30×","60×","100×","200×"];
+const S={SNVr:[0.9252,0.9695,0.9723,0.9695],SNVp:[0.8721,1.0,1.0,1.0],
+         INDr:[0.9000,0.9333,0.9000,0.9333],INDp:[0.8438,0.9655,0.9310,0.9655]};
+const svg=document.getElementById("c"),W=720,H=330,L=46,Rm=16,T=16,B=42,pw=W-L-Rm,ph=H-T-B;
+const n=COV.length,X=i=>L+pw*(i+0.5)/n, y0=0.80,y1=1.01,Y=v=>T+ph-ph*(v-y0)/(y1-y0);
+svg.appendChild(el("line",{x1:L,y1:T+ph,x2:W-Rm,y2:T+ph,stroke:"#cbd5e1"}));
+[0.80,0.85,0.90,0.95,1.00].forEach(v=>{const y=Y(v);
+  svg.appendChild(el("line",{x1:L,y1:y,x2:W-Rm,y2:y,stroke:"#eef2f7"}));
+  svg.appendChild(txt(L-7,y+3,v.toFixed(2),{anchor:"end",fill:"#94a3b8"}));});
+svg.appendChild(txt(16,T+ph/2,"recall / precision",{fill:"#64748b",size:11})).setAttribute("transform",`rotate(-90 16 ${T+ph/2})`);
+function line(arr,c){const pts=arr.map((v,i)=>`${X(i)},${Y(v)}`).join(" ");
+  svg.appendChild(el("polyline",{points:pts,fill:"none",stroke:c,"stroke-width":2.5}));
+  arr.forEach((v,i)=>svg.appendChild(el("circle",{cx:X(i),cy:Y(v),r:3.5,fill:c})));}
+line(S.SNVr,"#2563eb"); line(S.SNVp,"#60a5fa"); line(S.INDr,"#16a34a"); line(S.INDp,"#86efac");
+COV.forEach((c,i)=>svg.appendChild(txt(X(i),T+ph+16,c,{fill:"#334155",size:11.5})));
+svg.appendChild(txt(X(0),Y(0.8721)-8,"0.87",{fill:"#60a5fa",size:9.5,w:700}));
+svg.appendChild(txt((X(1)+X(2))/2,Y(1.0)-6,"precision → 1.00 (≥60×)",{fill:"#3b82f6",size:10,w:700}));
+</script>
+</body>
+</html>

--- a/docs/figures/chart_recall_vs_purity.html
+++ b/docs/figures/chart_recall_vs_purity.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Extreme-purity collapse is normal-starvation — and the fix</title>
+<title>Somatic recall vs purity — fixed budget vs pinned normal</title>
 <style>
   :root{--ink:#0f172a;--muted:#64748b;--line:#e2e8f0;--green:#16a34a;--red:#dc2626;}
   *{box-sizing:border-box}
   body{margin:0;background:#f8fafc;color:var(--ink);
        font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
-  .wrap{max-width:860px;margin:0 auto;padding:28px 20px 48px}
+  .wrap{max-width:840px;margin:0 auto;padding:28px 20px 48px}
   h1{font-size:22px;margin:0 0 2px}.sub{color:var(--muted);margin:0 0 16px}
   .legend{display:flex;gap:20px;flex-wrap:wrap;margin:0 0 12px;font-size:13px}
   .sw{display:inline-block;width:22px;height:3px;border-radius:2px;margin-right:7px;vertical-align:3px}
@@ -21,23 +21,22 @@
 </head>
 <body>
 <div class="wrap">
-  <h1>The extreme-purity collapse is normal-starvation — and pinning the normal fixes it</h1>
-  <p class="sub">Two purity sweeps on chr22 — <i>different callers and variant classes</i>, one shared
-  mechanism. A fixed budget starves the matched normal at high purity; a healthy normal does not.</p>
+  <h1>The extreme-purity collapse is normal-starvation — pinning the normal fixes it</h1>
+  <p class="sub">Same caller, same metric: Mutect2 somatic SNV recall (chr22, 60× model), sweeping purity
+  two ways — splitting a fixed budget (normal shrinks) vs holding the matched normal at 30×.</p>
   <div class="legend">
-    <span><span class="sw" style="background:var(--red)"></span>SV recall · Manta · fixed 60× budget (§3.7)</span>
-    <span><span class="sw" style="background:var(--green)"></span>SNV recall · Mutect2 · normal pinned 30× (re-run)</span>
+    <span><span class="sw" style="background:var(--red)"></span>Fixed 60× budget — normal 42→6× (§3.7-style)</span>
+    <span><span class="sw" style="background:var(--green)"></span>Matched normal pinned at 30×</span>
   </div>
-  <div class="panel"><svg id="c" viewBox="0 0 720 360" role="img" aria-label="recall vs purity, two regimes"></svg></div>
-  <p class="cap"><b>Under a fixed budget the matched normal shrinks with purity and recall collapses at
-  the extreme (SV recall → 0.17 at purity 0.9, normal ~6×); with the normal pinned at 30× recall instead
-  holds ~0.97 right through 0.9.</b> The two lines are not the same measurement — each is the clean test
-  within its own variant class — but they make one point: the collapse is <b>normal-starvation common to
-  any tumor/normal caller</b> (Mutect2 or Manta loses the germline reference it subtracts), not rneat's
-  variant generation. With a healthy normal, SNV recall even <i>rises</i> with purity and plateaus at the
-  detection ceiling (≥0.7); it is marginally lower at purity 0.3 (0.87) only because the pinned-normal
-  design leaves less tumor depth there. Fix tracked as <b>#315</b> (decouple matched-normal depth from
-  purity). Source: ACCESS report §3.7 + §4 purity re-run.</p>
+  <div class="panel"><svg id="c" viewBox="0 0 720 360" role="img" aria-label="SNV recall vs purity, two regimes"></svg></div>
+  <p class="cap"><b>Under a fixed budget, SNV recall collapses from 0.96 to 0.003 at purity 0.9 — near-total —
+  because the matched normal falls to 6× and Mutect2 loses the germline reference it subtracts. Pinning the
+  normal at 30× holds recall at 0.97 right through 0.9.</b> This is the controlled, same-caller before/after:
+  the collapse is matched-normal starvation (#315), not rneat's variant generation. SNV is hit even harder
+  than the SV path (§3.7, which bottomed at 0.17) because Mutect2 is more normal-dependent than Manta. Both
+  curves track together until the normal thins (≤18×); the pinned run is marginally lower at purity 0.3
+  (0.88) only because it spends less total depth there. <b>Recommendation:</b> hold normal coverage fixed
+  when sweeping purity. Source: ACCESS report §3.7 + §4 purity re-run.</p>
 </div>
 <script>
 const NS="http://www.w3.org/2000/svg";
@@ -45,30 +44,32 @@ const el=(t,a)=>{const e=document.createElementNS(NS,t);for(const k in a)e.setAt
 const txt=(x,y,s,o={})=>{const e=el("text",{x,y,"font-size":o.size||11,fill:o.fill||"#475569",
   "text-anchor":o.anchor||"middle","font-weight":o.w||400});e.textContent=s;return e;};
 const P=[0.3,0.5,0.7,0.9];
-const SV =[0.91,0.94,0.94,0.17];      // §3.7 SV recall, fixed 60x budget — normal starves
-const SNV=[0.873,0.967,0.970,0.970];  // §4 SNV recall, normal pinned at 30x
-const svg=document.getElementById("c"),W=720,H=360,L=52,Rm=18,T=18,B=70,pw=W-L-Rm,ph=H-T-B;
+const FIXED =[0.8837,0.9668,0.9640,0.0028];  // fixed 60x budget — normal 42/30/18/6
+const PINNED=[0.873,0.967,0.970,0.970];       // normal pinned 30x
+const NORMF =["42×","30×","18×","6×"];
+const svg=document.getElementById("c"),W=720,H=360,L=52,Rm=18,T=18,B=72,pw=W-L-Rm,ph=H-T-B;
 const X=p=>L+pw*(p-0.2)/(1.0-0.2), Y=v=>T+ph-ph*v/1.0;
 svg.appendChild(el("line",{x1:L,y1:T+ph,x2:W-Rm,y2:T+ph,stroke:"#cbd5e1"}));
 [0,.2,.4,.6,.8,1].forEach(v=>{const y=Y(v);
   svg.appendChild(el("line",{x1:L,y1:y,x2:W-Rm,y2:y,stroke:"#eef2f7"}));
   svg.appendChild(txt(L-8,y+3,v.toFixed(1),{anchor:"end",fill:"#94a3b8",size:10}));});
-svg.appendChild(txt(18,T+ph/2,"recall",{fill:"#64748b",size:11})).setAttribute("transform",`rotate(-90 18 ${T+ph/2})`);
+svg.appendChild(txt(18,T+ph/2,"Mutect2 SNV recall",{fill:"#64748b",size:11})).setAttribute("transform",`rotate(-90 18 ${T+ph/2})`);
 
 function series(R,color,labelBelow){
-  const pts=P.map((p,i)=>`${X(p)},${Y(R[i])}`).join(" ");
+  const pts=R.map((v,i)=>`${X(P[i])},${Y(v)}`).join(" ");
   svg.appendChild(el("polyline",{points:pts,fill:"none",stroke:color,"stroke-width":2.5}));
-  P.forEach((p,i)=>{
-    svg.appendChild(el("circle",{cx:X(p),cy:Y(R[i]),r:4,fill:color}));
-    svg.appendChild(txt(X(p),Y(R[i])+(labelBelow?16:-9),R[i].toFixed(2),{fill:color,w:700,size:11}));
+  R.forEach((v,i)=>{
+    svg.appendChild(el("circle",{cx:X(P[i]),cy:Y(v),r:4,fill:color}));
+    svg.appendChild(txt(X(P[i]),Y(v)+(labelBelow?16:-9),v.toFixed(2),{fill:color,w:700,size:11}));
   });
 }
-series(SV,"#dc2626",true);     // labels below the red (collapsing) line
-series(SNV,"#16a34a",false);   // labels above the green (held) line
-P.forEach(p=>svg.appendChild(txt(X(p),T+ph+18,"purity "+p,{fill:"#334155",size:11})));
-// annotate the two purity-0.9 endpoints (different metrics — no connector)
-svg.appendChild(txt(X(0.9),Y(0.17)+34,"normal ~6× (starved)",{fill:"#dc2626",size:10,w:700}));
-svg.appendChild(txt(X(0.9),Y(0.97)-26,"normal 30× (healthy)",{fill:"#16a34a",size:10,w:700}));
+series(PINNED,"#16a34a",false);  // held — labels above
+series(FIXED,"#dc2626",true);    // collapses — labels below
+P.forEach((p,i)=>{
+  svg.appendChild(txt(X(p),T+ph+18,"purity "+p,{fill:"#334155",size:11}));
+  svg.appendChild(txt(X(p),T+ph+32,"fixed-normal "+NORMF[i],{fill:"#94a3b8",size:9}));
+});
+svg.appendChild(txt(X(0.9),Y(0.0028)-10,"collapse",{fill:"#dc2626",size:10.5,w:700,anchor:"end"}));
 </script>
 </body>
 </html>

--- a/docs/figures/chart_tissue_sv_spectrum.html
+++ b/docs/figures/chart_tissue_sv_spectrum.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Per-tissue somatic SV spectra</title>
+<style>
+  :root{--brca:#db2777;--skin:#d97706;--lung:#2563eb;--ink:#0f172a;--muted:#64748b;--line:#e2e8f0;}
+  *{box-sizing:border-box}
+  body{margin:0;background:#f8fafc;color:var(--ink);
+       font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{max-width:860px;margin:0 auto;padding:28px 20px 48px}
+  h1{font-size:22px;margin:0 0 2px}.sub{color:var(--muted);margin:0 0 14px}
+  .legend{display:flex;gap:18px;flex-wrap:wrap;margin:0 0 14px;font-size:13px}
+  .sw{display:inline-block;width:13px;height:13px;border-radius:3px;margin-right:6px;vertical-align:-1px}
+  .panel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:16px;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+  svg{width:100%;height:auto;display:block;overflow:visible}
+  .cap{color:var(--muted);font-size:13px;margin-top:16px;border-top:1px solid var(--line);padding-top:14px}
+  .cap b{color:var(--ink)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>rneat reproduces per-tissue somatic SV signatures</h1>
+  <p class="sub">Somatic SV type composition of rneat's truth set under each bundled per-tissue model
+  (chr22, SV rate forced to ~200–280 events so the distribution is resolvable). % of each tissue's SVs.</p>
+  <div class="legend">
+    <span><span class="sw" style="background:var(--brca)"></span>BRCA (n=283)</span>
+    <span><span class="sw" style="background:var(--skin)"></span>skin (n=217)</span>
+    <span><span class="sw" style="background:var(--lung)"></span>lung (n=199)</span>
+  </div>
+  <div class="panel"><svg id="c" viewBox="0 0 760 360" role="img" aria-label="per-tissue SV type composition"></svg></div>
+  <p class="cap"><b>The expected tissue signatures emerge: skin is the most BND-enriched (59%), lung the most
+  DEL-leaning (40%), and BRCA the most DUP-enriched (24%, ~2× the others) — the latter exactly the BRCA1/2
+  tandem-duplicator phenotype.</b> This matches the PCAWG-derived per-tissue models (#202/#237). It is only
+  visible at scale: the chr22 default-rate run produced ~3 SVs/tissue, far too few to express a distribution
+  (a documented scale requirement, not a defect). BND is elevated across all three (an rneat generation
+  tendency, and unscored downstream — truvari doesn't benchmark breakends), so the tissue signal lives in
+  the <i>relative</i> enrichments. Source: ACCESS report §3.7 (per-tissue SV spectra).</p>
+</div>
+<script>
+const NS="http://www.w3.org/2000/svg";
+const el=(t,a)=>{const e=document.createElementNS(NS,t);for(const k in a)e.setAttribute(k,a[k]);return e;};
+const txt=(x,y,s,o={})=>{const e=el("text",{x,y,"font-size":o.size||10,fill:o.fill||"#475569",
+  "text-anchor":o.anchor||"middle","font-weight":o.w||400});e.textContent=s;return e;};
+const TYPES=["BND","DEL","DUP","INV","CNV"];
+// % of each tissue's somatic SVs  [BRCA, skin, lung]
+const PCT={BND:[41.0,59.4,32.2],DEL:[22.3,20.7,39.7],DUP:[23.7,12.4,14.1],INV:[10.2,3.7,10.6],CNV:[2.8,3.7,3.5]};
+const COL=["#db2777","#d97706","#2563eb"];
+const star={BND:1,DEL:2,DUP:0};  // which tissue index peaks in each type (skin/lung/BRCA)
+const svg=document.getElementById("c"),W=760,H=360,L=46,R=16,T=18,B=44,pw=W-L-R,ph=H-T-B;
+const ng=TYPES.length,gw=pw/ng,bw=gw*0.22;
+svg.appendChild(el("line",{x1:L,y1:T+ph,x2:W-R,y2:T+ph,stroke:"#cbd5e1"}));
+[0,15,30,45,60].forEach(v=>{const y=T+ph-ph*v/65;
+  svg.appendChild(el("line",{x1:L,y1:y,x2:W-R,y2:y,stroke:"#eef2f7"}));
+  svg.appendChild(txt(L-7,y+3,v+"%",{anchor:"end",fill:"#94a3b8"}));});
+svg.appendChild(txt(16,T+ph/2,"% of tissue's somatic SVs",{fill:"#64748b",size:11})).setAttribute("transform",`rotate(-90 16 ${T+ph/2})`);
+TYPES.forEach((ty,i)=>{
+  const x0=L+i*gw+gw*0.17;
+  PCT[ty].forEach((v,j)=>{
+    const h=ph*v/65,x=x0+j*(bw+4),y=T+ph-h;
+    svg.appendChild(el("rect",{x,y,width:bw,height:h,rx:2.5,fill:COL[j]}));
+    svg.appendChild(txt(x+bw/2,y-3,v.toFixed(0),{size:9,fill:"#475569"}));
+    if(star[ty]===j) svg.appendChild(txt(x+bw/2,y-13,"★",{size:11,fill:COL[j],w:700}));
+  });
+  svg.appendChild(txt(x0+1.5*(bw+4),T+ph+16,ty,{fill:"#334155",size:12,w:600}));
+});
+// signature callouts
+svg.appendChild(txt(W-R,T+6,"★ = tissue's defining enrichment",{anchor:"end",fill:"#64748b",size:10.5}));
+</script>
+</body>
+</html>

--- a/docs/figures/chart_tmr_response.html
+++ b/docs/figures/chart_tmr_response.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Somatic recall/precision vs tumor mutation rate</title>
+<style>
+  :root{--ink:#0f172a;--muted:#64748b;--line:#e2e8f0;}
+  *{box-sizing:border-box}
+  body{margin:0;background:#f8fafc;color:var(--ink);
+       font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  .wrap{max-width:820px;margin:0 auto;padding:28px 20px 48px}
+  h1{font-size:22px;margin:0 0 2px}.sub{color:var(--muted);margin:0 0 14px}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;margin:0 0 12px;font-size:12.5px}
+  .sw{display:inline-block;width:20px;height:3px;border-radius:2px;margin-right:6px;vertical-align:3px}
+  .panel{background:#fff;border:1px solid var(--line);border-radius:12px;padding:16px;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+  svg{width:100%;height:auto;display:block;overflow:visible}
+  .cap{color:var(--muted);font-size:13px;margin-top:16px;border-top:1px solid var(--line);padding-top:14px}
+  .cap b{color:var(--ink)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Calling is robust across tumor mutation burden</h1>
+  <p class="sub">Mutect2 recovery of rneat somatic truth (chr22, 60×, purity 0.6), sweeping the tumor
+  somatic mutation rate over a 100× range.</p>
+  <div class="legend">
+    <span><span class="sw" style="background:#2563eb"></span>SNV recall</span>
+    <span><span class="sw" style="background:#60a5fa"></span>SNV precision</span>
+    <span><span class="sw" style="background:#16a34a"></span>INDEL recall</span>
+    <span><span class="sw" style="background:#86efac"></span>INDEL precision</span>
+  </div>
+  <div class="panel"><svg id="c" viewBox="0 0 720 330" role="img" aria-label="recall/precision vs mutation rate"></svg></div>
+  <p class="cap"><b>SNV recall (~0.95–0.97) and precision (1.00) are flat across the full 1e-6 → 1e-4 range;
+  indel recall tapers from 1.00 to 0.89 as burden rises</b> — denser, more closely-spaced indels are
+  progressively harder to recover and left-normalize, an expected caller limit, not a simulator one
+  (precision stays ≥0.94). rneat's tumor-burden knob spans two orders of magnitude without destabilizing
+  the pipeline. <i>Note: this shows recovery vs rate; that the truth variant count scales with the
+  configured rate is a separate check (truth totals not in this TSV).</i> Source: ACCESS report §4 (tumor-mutation-rate sweep).</p>
+</div>
+<script>
+const NS="http://www.w3.org/2000/svg";
+const el=(t,a)=>{const e=document.createElementNS(NS,t);for(const k in a)e.setAttribute(k,a[k]);return e;};
+const txt=(x,y,s,o={})=>{const e=el("text",{x,y,"font-size":o.size||10,fill:o.fill||"#475569",
+  "text-anchor":o.anchor||"middle","font-weight":o.w||400});e.textContent=s;return e;};
+const R=["1e-6","1e-5","5e-5","1e-4"];
+const S={SNVr:[0.9429,0.9695,0.9697,0.9681],SNVp:[1.0,1.0,1.0,1.0],
+         INDr:[1.0,0.9333,0.8936,0.8853],INDp:[1.0,0.9655,0.9545,0.9427]};
+const svg=document.getElementById("c"),W=720,H=330,L=46,Rm=16,T=16,B=44,pw=W-L-Rm,ph=H-T-B;
+const n=R.length,X=i=>L+pw*(i+0.5)/n, y0=0.85,y1=1.01,Y=v=>T+ph-ph*(v-y0)/(y1-y0);
+svg.appendChild(el("line",{x1:L,y1:T+ph,x2:W-Rm,y2:T+ph,stroke:"#cbd5e1"}));
+[0.85,0.90,0.95,1.00].forEach(v=>{const y=Y(v);
+  svg.appendChild(el("line",{x1:L,y1:y,x2:W-Rm,y2:y,stroke:"#eef2f7"}));
+  svg.appendChild(txt(L-7,y+3,v.toFixed(2),{anchor:"end",fill:"#94a3b8"}));});
+svg.appendChild(txt(16,T+ph/2,"recall / precision",{fill:"#64748b",size:11})).setAttribute("transform",`rotate(-90 16 ${T+ph/2})`);
+function line(arr,c){const pts=arr.map((v,i)=>`${X(i)},${Y(v)}`).join(" ");
+  svg.appendChild(el("polyline",{points:pts,fill:"none",stroke:c,"stroke-width":2.5}));
+  arr.forEach((v,i)=>svg.appendChild(el("circle",{cx:X(i),cy:Y(v),r:3.5,fill:c})));}
+line(S.SNVr,"#2563eb"); line(S.SNVp,"#60a5fa"); line(S.INDr,"#16a34a"); line(S.INDp,"#86efac");
+R.forEach((r,i)=>svg.appendChild(txt(X(i),T+ph+16,r,{fill:"#334155",size:11})));
+svg.appendChild(txt(W/2,T+ph+34,"tumor somatic mutation rate (per base)",{fill:"#64748b",size:11}));
+svg.appendChild(txt(X(3),Y(0.8853)+13,"indel recall ↓ at high burden",{fill:"#16a34a",size:10,w:700,anchor:"end"}));
+</script>
+</body>
+</html>

--- a/docs/replication_audit.md
+++ b/docs/replication_audit.md
@@ -1,0 +1,93 @@
+# Replication coverage audit
+
+**Question:** before moving on from validation, which results rest on enough runs
+to trust, and which are single-draw point estimates that warrant replication —
+even where the single number looks good?
+
+**Short answer:** there are **no qualitative gaps** (every planned validation ran),
+but most *fidelity/recall* numbers are **single draws**. Performance and the
+scaling/allocator work are already replicated. The one statistically *fragile*
+headline is the **§3.7 SV per-type recall** (single run **and** small event
+counts). Determinism/order-independence need no reps (they are exact).
+
+## Classification
+
+Each result falls into one of four buckets:
+
+- **EXACT** — deterministic; repeating yields identical output, so n=1 is definitive.
+- **REPLICATED** — already run ≥2× (median or mean±sd reported).
+- **SINGLE / TIGHT** — one run, but over a large denominator (≥10⁴ variants), so the
+  sampling CI is already tight; reps only add error bars.
+- **SINGLE / FRAGILE** — one run over a small denominator or a noisy measurement;
+  the point estimate could move on a re-draw → **reps needed**.
+
+| § | Result | n | Denominator / nature | Bucket |
+|---|---|---|---|---|
+| 3.1 | Determinism (1 vs 8 thread, byte-identical) | 1 | exact (md5) | **EXACT** |
+| 3.10 | Order-independence (determ., thread-inv., shard-order, disjoint) | 1 | exact (md5) | **EXACT** |
+| 3.1 | Coverage / breadth / Ts/Tv / het-hom | 1 | whole-chr aggregates | SINGLE / TIGHT |
+| 3.2 | Performance vs NEAT (wall, RSS) | **3** | median of 3 (`benchmark.sbatch REPS=3`) | **REPLICATED** |
+| 3.6 | Thread × allocator × NUMA isolation | **2** | 2 reps | **REPLICATED** |
+| 3.6 | Procs-per-node throughput, whole-genome wall | ≥3* | `run_genome_reps REPS=3` + mean±sd | **REPLICATED*** |
+| 3.3 | Germline fidelity chr22 (SNP/indel recall) | 1 | ~10⁵ SNVs → tight CI | SINGLE / TIGHT |
+| 4 | Input variety (5 genomes) | 1 ea | 10⁵–4·10⁵ variants → tight | SINGLE / TIGHT |
+| 3.4 | Cancer end-to-end (somatic SNV/indel) | 1 | moderate somatic count | SINGLE / FRAGILE |
+| 3.9 | Cross-caller (Delly, VarScan2) | 1 | moderate | SINGLE / FRAGILE |
+| 4 | Cancer sweeps (purity / coverage / tmr) | 1/pt | moderate; some small | SINGLE / FRAGILE |
+| 3.7 | **SV per-type recall (DEL/DUP/INV)** | 1 | **small event count** (e.g. INV recall 1.000 may be 3/3) | **SINGLE / FRAGILE ← top priority** |
+| 4 | Per-tissue SV spectrum | 1 | ~200–280 SVs → adequate | SINGLE / TIGHT |
+
+\* The reps *machinery* (`run_genome_reps.sh` + `aggregate_reps.sh`, mean±sd per K)
+exists and was used for the K-sweep; confirm the headline whole-genome wall-clock
+(3 h 41 m shared / 2 h 30 m exclusive) is a rep mean, not a single run — and note
+that the **shared-partition** number is inherently high-variance (cross-tenant
+contention) and should be reported as a range, not a point.
+
+## What this means
+
+- **The conclusions don't change** with reps — the qualitative findings (flat
+  fidelity across genomes, the purity-collapse mechanism, coverage saturation,
+  tissue spectra, thread-vs-process scaling) are mechanistically explained and
+  robust. Reps buy **error bars and fluke-protection**, not new conclusions.
+- **The one number not to publish bare is §3.7 SV per-type recall.** With only a
+  handful of each SV type in the chr22/60×/0.8 truth, `INV = 1.000` and
+  `DEL = 0.882` carry wide confidence intervals. This is the must-replicate item.
+
+## Prioritized replication plan
+
+1. **§3.7 SV per-type recall — MUST.** 3 reps at 60×/0.8 with distinct seeds *and*
+   an elevated SV count (more events per run shrinks the CI directly, as the
+   tissue-spectrum run showed). Report mean ± sd per type.
+2. **Cancer recall — SHOULD.** 3 reps of the end-to-end point (§3.4) and the key
+   sweep points (purity 0.5/0.9, coverage 60×, tmr 1e-5). Confirms the purity
+   collapse and resolves the suspicious `0.7 ≡ 0.9` four-digit tie (saturation vs
+   artifact).
+3. **Germline fidelity + input variety — NICE.** 3 reps each for error bars; cheap,
+   and turns point estimates into mean ± sd. Conclusions won't move.
+4. **Whole-genome wall-clock — CONFIRM + CAVEAT.** Verify the headline used the
+   3-rep machinery; report the shared-partition figure as a range.
+5. **Determinism / order-independence — NONE.** Exact by construction; a re-run is
+   identical. (Optional one-off: confirm the contig-order sensitivity on a second
+   genome to show it generalizes — a correctness check, not a rep.)
+
+## How to run the reps
+
+The pipelines already derive a distinct seed per replicate; the sweep drivers now
+take a `REPS` env that submits each condition `REPS` times into `…_rep<r>` output
+dirs with distinct seeds (default `REPS=1` = unchanged behavior):
+
+```bash
+# input variety, 3 reps per genome
+REPS=3 GENOMES="…" bash scripts/delta/run_input_variety.sh
+
+# cancer sweeps, 3 reps per point (any axis)
+REPS=3 AXIS=purity bash scripts/delta/run_cancer_sweeps.sh
+
+# SV per-type (top priority): tissue axis is the SV path — 3 reps, elevated SV rate
+REPS=3 AXIS=tissue SV_RATE_SCALE=20 bash scripts/delta/run_cancer_sweeps.sh
+```
+
+The collectors emit one row per rep (the point/genome label carries the `_rep<r>`
+suffix); aggregate to **mean ± sd** by grouping on the base label. A future
+`aggregate_*` helper can fold this automatically; for now the per-rep rows are
+small enough to average on paste.

--- a/scripts/delta/run_cancer_sweeps.sh
+++ b/scripts/delta/run_cancer_sweeps.sh
@@ -40,26 +40,47 @@ SVPIPE="$REPO_ROOT/scripts/delta/sv_pipeline.sbatch"
 mkdir -p "$(dirname "$MANIFEST")"
 echo "# axis point jobid outdir total_cov purity tmr model" > "$MANIFEST"
 
+# REPS>1 submits each point REPS times with a DISTINCT per-rep seed into <out>_rep<r>,
+# for mean±sd error bars (see docs/replication_audit.md). REPS=1 = original behavior.
+REPS="${REPS:-1}"
+
+# submit_point <extra manifest cols> — caller sets PIPELINE, POINT, OUTBASE and the
+# pipeline env array PIPE_ENV=(KEY=val ...). Writes one manifest row per rep; uses a
+# distinct RNG_SEED_ROOT per rep when REPS>1 (both pipelines honor it).
+submit_point() {
+    local extra="$1" rr o lbl jid
+    for rr in $(seq 1 "$REPS"); do
+        if [[ "$REPS" -gt 1 ]]; then
+            o="${OUTBASE}_rep${rr}"; lbl="${POINT}_rep${rr}"
+            jid=$(env "${PIPE_ENV[@]}" OUTDIR="$o" RNG_SEED_ROOT="cancer $AXIS $POINT rep$rr" \
+                  sbatch --parsable "$PIPELINE")
+        else
+            o="$OUTBASE"; lbl="$POINT"
+            jid=$(env "${PIPE_ENV[@]}" OUTDIR="$o" sbatch --parsable "$PIPELINE")
+        fi
+        echo "$AXIS $lbl $jid $o $extra" | tee -a "$MANIFEST"
+    done
+}
+
 case "$AXIS" in
   purity)
     NORMAL_FIX="${NORMAL_FIX:-30}"               # matched-normal coverage, held constant (pinned mode)
-    FIXED_TOTAL="${FIXED_TOTAL:-}"               # if set: §3.7-style FIXED budget (normal shrinks) — the
-                                                 # same-caller "before" arm for an SNV collapse-vs-fix overlay
+    FIXED_TOTAL="${FIXED_TOTAL:-}"               # if set: §3.7-style FIXED budget (normal shrinks)
     PURITIES="${PURITIES:-0.3 0.5 0.7 0.9}"
     if [[ -n "$FIXED_TOTAL" ]]; then             # distinct manifest so it never clobbers the pinned run
         MANIFEST="${MANIFEST%.manifest}_fixed.manifest"
         echo "# axis point jobid outdir total_cov purity tmr model" > "$MANIFEST"
     fi
+    PIPELINE="$CANCER"
     for p in $PURITIES; do
         if [[ -n "$FIXED_TOTAL" ]]; then
-            total="$FIXED_TOTAL"; out="$SCRATCH/sweep_purity_p${p}_fixed${FIXED_TOTAL}"
+            total="$FIXED_TOTAL"; OUTBASE="$SCRATCH/sweep_purity_p${p}_fixed${FIXED_TOTAL}"
         else
             total=$(awk -v n="$NORMAL_FIX" -v p="$p" 'BEGIN{printf "%d", (n/(1-p))+0.5}')
-            out="$SCRATCH/sweep_purity_p${p}_n${NORMAL_FIX}"
+            OUTBASE="$SCRATCH/sweep_purity_p${p}_n${NORMAL_FIX}"
         fi
-        jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$total" PURITY="$p" OUTDIR="$out" \
-              sbatch --parsable "$CANCER")
-        echo "purity $p $jid $out $total $p - pancancer" | tee -a "$MANIFEST"
+        POINT="$p"; PIPE_ENV=(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$total" PURITY="$p")
+        submit_point "$total $p - pancancer"
     done
     if [[ -n "$FIXED_TOTAL" ]]; then
         echo "NOTE: FIXED budget ${FIXED_TOTAL}× (normal=(1-purity)·total, shrinks) — the §3.7-style 'before' arm."
@@ -70,35 +91,35 @@ case "$AXIS" in
   coverage)
     PURITY="${PURITY:-0.6}"
     COVERAGES="${COVERAGES:-30 60 100 200}"
+    PIPELINE="$CANCER"
     for c in $COVERAGES; do
-        out="$SCRATCH/sweep_cov_c${c}_p${PURITY}"
-        jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$c" PURITY="$PURITY" OUTDIR="$out" \
-              sbatch --parsable "$CANCER")
-        echo "coverage $c $jid $out $c $PURITY - pancancer" | tee -a "$MANIFEST"
+        OUTBASE="$SCRATCH/sweep_cov_c${c}_p${PURITY}"; POINT="$c"
+        PIPE_ENV=(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$c" PURITY="$PURITY")
+        submit_point "$c $PURITY - pancancer"
     done
     ;;
   tmr)
     PURITY="${PURITY:-0.6}"; TOTAL_COVERAGE="${TOTAL_COVERAGE:-60}"
     TMRS="${TMRS:-1e-6 1e-5 5e-5 1e-4}"
-    for r in $TMRS; do
-        out="$SCRATCH/sweep_tmr_r${r}_c${TOTAL_COVERAGE}_p${PURITY}"
-        jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$TOTAL_COVERAGE" PURITY="$PURITY" \
-              TUMOR_MUTATION_RATE="$r" OUTDIR="$out" sbatch --parsable "$CANCER")
-        echo "tmr $r $jid $out $TOTAL_COVERAGE $PURITY $r pancancer" | tee -a "$MANIFEST"
+    PIPELINE="$CANCER"
+    for rate in $TMRS; do
+        OUTBASE="$SCRATCH/sweep_tmr_r${rate}_c${TOTAL_COVERAGE}_p${PURITY}"; POINT="$rate"
+        PIPE_ENV=(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$TOTAL_COVERAGE" PURITY="$PURITY" TUMOR_MUTATION_RATE="$rate")
+        submit_point "$TOTAL_COVERAGE $PURITY $rate pancancer"
     done
     ;;
   tissue)
     PURITY="${PURITY:-0.8}"; TOTAL_COVERAGE="${TOTAL_COVERAGE:-60}"
     SV_RATE_SCALE="${SV_RATE_SCALE:-1.5}"
     TISSUES="${TISSUES:-BRCA skin lung}"
+    PIPELINE="$SVPIPE"
     for t in $TISSUES; do
         model="$REPO_ROOT/tools/cosmic_pancancer_sv_${t}.json.gz"
         [[ -f "$model" ]] || { echo "missing model: $model — skipping $t" >&2; continue; }
-        out="$SCRATCH/sweep_tissue_${t}"
-        jid=$(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$TOTAL_COVERAGE" PURITY="$PURITY" \
-              SV_RATE_SCALE="$SV_RATE_SCALE" TUMOR_MODEL="$model" OUTDIR="$out" \
-              RUN_DELLY=1 RUN_CNV=1 sbatch --parsable "$SVPIPE")
-        echo "tissue $t $jid $out $TOTAL_COVERAGE $PURITY - $model" | tee -a "$MANIFEST"
+        OUTBASE="$SCRATCH/sweep_tissue_${t}"; POINT="$t"
+        PIPE_ENV=(REFERENCE="$REFERENCE" TOTAL_COVERAGE="$TOTAL_COVERAGE" PURITY="$PURITY" \
+                  SV_RATE_SCALE="$SV_RATE_SCALE" TUMOR_MODEL="$model" RUN_DELLY=1 RUN_CNV=1)
+        submit_point "$TOTAL_COVERAGE $PURITY - $model"
     done
     ;;
   *) echo "unknown AXIS=$AXIS (expected purity|coverage|tmr|tissue)" >&2; exit 1 ;;

--- a/scripts/delta/run_input_variety.sh
+++ b/scripts/delta/run_input_variety.sh
@@ -22,17 +22,29 @@ source "$REPO_ROOT/scripts/delta/lib_report.sh"
 
 GENOMES="${GENOMES:?set GENOMES to a space-separated list of reference FASTAs}"
 COVERAGE="${COVERAGE:-30}"
+# REPS>1 submits each genome REPS times with a DISTINCT seed into variety_<g>_rep<r>,
+# for mean±sd error bars (see docs/replication_audit.md). REPS=1 = original behavior.
+REPS="${REPS:-1}"
 MANIFEST="${MANIFEST:-${RESULTS_DIR:-$HOME}/variety.manifest}"
 mkdir -p "$(dirname "$MANIFEST")"
 echo "# name jobid outdir reference" > "$MANIFEST"
 
 for ref in $GENOMES; do
     if [[ ! -f "$ref" ]]; then echo "MISSING: $ref — skipping" >&2; continue; fi
-    name="$(basename "$ref")"; name="${name%.*}"
-    out="$SCRATCH/variety_$name"
-    jid=$(REFERENCE="$ref" TOOLS=rneat COVERAGE="$COVERAGE" OUTDIR="$out" \
-          sbatch --parsable "$REPO_ROOT/scripts/delta/germline_e2e.sbatch")
-    echo "$name $jid $out $ref" | tee -a "$MANIFEST"
+    base="$(basename "$ref")"; base="${base%.*}"
+    for r in $(seq 1 "$REPS"); do
+        if [[ "$REPS" -gt 1 ]]; then
+            name="${base}_rep${r}"; out="$SCRATCH/variety_${base}_rep${r}"
+            jid=$(REFERENCE="$ref" TOOLS=rneat COVERAGE="$COVERAGE" OUTDIR="$out" \
+                  SEED="variety $base rep$r" \
+                  sbatch --parsable "$REPO_ROOT/scripts/delta/germline_e2e.sbatch")
+        else
+            name="$base"; out="$SCRATCH/variety_$base"   # unchanged default seed
+            jid=$(REFERENCE="$ref" TOOLS=rneat COVERAGE="$COVERAGE" OUTDIR="$out" \
+                  sbatch --parsable "$REPO_ROOT/scripts/delta/germline_e2e.sbatch")
+        fi
+        echo "$name $jid $out $ref" | tee -a "$MANIFEST"
+    done
 done
 
 echo


### PR DESCRIPTION
## Two things

### 1. Carries forward work the #324 merge didn't capture
PR #324 merged the branch at `32bf7ca`; three later commits never landed on `develop`:
- `602a3db` — **definitive** purity overlay (same-caller SNV fixed-budget collapse to **0.003** vs pinned-normal 0.97) + **coverage** and **tmr** sweep figures
- `508dbc3` — §3.7 fixed-budget-arm result
- `d8a5e70` — **per-tissue SV-spectrum** figure + §3.7 paragraph

So `develop` is currently missing 3 figures and 2 §3.7 updates and still shows the *older* cross-metric purity chart. This PR brings them current (branch was merged with `develop` first, so the diff is clean — no overlap with already-merged content).

### 2. Replication-coverage audit + REPS support
Answers "did we miss anything / does anything need more reps before moving on."

**`docs/replication_audit.md`** classifies every Phase-1/2 result:
- **EXACT** (determinism, order-independence) — n=1 definitive, no reps.
- **REPLICATED** — perf (n=3 median), allocator/thread isolation (2 reps), whole-genome wall-clock (3-rep machinery).
- **SINGLE / TIGHT** — germline fidelity, input variety, tissue spectrum — large denominators, reps only add error bars.
- **SINGLE / FRAGILE** — cancer recall, sweeps, and especially **§3.7 SV per-type recall** (single run + small event counts) → the **must-replicate** item.

**Verdict:** no qualitative gaps; conclusions are robust; the one number not to publish bare is §3.7 SV per-type recall.

**`REPS` env** added to `run_input_variety.sh` and `run_cancer_sweeps.sh`: submits each genome/point `REPS`× into `<out>_rep<r>` with a distinct per-rep seed (both pipelines honor `RNG_SEED_ROOT`), for mean±sd. `REPS=1` = unchanged behavior. Collectors already emit one row per rep (label carries `_rep<r>`); aggregate by grouping on the base label.

Verified: `bash -n` clean on both drivers; env/seed passing confirmed (incl. space-containing seeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)