### PR TITLE
feat(delta): PRUNE=1 — drop FASTQ+BAM after scoring (scratch-quota guardrail)

### DIFF
--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -64,6 +64,10 @@ PAIRED="${PAIRED:-true}"
 FRAG_MEAN="${FRAG_MEAN:-350}"
 FRAG_SD="${FRAG_SD:-50}"
 SV_RATE_SCALE="${SV_RATE_SCALE:-1.0}"   # >0 enables SV simulation in tumor pass
+# PRUNE=1 deletes the bulky FASTQ + BAM intermediates after a SUCCESSFUL score,
+# keeping only the small result artifacts (scored*.stats.csv, VCFs, logs). Use for
+# large sweeps so per-point output doesn't exhaust the shared scratch project quota.
+PRUNE="${PRUNE:-0}"
 
 # Tumor mutation model (COSMIC pan-cancer). Bundled in the repo.
 TUMOR_MODEL="$REPO_ROOT/tools/cosmic_v104_pancancer_model.json.gz"
@@ -396,3 +400,13 @@ fi
 
 # Persist report artifacts off scratch + record provenance/resources.
 archive_run cancer "$OUTDIR" scored.stats.csv
+
+# Optional cleanup of bulky intermediates once scored + archived, so large sweeps
+# don't exhaust the shared scratch project quota. Only prunes after a SUCCESSFUL
+# score (scored.stats.csv present) so a failed run keeps its inputs for resume.
+if [[ "$PRUNE" == "1" && -f "$OUTDIR/scored.stats.csv" ]]; then
+    echo "[prune] PRUNE=1 — removing FASTQ + BAM intermediates (keeping scores, VCFs, logs)..."
+    rm -f "$OUTDIR"/*.fastq.gz \
+          "$OUTDIR"/normal.bam "$OUTDIR"/normal.bam.bai \
+          "$OUTDIR"/tumor.bam  "$OUTDIR"/tumor.bam.bai
+fi

--- a/scripts/delta/run_cancer_sweeps.sh
+++ b/scripts/delta/run_cancer_sweeps.sh
@@ -52,11 +52,11 @@ submit_point() {
     for rr in $(seq 1 "$REPS"); do
         if [[ "$REPS" -gt 1 ]]; then
             o="${OUTBASE}_rep${rr}"; lbl="${POINT}_rep${rr}"
-            jid=$(env "${PIPE_ENV[@]}" OUTDIR="$o" RNG_SEED_ROOT="cancer $AXIS $POINT rep$rr" \
+            jid=$(env "${PIPE_ENV[@]}" OUTDIR="$o" PRUNE="${PRUNE:-0}" RNG_SEED_ROOT="cancer $AXIS $POINT rep$rr" \
                   sbatch --parsable "$PIPELINE")
         else
             o="$OUTBASE"; lbl="$POINT"
-            jid=$(env "${PIPE_ENV[@]}" OUTDIR="$o" sbatch --parsable "$PIPELINE")
+            jid=$(env "${PIPE_ENV[@]}" OUTDIR="$o" PRUNE="${PRUNE:-0}" sbatch --parsable "$PIPELINE")
         fi
         echo "$AXIS $lbl $jid $o $extra" | tee -a "$MANIFEST"
     done


### PR DESCRIPTION
## Why

The replicated purity/coverage sweeps failed mid-run with **`Disk quota exceeded` (os error 122)** — the shared `bhrd` **project** scratch quota (not the user quota) filled because 24 concurrent high-coverage jobs each kept full FASTQ + BAM. Only the small 30× jobs finished.

## Change

- **`cancer_pipeline.sbatch`** — `PRUNE=1` deletes the bulky FASTQ + BAM intermediates **after a successful score** (guarded on `scored.stats.csv` so a failed run keeps inputs for resume), retaining the small artifacts (scores, VCFs, logs). Off by default — current behavior unchanged.
- **`run_cancer_sweeps.sh`** — forwards `PRUNE` to every submitted job, so a replicated sweep (`REPS=3`) keeps a bounded footprint.

## Use

```bash
PRUNE=1 REPS=3 AXIS=coverage bash scripts/delta/run_cancer_sweeps.sh
PRUNE=1 REPS=3 AXIS=purity NORMAL_FIX=15 bash scripts/delta/run_cancer_sweeps.sh
```

`bash -n` clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)