### PR TITLE
chore: sync main with in-repo conda-recipe v1.18.0 bump

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.17.4" %}
+{% set version = "1.18.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 2dd8958533944d0cb21f2c73bdd521f10f18932eeeea2c771f30bb07127de99c
+  sha256: b2258f5cb38ad99cf8eca8dc571f18751ee42006520dc4a01e8fa2cf1ee9f01e
 
 build:
   number: 0


### PR DESCRIPTION
Brings the in-repo `conda-recipe/meta.yaml` v1.18.0 bump (#334) to main so main's recipe copy matches the released tag. No code change; restores develop == main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)