### PR TITLE
feat(delta): one-command regression run (MODE=run) + NA-safe gate

### DIFF
--- a/docs/regression_protocol.md
+++ b/docs/regression_protocol.md
@@ -112,14 +112,28 @@ simulation logic:
 - **`scripts/delta/regression_gate.sh baseline candidate [max_tier]`** — applies the
   gates, prints a PASS/FAIL table, and exits non-zero on any FAIL (CI-friendly).
 
-Usage on a feature branch (from repo root):
+**One command (fire-and-forget)** on a feature branch, from repo root:
 
 ```bash
-MODE=submit TIER=1 LABEL=cand bash scripts/delta/regression_suite.sh   # submit; prints manifest path
-# ...wait for jobs (squeue --me)...
-MODE=collect MANIFEST=<path> bash scripts/delta/regression_suite.sh > candidate_metrics.tsv
-bash scripts/delta/regression_gate.sh scripts/delta/baseline_metrics.tsv candidate_metrics.tsv 1
+MODE=run TIER=1 LABEL=adapters bash scripts/delta/regression_suite.sh
 ```
+
+This submits the tier's jobs **plus a dependency gate job** (`--dependency=afterany`)
+that auto-collects and writes a PASS/FAIL verdict to
+`$RESULTS_DIR/regression_<label>.verdict.txt` when they finish — no babysitting.
+A crashed harness surfaces as a `FAIL` (non-numeric), not a silent pass.
+
+Manual three-step (if you want to inspect between stages):
+
+```bash
+MODE=submit  TIER=1 LABEL=cand bash scripts/delta/regression_suite.sh
+MODE=collect MANIFEST=<path>   bash scripts/delta/regression_suite.sh > candidate.tsv
+bash scripts/delta/regression_gate.sh scripts/delta/baseline_metrics.tsv candidate.tsv 1
+```
+
+There is no automatic trigger (git hook / CI) — GitHub runners can't reach Delta,
+so a run is kicked off deliberately (the convention: `MODE=run TIER=1` on the
+feature branch before merging; `TIER=2` for SV/perf-touching changes).
 
 The gate logic and all collect parsers are unit-tested; the `sbatch` submit path
 runs on Delta. Capturing a fresh baseline is just the same collect step pointed at

--- a/scripts/delta/regression_gate.sh
+++ b/scripts/delta/regression_gate.sh
@@ -44,16 +44,19 @@ for m, v in B.items():
     if m not in C:
         rows.append((m, tier, "SKIP", "absent in candidate")); missing += 1; continue
     cv = C[m][0]
+    cvn = num(cv)
+    if gate != "exact" and cvn is None:
+        rows.append((m, tier, "FAIL", f"{cv} — non-numeric (job failed / no output?)")); fails += 1; continue
     if gate == "exact":
         ok = (cv == val); detail = f"{cv}  (baseline {val})"
     elif gate == "ge2sd":
-        thr = num(val) - 2*num(sd); ok = num(cv) >= thr
+        thr = num(val) - 2*num(sd); ok = cvn >= thr
         detail = f"{cv} ≥ {thr:.3f}   (baseline {val} ± {sd})"
     elif gate.startswith("band:"):
-        _, lo, hi = gate.split(":"); ok = num(lo) <= num(cv) <= num(hi)
+        _, lo, hi = gate.split(":"); ok = num(lo) <= cvn <= num(hi)
         detail = f"{cv} ∈ [{lo}, {hi}]"
     elif gate.startswith("lepct:"):
-        p = num(gate.split(":")[1]); thr = num(val)*(1+p/100); ok = num(cv) <= thr
+        p = num(gate.split(":")[1]); thr = num(val)*(1+p/100); ok = cvn <= thr
         detail = f"{cv} ≤ {thr:.2f}   (baseline {val} +{p:.0f}%)"
     else:
         ok = False; detail = f"unknown gate '{gate}'"

--- a/scripts/delta/regression_suite.sh
+++ b/scripts/delta/regression_suite.sh
@@ -1,75 +1,74 @@
 #!/usr/bin/env bash
-# Run a regression tier on the CURRENT build and collect metrics for regression_gate.sh.
+# Run a regression tier on the CURRENT build and gate it against the baseline.
 # Thin orchestrator over the existing harnesses — no new simulation logic.
 #
-#   MODE=submit  TIER=0|1   — submit the tier's jobs, write a manifest of (kind prefix jobid outdir)
-#   MODE=collect MANIFEST=… — after the jobs finish, extract metrics → stdout (the candidate TSV)
+#   MODE=run     TIER=0|1   — ONE COMMAND: submit the tier's jobs + a dependency
+#                            "gate" job that auto-collects and writes a PASS/FAIL
+#                            verdict when they finish. Fire-and-forget; no babysitting.
+#   MODE=submit  TIER=0|1   — submit only; write the manifest (manual collect later).
+#   MODE=collect MANIFEST=… — extract metrics from finished jobs → stdout (candidate TSV).
+#   MODE=gate    MANIFEST=… — collect + run regression_gate.sh; write the verdict file
+#                            (this is what the dependency job runs).
 #
-# Typical flow (on a feature branch, from repo root):
-#   MODE=submit TIER=1 LABEL=cand bash scripts/delta/regression_suite.sh      # submits, prints manifest path
-#   # ...wait for the jobs (squeue --me)...
-#   MODE=collect MANIFEST=<path> bash scripts/delta/regression_suite.sh > candidate_metrics.tsv
-#   bash scripts/delta/regression_gate.sh scripts/delta/baseline_metrics.tsv candidate_metrics.tsv "$TIER"
+# One-command usage on a feature branch (from repo root):
+#   MODE=run TIER=1 LABEL=adapters bash scripts/delta/regression_suite.sh
+#   # ... jobs run; when the gate job finishes, read the verdict file it prints ...
 #
 # Tier 2 (variety, SV per-type reps, sweeps) is heavier and seam-specific — drive it
-# with run_input_variety.sh / run_cancer_sweeps.sh (REPS=3) + their collect_* scripts,
-# then append rows to the candidate TSV (sv_<type>_recall, etc.). See docs/regression_protocol.md.
-set -euo pipefail
+# with run_input_variety.sh / run_cancer_sweeps.sh (REPS=3) + collect_* and append rows.
+# See docs/regression_protocol.md.
+set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH + RESULTS_DIR
 
-MODE="${MODE:-submit}"
+MODE="${MODE:-run}"
 TIER="${TIER:-1}"
 LABEL="${LABEL:-cand}"
 DATA="${DATA:-$SCRATCH/neat_data}"
-MANIFEST="${MANIFEST:-${RESULTS_DIR:-$HOME}/regression_${LABEL}.manifest}"
+ACCT="${ACCESS_ACCOUNT:-bhrd-delta-cpu}"
+RD="${RESULTS_DIR:-$HOME}"
+MANIFEST="${MANIFEST:-$RD/regression_${LABEL}.manifest}"
+CAND="$RD/regression_${LABEL}.candidate.tsv"
+VERDICT="$RD/regression_${LABEL}.verdict.txt"
+BASELINE="$REPO_ROOT/scripts/delta/baseline_metrics.tsv"
 D="$REPO_ROOT/scripts/delta"
 
-# ── submit ───────────────────────────────────────────────────────────────
-if [[ "$MODE" == "submit" ]]; then
+# ── submit the tier's harness jobs (writes manifest: kind prefix jobid outdir) ──
+do_submit() {
     mkdir -p "$(dirname "$MANIFEST")"
     echo "# kind prefix jobid outdir" > "$MANIFEST"
-    sub() { # kind prefix outdir sbatch-script env...
-        local kind="$1" prefix="$2" out="$3" script="$4"; shift 4
+    sub() { local kind="$1" prefix="$2" out="$3" script="$4"; shift 4
         local jid; jid=$(env "$@" OUTDIR="$out" sbatch --parsable "$D/$script")
-        echo "$kind $prefix $jid $out" | tee -a "$MANIFEST"
-    }
-    # Tier 0 — determinism + ecoli fidelity + perf (perf job covers all its genomes)
-    sub order   -     "$SCRATCH/reg_${LABEL}_order"      run_order_independence.sbatch REFERENCE="$DATA/yeast.fa"
-    sub germline ecoli "$SCRATCH/reg_${LABEL}_germ_ecoli" germline_e2e.sbatch          REFERENCE="$DATA/ecoli.fa" TOOLS=rneat
-    sub perf    -     "$SCRATCH/reg_${LABEL}_perf"       benchmark.sbatch
+        echo "$kind $prefix $jid $out" | tee -a "$MANIFEST"; }
+    sub order    -      "$SCRATCH/reg_${LABEL}_order"      run_order_independence.sbatch REFERENCE="$DATA/yeast.fa"
+    sub germline ecoli  "$SCRATCH/reg_${LABEL}_germ_ecoli" germline_e2e.sbatch           REFERENCE="$DATA/ecoli.fa" TOOLS=rneat
+    sub perf     -      "$SCRATCH/reg_${LABEL}_perf"       benchmark.sbatch
     if [[ "$TIER" -ge 1 ]]; then
         sub germline chr22 "$SCRATCH/reg_${LABEL}_germ_chr22" germline_e2e.sbatch   REFERENCE="$DATA/chr22.fa" TOOLS=rneat
         sub cancer  somatic "$SCRATCH/reg_${LABEL}_cancer"    cancer_pipeline.sbatch REFERENCE="$DATA/chr22.fa" TOTAL_COVERAGE=30 PURITY=0.6 PRUNE=1
     fi
-    echo
-    echo "Submitted TIER=$TIER. Manifest: $MANIFEST   (watch: squeue --me)"
-    echo "When done: MODE=collect MANIFEST=$MANIFEST bash $0 > candidate_metrics.tsv"
-    exit 0
-fi
+}
 
-# ── collect ──────────────────────────────────────────────────────────────
-[[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
-
-while read -r kind prefix jobid outdir; do
-    [[ "$kind" == \#* || -z "${kind:-}" ]] && continue
-    case "$kind" in
-      order)
-        # parse the RESULTS block from the job's .out (in the submit dir)
-        f=$(ls -t "$D/../../rneat-orderindep_${jobid}.out" rneat-orderindep_${jobid}.out 2>/dev/null | head -1 || true)
-        [[ -f "$f" ]] || f="rneat-orderindep_${jobid}.out"
-        get(){ grep -m1 "$1" "$f" 2>/dev/null | grep -oE 'PASS|FAIL' | head -1; }
-        # thread-invariance: PASS iff 1- and N-thread determinism hold and mt==1thread
-        ti=FAIL; grep -q 'multithread_vs_1thread:.*same' "$f" 2>/dev/null && \
-                 [[ "$(get determinism_1thread)" == PASS ]] && ti=PASS
-        printf '%s\t%s\n' determinism_thread_invariant "$ti"
-        printf '%s\t%s\n' shard_order_independent "$(get shard_order_independent)"
-        printf '%s\t%s\n' shard_disjoint          "$(get shard_disjoint)"
-        printf '%s\t%s\n' contig_order_independent "$(get contig_order_independent)"
-        ;;
-      germline)
-        python3 - "$outdir/rneat_scored.summary.csv" "$prefix" <<'PY'
+# ── extract metrics from finished jobs → stdout (candidate TSV) ──
+do_collect() {
+    [[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; return 1; }
+    while read -r kind prefix jobid outdir; do
+        [[ "$kind" == \#* || -z "${kind:-}" ]] && continue
+        case "$kind" in
+          order)
+            local f="$REPO_ROOT/rneat-orderindep_${jobid}.out"
+            [[ -f "$f" ]] || f="rneat-orderindep_${jobid}.out"
+            get(){ grep -m1 "$1" "$f" 2>/dev/null | grep -oE 'PASS|FAIL' | head -1; }
+            local ti=FAIL
+            if grep -q 'multithread_vs_1thread:.*same' "$f" 2>/dev/null && [[ "$(get determinism_1thread)" == PASS ]]; then ti=PASS; fi
+            printf '%s\t%s\n' determinism_thread_invariant "$ti"
+            printf '%s\t%s\n' shard_order_independent "$(get shard_order_independent)"
+            printf '%s\t%s\n' shard_disjoint          "$(get shard_disjoint)"
+            printf '%s\t%s\n' contig_order_independent "$(get contig_order_independent)"
+            ;;
+          germline)
+            python3 - "$outdir/rneat_scored.summary.csv" "$prefix" <<'PY'
 import csv, sys
 f, pre = sys.argv[1], sys.argv[2]
 try: rows = {r["Type"]: r for r in csv.DictReader(open(f)) if r.get("Filter") == "PASS"}
@@ -84,16 +83,15 @@ print(f"{pre}_indel_precision\t{g('INDEL','METRIC.Precision')}")
 try: print(f"{pre}_tstv\t{float(rows['SNP']['QUERY.TOTAL.TiTv_ratio']):.3f}")
 except Exception: print(f"{pre}_tstv\tNA")
 PY
-        ;;
-      perf)
-        # median.tsv: genome size_mb threads tool wall_s peak_rss_mb  (rneat, 1 thread)
-        m="$outdir/median.tsv"
-        for g in ecoli chr22; do
-          awk -F'\t' -v g="$g" '$1==g && $4=="rneat" && $3==1 {print g"_wall_s\t"$5"\n"g"_rss_mb\t"$6}' "$m" 2>/dev/null
-        done
-        ;;
-      cancer)
-        python3 - "$outdir/scored.stats.csv" <<'PY'
+            ;;
+          perf)
+            local m="$outdir/median.tsv"
+            for gg in ecoli chr22; do
+              awk -F'\t' -v g="$gg" '$1==g && $4=="rneat" && $3==1 {print g"_wall_s\t"$5"\n"g"_rss_mb\t"$6}' "$m" 2>/dev/null
+            done
+            ;;
+          cancer)
+            python3 - "$outdir/scored.stats.csv" <<'PY'
 import csv, sys
 f = sys.argv[1]
 try: rows = {(r.get("type") or "").strip().lower(): r for r in csv.DictReader(open(f))}
@@ -110,6 +108,42 @@ def g(types, k):
 print(f"somatic_snv_recall\t{g(('snvs','snp','snps'),'recall')}")
 print(f"somatic_indel_recall\t{g(('indels','indel'),'recall')}")
 PY
-        ;;
-    esac
-done < "$MANIFEST"
+            ;;
+        esac
+    done < "$MANIFEST"
+}
+
+case "$MODE" in
+  submit)
+    do_submit
+    echo; echo "Submitted TIER=$TIER. Manifest: $MANIFEST"
+    echo "When done: MODE=collect MANIFEST=$MANIFEST bash $0 > candidate.tsv ; then regression_gate.sh"
+    ;;
+  collect)
+    do_collect
+    ;;
+  gate)
+    do_collect > "$CAND"
+    echo "candidate metrics → $CAND"
+    set +e
+    bash "$D/regression_gate.sh" "$BASELINE" "$CAND" "$TIER" | tee "$VERDICT"
+    rc=${PIPESTATUS[0]}
+    set -e 2>/dev/null || true
+    echo "verdict ($([ "$rc" -eq 0 ] && echo PASS || echo FAIL)) → $VERDICT"
+    exit "$rc"
+    ;;
+  run)
+    do_submit
+    deps=$(awk 'NR>1 && $3 ~ /^[0-9]+$/ {print $3}' "$MANIFEST" | paste -sd:)
+    [[ -n "$deps" ]] || { echo "no jobs submitted — aborting gate" >&2; exit 1; }
+    gjid=$(sbatch --parsable --job-name="reg-gate-${LABEL}" --account="$ACCT" --partition=cpu \
+        --time=00:20:00 --mem=4G --output="$RD/reg-gate_${LABEL}_%j.out" \
+        --dependency=afterany:"$deps" \
+        --wrap="cd '$REPO_ROOT' && MODE=gate TIER=$TIER LABEL='$LABEL' MANIFEST='$MANIFEST' bash scripts/delta/regression_suite.sh")
+    echo
+    echo "TIER=$TIER submitted; gate job $gjid runs after them (afterany)."
+    echo "Verdict will be written to: $VERDICT   (gate log: $RD/reg-gate_${LABEL}_${gjid}.out)"
+    echo "Watch: squeue --me"
+    ;;
+  *) echo "unknown MODE=$MODE (run|submit|collect|gate)" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
Follow-up to #330 (which merged at the suite commit, before this one).

- **`MODE=run TIER=n`** — one fire-and-forget command: submits the tier's jobs + a SLURM dependency gate job (`--dependency=afterany`) that auto-collects and writes a PASS/FAIL verdict file when they finish. No manual collect/gate step.
- **`MODE=gate`** — the dependency job (collect + gate + verdict), alongside the existing `submit`/`collect`.
- **gate hardened** — a non-numeric candidate (crashed harness / missing output) is now a `FAIL`, not a Python error.
- doc leads with the one-command flow + notes there's no CI auto-trigger (Delta isn't reachable from runners).

`bash -n` clean; gate re-tested incl. the NA path (FAILs gracefully, exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)