### PR TITLE
chore(conda-recipe): bump in-repo recipe to v1.18.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.17.4" %}
+{% set version = "1.18.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 2dd8958533944d0cb21f2c73bdd521f10f18932eeeea2c771f30bb07127de99c
+  sha256: b2258f5cb38ad99cf8eca8dc571f18751ee42006520dc4a01e8fa2cf1ee9f01e
 
 build:
   number: 0


### PR DESCRIPTION
Sync the in-repo `conda-recipe/meta.yaml` with the v1.18.0 release:
- `version` 1.17.4 → 1.18.0
- `sha256` → `b2258f5c…` (sha256 of the v1.18.0 source tarball)

Dependency set is identical to v1.17.4 (verified via `Cargo.lock` diff), so the bundled `THIRDPARTY.yml` license list is unchanged. Bioconda itself will be bumped by the autobump bot off the v1.18.0 GitHub release (manual PR to `bioconda-recipes` only needed if the bot doesn't fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)