### PR TITLE
release: v1.19.0 — 3' adapter readthrough (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+Unreleased
+==========
+## Unreleased (targeting rneat v1.19.0)
+
+_Version bump + date land with the develop→main release PR; captured here so the work
+isn't lost between merge and release._
+
+### Read generation
+- Optional 3′ adapter readthrough (#125): `adapters: {enabled, preset: truseq|nextera|custom, r1, r2}`.
+  **Default off** — output byte-identical when the block is omitted. When enabled, a fragment
+  whose insert is shorter than `read_len` is kept and the read is padded to `read_len` at its
+  3′ end with adapter sequence (R1→`r1`, R2→`r2`, appended after R2 is reverse-complemented),
+  carrying model quality/error, soft-clipped (`S`) in the golden BAM, introducing no variants.
+  Incompatible with `long_reads`. Amount of readthrough scales with the insert distribution
+  relative to `read_len`.
+- `keep_short_fragments`: keep short inserts as insert-length **genomic** reads *without*
+  adapter padding — the adapter-free short-insert mode.
+
+### Fixed
+- Adapter path emitted a malformed FASTQ record — quality string one character longer than
+  the sequence — for degenerate zero-length inserts (`start == end`). Invisible to `zcat`/`wc`
+  but bwa-mem2's parser halts at the first such record, silently truncating alignment to a few
+  thousand reads. Zero-length inserts are now skipped (both mates, streams stay in sync); no
+  effect when adapters are off.
+
+### Validation / tooling
+- 4-arm adapter validation harness (off / short_ctrl / on_raw / on_trim) with a contrast-based,
+  data-driven collector that isolates the adapter effect from the short-insert coverage effect
+  (`scripts/delta/`). Result: adapter readthrough is detectable and **fully callable** — GATK
+  SNP/indel fidelity is unchanged (within replication noise) whether adapters are fastp-trimmed
+  or left for BWA-MEM2 to soft-clip; the only fidelity difference vs a long-insert baseline is
+  the reduced effective coverage of short inserts, present with adapters entirely absent.
+- `germline_e2e.sbatch`: node-local staging (`LOCAL_STAGE`, immune to shared-Lustre OST drops)
+  and a fastp thread cap (avoids a livelock at high `--cpus-per-task`).
+
+### Docs
+- README: new "3′ Adapter Readthrough" section (config, presets, use cases, validated behavior).
+
+
 6/29/2026
 =========
 ## rneat v1.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-Unreleased
-==========
-## Unreleased (targeting rneat v1.19.0)
+7/2/2026
+========
+## rneat v1.19.0
 
-_Version bump + date land with the develop→main release PR; captured here so the work
-isn't lost between merge and release._
+Optional Illumina 3′ adapter readthrough (#125) — realistic short-insert data that
+exercises adapter-trim QC — plus the correctness fix and Delta validation surfaced
+while building it. Default off; output byte-identical to v1.18.0 when the `adapters`
+block is omitted.
 
 ### Read generation
 - Optional 3′ adapter readthrough (#125): `adapters: {enabled, preset: truseq|nextera|custom, r1, r2}`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "bincode",
  "bstr",
@@ -1095,7 +1095,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.18.0'
+version = '1.19.0'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/README.md
+++ b/README.md
@@ -343,6 +343,64 @@ seqkit shuffle -2 sample_R1.fastq.gz sample_R2.fastq.gz \
 
 `seqkit` uses reservoir sampling and streams from disk, keeping memory use bounded regardless of file size (`seqkit` is an open source toolkit for FASTQ files: https://github.com/shenwei356/seqkit).
 
+3′ Adapter Readthrough
+======================
+Real Illumina libraries whose insert is shorter than the read length "read through" the
+fragment into the 3′ sequencing adapter — the read's tail is adapter sequence, not genome.
+`rneat` can simulate this so short-insert data looks realistic and exercises downstream
+adapter-trimming QC. **Disabled by default** — output is byte-identical to prior versions
+when the `adapters` block is omitted.
+
+```yaml
+adapters:
+  enabled: true
+  preset: truseq        # truseq | nextera | custom
+  # for preset: custom, give explicit 5′→3′ uppercase-ACGT sequences:
+  # r1: AGATCGGAAGAGC...
+  # r2: AGATCGGAAGAGC...
+```
+
+When enabled, any fragment whose insert is shorter than `read_len` is kept (instead of
+being resampled away) and the read is padded to `read_len` at its 3′ end with adapter
+sequence — R1 gets `r1`, R2 gets `r2` (appended after R2 is reverse-complemented, matching
+real read orientation). Adapter bases carry the same quality/error models as genomic bases,
+are marked soft-clipped (`S`) in the golden BAM, and never introduce variants. **How much
+readthrough you get is controlled by how many inserts fall below `read_len`** — i.e. by
+`fragment_mean` / `fragment_st_dev` relative to `read_len`. With a long-insert setting
+(`fragment_mean` ≫ `read_len`) essentially no reads reach the adapter and enabling this
+changes nothing.
+
+Presets:
+- `truseq` — Illumina TruSeq (`AGATCGGAAGAGC…`), the most common.
+- `nextera` — Nextera / transposase (`CTGTCTCTTATACACATCT`).
+- `custom` — supply your own `r1` / `r2`.
+
+Not compatible with `long_reads: true` (adapter readthrough is a short-read phenomenon).
+
+**When to enable it:**
+- **Validating adapter-trimming pipelines** — generate reads with known adapter content to
+  confirm fastp / cutadapt / Trim Galore settings actually detect and remove it.
+- **Short-insert libraries** — small-RNA / cfDNA / degraded-DNA style data where inserts sit
+  near or below the read length and readthrough is expected; the simulated reads then match
+  what the sequencer really produces.
+- **Aligner soft-clip benchmarking** — untrimmed adapter tails should be soft-clipped by the
+  aligner; use this to check that behaviour end-to-end.
+- **Realistic FASTQ→VCF tests** — exercise the whole trim → align → call path on data that
+  carries adapters instead of idealized adapter-free reads.
+
+To keep short inserts as **genomic** reads *without* modeling adapters (e.g. to study the
+coverage behaviour of a short-insert library on its own), set `keep_short_fragments: true`
+instead of enabling `adapters` — short fragments are then emitted as insert-length reads
+with no adapter padding.
+
+**Validated behaviour** (paired germline benchmark: chr22, 30×, TruSeq, 3 reps/arm,
+BWA-MEM2 → GATK HaplotypeCaller vs the golden VCF): adapter readthrough is **detectable**
+(fastp adapter content and aligner soft-clip fraction rise only when it is enabled) and
+**fully callable** — SNP and indel recall/precision/F1 are unchanged within replication
+noise whether the adapters are fastp-trimmed or left for BWA-MEM2 to soft-clip. An
+adapter-free short-insert control showed the only fidelity difference versus a long-insert
+baseline is the reduced effective coverage of short inserts (mate overlap), not the adapters.
+
 Parallel Processing
 ===================
 `rneat gen-reads` processes contigs in parallel by default using rayon's work-stealing thread pool. Each contig is an independent unit of work — variant generation, fragment sampling, and FASTQ/BAM writing all happen concurrently across contigs — so references with many contigs scale well across cores.

--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -84,6 +84,11 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
     buffer2: &mut B2,
     read_length: usize,
     long_reads: bool,
+    // Keep short inserts (insert < read_length) and emit insert-length reads instead
+    // of dropping them. Implied when adapters are on (readthrough pads them); set on its
+    // own for the adapter-free short-insert control. Independent of adapter padding,
+    // which is driven solely by non-empty r1_adapter/r2_adapter below.
+    keep_short: bool,
     read_name_prefix: &str,
     quality_score_model: &QualityScoreModel,
     sequencing_error_model: &SequencingErrorModel,
@@ -133,7 +138,10 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
         if insert_len == 0 {
             continue;
         }
-        let effective_read_len = if adapters_on {
+        // Cap the read at the insert whenever short fragments are being kept — with
+        // adapters on (padded back to read_length below) OR in the adapter-free
+        // keep_short control (emitted as an insert-length genomic read).
+        let effective_read_len = if adapters_on || keep_short {
             insert_len.min(read_length)
         } else if long_reads {
             fragment.len().min(read_length)
@@ -906,6 +914,7 @@ mod tests {
             &mut buf2,
             10,
             false,
+            false, // keep_short
             "chr1",
             &quality_model,
             &seq_err_model,
@@ -1000,6 +1009,7 @@ mod tests {
             &mut buf2,
             70,
             false,
+            false, // keep_short
             "chr1",
             &quality_model,
             &seq_err_model,
@@ -1092,6 +1102,7 @@ mod tests {
             &mut buf2,
             read_length,
             false, // long_reads
+            true,  // keep_short (adapters on → short fragments kept)
             "chr1",
             &quality_model,
             &seq_err_model,
@@ -1131,6 +1142,79 @@ mod tests {
                 i += 4;
             }
         }
+    }
+
+    #[test]
+    fn test_write_block_fastq_keep_short_no_adapter_emits_genomic_insert_length_reads() {
+        // keep_short control (#125): short fragments kept, NO adapter (empty slices).
+        // A short insert must produce an insert-LENGTH genomic read (not padded to
+        // read_length, not dropped), and records stay well-formed (seq == qual).
+        use crate::structs::{
+            mutated_map::MutatedMap,
+            sequence_block::{RegionType, SequenceBlock, SequenceMap},
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let seq_len: usize = 300;
+        let sequence: Vec<Nucleotide> = (0..seq_len)
+            .map(|i| match i % 4 {
+                0 => A,
+                1 => C,
+                2 => G,
+                _ => T,
+            })
+            .collect();
+        let block = SequenceBlock {
+            contig: "chr1".to_string(),
+            ref_start: 0,
+            ref_end: seq_len,
+            sequence,
+            sequence_map: vec![SequenceMap::from(RegionType::NonNRegion, 0, seq_len)],
+        };
+        let mutated_map = MutatedMap::from_interval(0, seq_len, vec![]).unwrap();
+        let read_length = 70usize;
+        // one short insert (30 < read_length) + one full insert (== read_length).
+        let fragments = vec![(10, 40), (100, 170)];
+        let out_path = temp_dir.path().join("r1.fastq.gz");
+        let mut buf1 = GzEncoder::new(
+            create_output_file(&out_path, true).unwrap(),
+            Compression::default(),
+        );
+        use crate::file_tools::file_io::VectorBuffer;
+        let mut buf2 = GzEncoder::new(VectorBuffer::new(), Compression::default());
+        let seq_err_model = SequencingErrorModel::default().unwrap();
+        let quality_model = QualityScoreModel::default().unwrap();
+        let mut rng = NeatRng::new_from_seed(&vec!["keep-short".to_string()]).unwrap();
+        write_block_fastq(
+            fragments,
+            &mutated_map,
+            &block,
+            false, // single-ended (simplest) — R1 only
+            &mut buf1,
+            &mut buf2,
+            read_length,
+            false, // long_reads
+            true,  // keep_short
+            "chr1",
+            &quality_model,
+            &seq_err_model,
+            &mut rng,
+            None,
+            &mut AdCounter::new(),
+            &[], // NO adapter → genomic reads, no padding
+            &[],
+        )
+        .unwrap();
+        buf1.finish().unwrap();
+        let lines: Vec<String> = read_gzip_lines(&out_path).unwrap().map(|l| l.unwrap()).collect();
+        assert_eq!(lines.len(), 8, "expected 2 reads (both fragments kept), got {}", lines.len());
+        let read_lens: Vec<usize> = (0..lines.len()).step_by(4).map(|i| {
+            assert_eq!(lines[i + 1].len(), lines[i + 3].len(), "seq/qual mismatch");
+            lines[i + 1].len()
+        }).collect();
+        // Short insert (30) → 30 bp genomic read (NOT padded to 70); full insert → 70 bp.
+        let mut sorted = read_lens.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![30, 70], "expected insert-length reads [30, 70], got {:?}", read_lens);
     }
 
     // --- CIGAR-building tests for the refactored generate_read ---
@@ -1679,6 +1763,7 @@ mod tests {
             &mut buf2,
             read_len,
             false,
+            false, // keep_short
             "chr1",
             &quality_model,
             &seq_err_model,

--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -122,6 +122,17 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
         // 3' adapter pads it to read_length after orientation (see append_adapter_readthrough);
         // capping at the insert length keeps generate_read from truncating-and-dropping it.
         let insert_len = end - start;
+        // A zero-length insert (start == end) is a degenerate "adapter dimer": it
+        // carries no genomic bases, and with adapters on the padding path built a
+        // record whose quality string ran one char longer than the sequence
+        // (effective_read_len == 0 desyncs the seq/qual construction). That is a
+        // malformed FASTQ record — harmless to `zcat`/`wc`, but bwa-mem2's parser
+        // stops at the first one and silently truncates alignment to a few thousand
+        // reads (#125). Skip the whole pair so the R1/R2 streams stay in sync; this
+        // never fires when adapters are off (fragments are already >= read_length).
+        if insert_len == 0 {
+            continue;
+        }
         let effective_read_len = if adapters_on {
             insert_len.min(read_length)
         } else if long_reads {
@@ -1023,6 +1034,103 @@ mod tests {
             "expected 4 unique names, got duplicates in: {:?}",
             names
         );
+    }
+
+    #[test]
+    fn test_write_block_fastq_skips_zero_insert_no_malformed_record() {
+        // Regression (#125): a zero-length insert (start == end) is a degenerate
+        // adapter-dimer fragment. With adapters on it used to emit a record whose
+        // quality string ran one char longer than the sequence — malformed FASTQ
+        // that `zcat`/`wc` ignore but bwa-mem2's parser halts on, silently
+        // truncating alignment to a few thousand reads. It must be skipped, and
+        // every emitted record must have seq.len() == qual.len() == read_length.
+        use crate::structs::{
+            mutated_map::MutatedMap,
+            sequence_block::{RegionType, SequenceBlock, SequenceMap},
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let seq_len: usize = 300;
+        let sequence: Vec<Nucleotide> = (0..seq_len)
+            .map(|i| match i % 4 {
+                0 => A,
+                1 => C,
+                2 => G,
+                _ => T,
+            })
+            .collect();
+        let block = SequenceBlock {
+            contig: "chr1".to_string(),
+            ref_start: 0,
+            ref_end: seq_len,
+            sequence,
+            sequence_map: vec![SequenceMap::from(RegionType::NonNRegion, 0, seq_len)],
+        };
+        let mutated_map = MutatedMap::from_interval(0, seq_len, vec![]).unwrap();
+        let read_length = 70usize;
+        // zero-insert (must be skipped) + short insert (adapter-padded) + full insert.
+        let fragments = vec![(50, 50), (10, 40), (100, 170)];
+        let r1_path = temp_dir.path().join("r1.fastq.gz");
+        let r2_path = temp_dir.path().join("r2.fastq.gz");
+        let mut buf1 = GzEncoder::new(
+            create_output_file(&r1_path, true).unwrap(),
+            Compression::default(),
+        );
+        let mut buf2 = GzEncoder::new(
+            create_output_file(&r2_path, true).unwrap(),
+            Compression::default(),
+        );
+        let seq_err_model = SequencingErrorModel::default().unwrap();
+        let quality_model = QualityScoreModel::default().unwrap();
+        let mut rng = NeatRng::new_from_seed(&vec!["zero-insert".to_string()]).unwrap();
+        let adapter: Vec<Nucleotide> = vec![A, G, A, T, C, G, G, A, A, G, A, G, C];
+        write_block_fastq(
+            fragments,
+            &mutated_map,
+            &block,
+            true, // paired_ended
+            &mut buf1,
+            &mut buf2,
+            read_length,
+            false, // long_reads
+            "chr1",
+            &quality_model,
+            &seq_err_model,
+            &mut rng,
+            None,
+            &mut AdCounter::new(),
+            &adapter,
+            &adapter,
+        )
+        .unwrap();
+        buf1.finish().unwrap();
+        buf2.finish().unwrap();
+
+        for path in [&r1_path, &r2_path] {
+            let lines: Vec<String> = read_gzip_lines(path).unwrap().map(|l| l.unwrap()).collect();
+            // Two fragments produce reads; the zero-insert pair is skipped (4 lines each).
+            assert_eq!(
+                lines.len(),
+                8,
+                "expected 2 records (zero-insert skipped) in {:?}, got {} lines",
+                path,
+                lines.len()
+            );
+            let mut i = 0;
+            while i < lines.len() {
+                let seq = &lines[i + 1];
+                let qual = &lines[i + 3];
+                assert_eq!(
+                    seq.len(),
+                    qual.len(),
+                    "malformed FASTQ in {:?}: seq={} qual={}",
+                    path,
+                    seq.len(),
+                    qual.len()
+                );
+                assert_eq!(seq.len(), read_length, "read not padded to read_length in {:?}", path);
+                i += 4;
+            }
+        }
     }
 
     // --- CIGAR-building tests for the refactored generate_read ---

--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -90,8 +90,14 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
     rng: &mut NeatRng,
     mut bam_writer: Option<&mut dyn BamRecordStager>,
     ad_counter: &mut AdCounter,
+    // 3' adapter readthrough (#125). Empty slices = disabled (no behavior change).
+    // When non-empty, reads whose insert < read_length are padded to read_length
+    // with adapter sequence: R1 gets r1_adapter, R2 gets r2_adapter.
+    r1_adapter: &[Nucleotide],
+    r2_adapter: &[Nucleotide],
 ) -> Result<(), FastqToolsError> {
     debug!("writing reads for {}", sequence_block.contig);
+    let adapters_on = !r1_adapter.is_empty() || !r2_adapter.is_empty();
     // Pad the fetched fragment with extra reference beyond `end` so deletions
     // (sequencing-error or literal-variant) near a read's tail have bases to
     // consume instead of exhausting the buffer and raising TruncatedRead.
@@ -112,7 +118,13 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
         let fragment = sequence_block.get_subseq_slice(start, padded_end)?;
         // In long-read mode a fragment may be shorter than read_length; truncate the read
         // to the actual fragment length rather than discarding it.
-        let effective_read_len = if long_reads {
+        // With adapters on, a short insert generates an insert-length read here, then the
+        // 3' adapter pads it to read_length after orientation (see append_adapter_readthrough);
+        // capping at the insert length keeps generate_read from truncating-and-dropping it.
+        let insert_len = end - start;
+        let effective_read_len = if adapters_on {
+            insert_len.min(read_length)
+        } else if long_reads {
             fragment.len().min(read_length)
         } else {
             read_length
@@ -181,7 +193,7 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
 
         let quality_scores_1 =
             quality_score_model.generate_quality_scores(effective_read_len, rng)?;
-        let r1_record = match generate_read(
+        let mut r1_record = match generate_read(
             fragment,
             &reads1_flagged,
             &read1_variants,
@@ -206,6 +218,17 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
             }
             Err(e) => return Err(e),
         };
+        // R1 adapter readthrough: pad a short-insert read to read_length at its 3' end.
+        if adapters_on {
+            r1_record = append_adapter_readthrough(
+                r1_record,
+                r1_adapter,
+                read_length,
+                quality_score_model,
+                sequencing_error_model,
+                rng,
+            )?;
+        }
 
         // Generate r2 BEFORE writing r1, so that a TruncatedRead on r2
         // skips BOTH reads together. Otherwise r1 lands in buffer1 with
@@ -253,7 +276,23 @@ pub fn write_block_fastq<B1: Write, B2: Write>(
                 true,
                 ad_counter,
             ) {
-                Ok(record) => Some(reverse_complement_record(record)),
+                Ok(record) => {
+                    // Flip to the reverse mate FIRST, then append the R2 adapter at
+                    // the (now 3') end — so R2 carries the R2 adapter in read
+                    // orientation, exactly as a trimmer expects.
+                    let mut rec = reverse_complement_record(record);
+                    if adapters_on {
+                        rec = append_adapter_readthrough(
+                            rec,
+                            r2_adapter,
+                            read_length,
+                            quality_score_model,
+                            sequencing_error_model,
+                            rng,
+                        )?;
+                    }
+                    Some(rec)
+                }
                 Err(FastqToolsError::TruncatedRead(msg)) => {
                     debug!("{}", msg);
                     // Drop r1 alongside r2 so the streams stay in sync.
@@ -545,6 +584,51 @@ fn reverse_complement_record(mut record: ReadRecord) -> ReadRecord {
     record
 }
 
+/// Append 3' sequencing-adapter readthrough to a FINAL-oriented read (#125).
+/// When the insert was shorter than `read_length`, the record holds only the
+/// insert bases; this pads it to `read_length` with adapter sequence sourced
+/// cyclically (real reads can read through into — and past — the adapter).
+/// Adapter bases:
+///   - carry the same per-base substitution error as insert bases, so trimmers
+///     see realistic (not pristine) adapters; insertion/deletion errors are
+///     intentionally NOT applied here, to keep the read exactly `read_length`,
+///   - take quality scores from the same quality model,
+///   - are soft-clipped (`'S'`) in the golden BAM — they are not reference-aligned,
+///   - carry no variants (adapter is not reference-derived).
+/// Pass the R1 adapter for R1, and the R2 adapter for the post-flip R2 read.
+/// (The end-to-end fastp/cutadapt trim check is an integration step — see #125.)
+fn append_adapter_readthrough(
+    mut record: ReadRecord,
+    adapter: &[Nucleotide],
+    read_length: usize,
+    quality_score_model: &QualityScoreModel,
+    sequencing_error_model: &SequencingErrorModel,
+    rng: &mut NeatRng,
+) -> Result<ReadRecord, FastqToolsError> {
+    let current = record.sequence.len();
+    if adapter.is_empty() || current >= read_length {
+        return Ok(record);
+    }
+    let n_adapter = read_length - current;
+    let quals = quality_score_model.generate_quality_scores(n_adapter, rng)?;
+    for (i, &score) in quals.iter().enumerate() {
+        let mut base = adapter[i % adapter.len()];
+        let prob = sequencing_error_model.convert_score(score)?;
+        if rng.random()? < prob {
+            // Substitution noise only — preserves exact read_length.
+            if let SequencingErrorType::SnpError(b) =
+                sequencing_error_model.generate_sequencing_error(base, rng)?
+            {
+                base = b;
+            }
+        }
+        record.sequence.push(base.into());
+        record.quality_scores.push(score);
+        record.cigar_ops.push('S');
+    }
+    Ok(record)
+}
+
 pub fn write_read_to_fastq<W: Write>(
     record: &ReadRecord,
     buffer: &mut W,
@@ -688,6 +772,80 @@ mod tests {
         assert_eq!(reverse_complement(read), revcomp);
     }
 
+    // --- adapter readthrough (#125) ---
+    fn adapter_rec(seq: &str, paired: bool, reverse: bool) -> ReadRecord {
+        ReadRecord {
+            name: "frag/1".to_string(),
+            sequence: seq.to_string(),
+            quality_scores: vec![30; seq.len()],
+            cigar_ops: vec!['M'; seq.len()],
+            is_paired: paired,
+            is_reverse: reverse,
+            contig: "chr1".to_string(),
+            position: 0,
+            mate_contig: "chr1".to_string(),
+            mate_position: 0,
+            template_length: 0,
+        }
+    }
+
+    #[test]
+    fn test_append_adapter_pads_to_read_length_and_softclips() {
+        // Short insert (8) + adapter -> exactly read_length (20), adapter region soft-clipped.
+        let (read_length, insert_len) = (20usize, 8usize);
+        let adapter: Vec<Nucleotide> = "GATCGATCGATCGATC".chars().map(Nucleotide::from).collect();
+        let qm = QualityScoreModel::default().unwrap();
+        let em = SequencingErrorModel::default().unwrap();
+        let mut rng = NeatRng::new_from_seed(&vec!["adapter".to_string()]).unwrap();
+        let out = append_adapter_readthrough(
+            adapter_rec(&"A".repeat(insert_len), true, false),
+            &adapter, read_length, &qm, &em, &mut rng,
+        ).unwrap();
+        assert_eq!(out.sequence.len(), read_length, "padded to read_length");
+        assert_eq!(out.quality_scores.len(), read_length);
+        assert_eq!(out.cigar_ops.len(), read_length);
+        assert!(out.cigar_ops[..insert_len].iter().all(|&c| c == 'M'), "insert stays M");
+        assert_eq!(
+            out.cigar_ops[insert_len..].iter().filter(|&&c| c == 'S').count(),
+            read_length - insert_len,
+            "adapter region is soft-clipped",
+        );
+    }
+
+    #[test]
+    fn test_append_adapter_noop_when_insert_ge_read_length() {
+        let read_length = 10usize;
+        let adapter: Vec<Nucleotide> = "GGGG".chars().map(Nucleotide::from).collect();
+        let qm = QualityScoreModel::default().unwrap();
+        let em = SequencingErrorModel::default().unwrap();
+        let mut rng = NeatRng::new_from_seed(&vec!["x".to_string()]).unwrap();
+        let rec = adapter_rec("ACGTACGTAC", false, false); // already read_length
+        let before = rec.sequence.clone();
+        let out = append_adapter_readthrough(rec, &adapter, read_length, &qm, &em, &mut rng).unwrap();
+        assert_eq!(out.sequence, before, "no adapter when insert >= read_length");
+    }
+
+    #[test]
+    fn test_r2_adapter_appended_forward_after_flip() {
+        // The caller flips R2 (reverse_complement_record) THEN appends the R2 adapter,
+        // so the adapter must sit at the final read's 3' end in FORWARD orientation —
+        // an A/C-rich adapter leaves the tail A/C-rich, NOT the G/T-rich revcomp.
+        let read_length = 30usize;
+        let flipped = reverse_complement_record(adapter_rec("ACGTAC", true, false));
+        assert!(flipped.is_reverse);
+        let r2_adapter: Vec<Nucleotide> =
+            "AAAACCCCAAAACCCCAAAACCCC".chars().map(Nucleotide::from).collect();
+        let qm = QualityScoreModel::default().unwrap();
+        let em = SequencingErrorModel::default().unwrap();
+        let mut rng = NeatRng::new_from_seed(&vec!["r2".to_string()]).unwrap();
+        let out = append_adapter_readthrough(flipped, &r2_adapter, read_length, &qm, &em, &mut rng).unwrap();
+        assert_eq!(out.sequence.len(), read_length);
+        let tail = &out.sequence[6..];
+        let ac = tail.chars().filter(|c| matches!(c, 'A' | 'C')).count();
+        let gt = tail.chars().filter(|c| matches!(c, 'G' | 'T')).count();
+        assert!(ac > gt, "R2 adapter must be forward (A/C-rich), not revcomp'd; tail={tail}");
+    }
+
     #[test]
     fn test_write_block_fastq_ref_start_in_read_name() {
         // Verifies that when a SequenceBlock has ref_start > 0, the read names in the
@@ -743,6 +901,8 @@ mod tests {
             &mut rng,
             None,
             &mut AdCounter::new(),
+            &[],
+            &[],
         )
         .unwrap();
         buf1.finish().unwrap();
@@ -835,6 +995,8 @@ mod tests {
             &mut rng,
             None,
             &mut AdCounter::new(),
+            &[],
+            &[],
         )
         .unwrap();
         buf1.finish().unwrap();
@@ -1415,6 +1577,8 @@ mod tests {
             &mut rng,
             stager,
             &mut AdCounter::new(),
+            &[],
+            &[],
         )
         .unwrap();
     }

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -17,8 +17,11 @@ performance and fidelity, and (3) validate the cancer workflow end-to-end throug
 a real somatic-variant-calling pipeline.
 
 A central outcome is methodological: **benchmarking rneat against NEAT 4 and
-against GATK/Mutect2 surfaced — and we fixed — five real simulator defects** that
-unit tests had not caught. The verification process is itself a result.
+against GATK/Mutect2 surfaced — and we fixed — six real simulator defects** that
+unit tests had not caught. The verification process is itself a result — most
+strikingly for the sixth defect (§3.11), a malformed-FASTQ bug that was invisible
+to local read-count checks and only surfaced when a real aligner ran the data at
+scale on Delta.
 
 ---
 
@@ -113,7 +116,7 @@ purity/coverage point — both expanded in Phase 2.
 
 ### 3.5 Defects found and fixed through verification
 
-Benchmarking surfaced five real bugs invisible to unit tests; each was diagnosed,
+Benchmarking surfaced six real bugs invisible to unit tests; each was diagnosed,
 fixed, and re-verified end-to-end:
 
 | # | Defect | Effect when fixed |
@@ -123,9 +126,14 @@ fixed, and re-verified end-to-end:
 | #287 | Indels garbled on reverse-strand reads | indel precision 0.07 → 0.49 (read-level) |
 | #289 | Coverage regression introduced by #287 (R2 deletion truncation) | restored −14.5% lost read pairs |
 | #290 | som.py indel normalization off by default (scoring) | cancer indel recall 0.60 → 0.90 |
+| #125 | Adapter path wrote a malformed FASTQ record (quality one char longer than the sequence) for zero-length inserts; bwa-mem2 halts at the first such record | short-insert adapter alignment 2,986 → 3.89M reads (silent truncation eliminated); SNP recall 0.0004 → 0.944 |
 
-All affect every paired-end run, not just cancer. The somatic-SNV journey
-(0.33 → 0.94) and cancer-indel journey (0.20 → 0.90) trace the cumulative impact.
+All affect every paired-end run, not just cancer (the sixth affects any short-insert
+adapter run). The somatic-SNV journey (0.33 → 0.94) and cancer-indel journey
+(0.20 → 0.90) trace the cumulative impact. Defect #125 is detailed in §3.11: it is
+the clearest case of verification-as-result — local `zcat`/`wc` read counts were
+correct (line counts are unaffected by a too-long quality string), so the bug was
+only exposed by pushing the data through a real aligner at scale.
 
 ### 3.6 Multicore scaling and the whole-genome strategy
 
@@ -508,6 +516,71 @@ and the merge never depends on reproducing the monolithic stream. A backlog item
 output contig-order-independent (and let a sharded run optionally reproduce a
 monolithic one). Net: rneat is reproducible and parallelism-invariant where it
 matters, and its HPC sharding is verifiably correct.
+
+### 3.11 Adapter readthrough validation (chr22, 30×, TruSeq) — and a bug only Delta caught
+
+`rneat` added optional Illumina 3′ adapter readthrough (#125): when a fragment's
+insert is shorter than the read length, the read is padded at its 3′ end with adapter
+sequence, exactly as a real sequencer produces. We used Delta both to **confirm the new
+feature is callable** and — as it turned out — to **catch a correctness bug that no local
+check had surfaced**.
+
+**Design.** A four-arm matrix on the germline variant-calling pipeline
+(rneat → BWA-MEM2 → GATK HaplotypeCaller → hap.py), chr22 at 30×, TruSeq preset, three
+replicates per arm, paired by seed so the truth set is identical across arms. The arms are
+built to *isolate the adapter effect from the insert-size effect* — necessary because the
+no-adapter baseline rejects short fragments, so a naïve off-vs-on comparison confounds the
+two:
+
+| arm | inserts | adapter |
+|---|---|---|
+| `off` | long (short fragments rejected) | none — baseline |
+| `short_ctrl` | short (kept) | none — genomic reads |
+| `on_raw` | short | readthrough, aligned raw |
+| `on_trim` | short | readthrough, fastp-trimmed |
+
+**The bug Delta caught.** The first at-scale run collapsed: the adapter arms recovered
+almost no variants (SNP recall ≈ 0.0004) and their BAMs held ~2,986 reads instead of ~3.9M.
+This was *not* reproducible from read counts alone — `zcat | wc` reported the full read
+count locally, and rneat's own logs reported success. The cause was a malformed FASTQ record
+(quality string one character longer than the sequence) emitted for degenerate zero-length
+inserts; a too-long quality line leaves the 4-lines-per-record count intact but makes
+**bwa-mem2's parser stop at the first offending record**, silently truncating alignment.
+The defect was therefore invisible to every local sanity check and only manifested when the
+data passed through a real aligner at production scale — precisely the kind of failure the
+Delta verification pipeline exists to surface. Once diagnosed (bisected to zero-insert
+fragments, 5,513 malformed records in a 3.9M-read run), the fix was a one-line guard plus a
+regression test asserting `seq.len() == qual.len()` for every emitted record. It is
+catalogued as defect #125 in §3.5.
+
+**Result after the fix.** Adapter readthrough is realistic and fully callable. The realism
+signals move only when the feature is enabled, and the fidelity contrasts show the adapters
+themselves cost nothing:
+
+| realism signal | off | on_raw | on_trim |
+|---|---|---|---|
+| fastp adapter reads | 5,913 | 2,425,876 | 2,425,876 |
+| soft-clip fraction | 0.0004 | 0.0804 | 0.0006 (recovered by trim) |
+| mean insert size | 214.6 | 178.5 | 178.5 |
+| mean read length | 151 | 151 | 139 (adapter trimmed) |
+
+| fidelity contrast (Δ = A − B) | isolates | snp_recall | indel_recall |
+|---|---|---|---|
+| `on_trim` − `short_ctrl` | pure adapter effect (same inserts) | +0.0003 | +0.0018 |
+| `on_raw` − `on_trim` | adapter handling (soft-clip vs trim) | −0.0002 | −0.0009 |
+| `short_ctrl` − `off` | short-insert coverage effect (no adapters) | −0.0263 | −0.0334 |
+
+Adding adapter readthrough to short-insert reads costs no fidelity (within replication
+noise), whether the adapters are fastp-trimmed or left for BWA-MEM2 to soft-clip. The only
+fidelity difference versus the long-insert baseline is the reduced effective coverage of
+short-insert libraries (mate overlap) — present in `short_ctrl` with adapters entirely
+absent, so it is not attributable to readthrough.
+
+**Infrastructure note.** These runs also hardened the harness against Delta's shared
+filesystem: after a Lustre OST dropped mid-run and wedged jobs in uninterruptible I/O wait,
+the germline pipeline was moved to node-local NVMe staging (heavy FASTQ/BAM I/O on the
+compute node's local disk, only small artifacts copied back to Lustre), making it immune to
+transient OST outages; a fastp thread-count livelock at high core counts was also capped.
 
 ---
 

--- a/rneat/src/gen_reads/utils/config.rs
+++ b/rneat/src/gen_reads/utils/config.rs
@@ -12,6 +12,28 @@ use std::path::PathBuf;
 use std::string::String;
 use std::{env, fs};
 
+/// Optional 3' sequencing-adapter readthrough config (#125). When `enabled`,
+/// reads whose insert is shorter than `read_len` are padded at the 3' end with
+/// adapter sequence (R1 gets `r1`, R2 gets `r2`), matching real Illumina data so
+/// downstream adapter-trim QC stages are actually exercised. Default disabled.
+/// `r1`/`r2` are resolved 5'->3' uppercase-ACGT sequences (from a preset or custom).
+#[derive(Debug, Clone)]
+pub struct AdapterConfig {
+    pub enabled: bool,
+    pub r1: String,
+    pub r2: String,
+}
+
+impl Default for AdapterConfig {
+    fn default() -> Self {
+        AdapterConfig {
+            enabled: false,
+            r1: String::new(),
+            r2: String::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RunConfiguration {
     // This struct holds all the parameters for this particular run. It is derived from input either
@@ -95,6 +117,9 @@ pub struct RunConfiguration {
     // references; raise toward 1.0 for small contigs (bacteria/viruses) or
     // native aneuploidy. Only affects de novo SV sampling, not input_vcf SVs.
     pub sv_max_length_fraction: f64,
+    // Optional 3' sequencing-adapter readthrough (#125). Default disabled; when
+    // disabled, output is byte-identical to pre-adapter behavior.
+    pub adapters: AdapterConfig,
 }
 
 impl Default for RunConfiguration {
@@ -135,6 +160,7 @@ impl Default for RunConfiguration {
             long_reads: false,
             sv_rate_scale: 0.0,
             sv_max_length_fraction: 0.25,
+            adapters: AdapterConfig::default(),
         }
     }
 }
@@ -492,6 +518,51 @@ impl RunConfiguration {
                             )
                         })?;
                     }
+                    "adapters" => {
+                        // Nested map: { enabled, preset: truseq|nextera|custom, r1, r2 }.
+                        let enabled = value
+                            .get("enabled")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        config.adapters.enabled = enabled;
+                        if enabled {
+                            let preset = value
+                                .get("preset")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("truseq")
+                                .to_lowercase();
+                            match preset.as_str() {
+                                "truseq" => {
+                                    config.adapters.r1 =
+                                        "AGATCGGAAGAGCACACGTCTGAACTCCAGTCA".to_string();
+                                    config.adapters.r2 =
+                                        "AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT".to_string();
+                                }
+                                "nextera" => {
+                                    config.adapters.r1 = "CTGTCTCTTATACACATCT".to_string();
+                                    config.adapters.r2 = "CTGTCTCTTATACACATCT".to_string();
+                                }
+                                "custom" => {
+                                    config.adapters.r1 = value
+                                        .get("r1")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("")
+                                        .to_uppercase();
+                                    config.adapters.r2 = value
+                                        .get("r2")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("")
+                                        .to_uppercase();
+                                }
+                                other => {
+                                    error!(
+                                        "Unknown adapter preset '{other}'; expected truseq|nextera|custom"
+                                    );
+                                    return Err(GenerateReadsError::ConfigError);
+                                }
+                            }
+                        }
+                    }
                     _ => continue,
                 },
             }
@@ -514,6 +585,35 @@ impl RunConfiguration {
         info!("\t>paired ended: {}", config.paired_ended);
         if config.long_reads {
             info!("\t>long reads mode: enabled (short fragments produce truncated reads)");
+        }
+        if config.adapters.enabled {
+            if config.long_reads {
+                error!(
+                    "Invalid config: adapters.enabled=true is incompatible with long_reads=true. \
+                     Illumina-style 3' adapter readthrough does not occur on long-read platforms. \
+                     Set long_reads=false (short-read Illumina) or adapters.enabled=false."
+                );
+                return Err(GenerateReadsError::ConfigError);
+            }
+            let acgt = |s: &str| !s.is_empty() && s.chars().all(|c| matches!(c, 'A' | 'C' | 'G' | 'T'));
+            if config.adapters.r1.is_empty() || config.adapters.r2.is_empty() {
+                error!(
+                    "Invalid config: adapters.enabled=true but an adapter sequence is empty \
+                     (preset 'custom' requires non-empty r1 and r2)."
+                );
+                return Err(GenerateReadsError::ConfigError);
+            }
+            if !acgt(&config.adapters.r1) || !acgt(&config.adapters.r2) {
+                error!(
+                    "Invalid config: adapter sequences must contain only A/C/G/T (uppercase); got r1='{}', r2='{}'.",
+                    config.adapters.r1, config.adapters.r2
+                );
+                return Err(GenerateReadsError::ConfigError);
+            }
+            info!(
+                "\t>adapters: enabled (R1={}, R2={})",
+                config.adapters.r1, config.adapters.r2
+            );
         }
         if config.overwrite_output {
             warn!("\t>Overwriting any existing files.")
@@ -690,6 +790,7 @@ mod tests {
             long_reads: false,
             sv_rate_scale: 0.0,
             sv_max_length_fraction: 0.25,
+            adapters: AdapterConfig::default(),
         };
 
         println!("{:?}", test_configuration);
@@ -999,6 +1100,80 @@ mod tests {
         scrape_config.insert("rng_seed".to_string(), Value::Number(42.into()));
         let config = RunConfiguration::from_scrape_config(scrape_config).unwrap();
         assert_eq!(config.rng_seed.as_deref(), Some("42"));
+    }
+
+    fn write_cfg(dir: &std::path::Path, body: &str) -> PathBuf {
+        let yaml = dir.join("c.yml");
+        std::fs::write(
+            &yaml,
+            format!("reference: test_data/references/H1N1.fa\noutput_dir: ./\n{body}"),
+        )
+        .unwrap();
+        yaml
+    }
+
+    #[test]
+    fn test_adapters_default_disabled() {
+        // Default preserves pre-adapter behavior: disabled.
+        assert!(!RunConfiguration::default().adapters.enabled);
+    }
+
+    #[test]
+    fn test_adapters_truseq_preset() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = write_cfg(dir.path(), "adapters:\n  enabled: true\n  preset: truseq\n");
+        let cfg = RunConfiguration::from_yaml_file(&yaml).unwrap();
+        assert!(cfg.adapters.enabled);
+        assert_eq!(cfg.adapters.r1, "AGATCGGAAGAGCACACGTCTGAACTCCAGTCA");
+        assert_eq!(cfg.adapters.r2, "AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT");
+    }
+
+    #[test]
+    fn test_adapters_nextera_preset() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = write_cfg(dir.path(), "adapters:\n  enabled: true\n  preset: nextera\n");
+        let cfg = RunConfiguration::from_yaml_file(&yaml).unwrap();
+        assert_eq!(cfg.adapters.r1, "CTGTCTCTTATACACATCT");
+        assert_eq!(cfg.adapters.r2, "CTGTCTCTTATACACATCT");
+    }
+
+    #[test]
+    fn test_adapters_custom_uppercased() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = write_cfg(
+            dir.path(),
+            "adapters:\n  enabled: true\n  preset: custom\n  r1: acgtacgt\n  r2: tgcatgca\n",
+        );
+        let cfg = RunConfiguration::from_yaml_file(&yaml).unwrap();
+        assert_eq!(cfg.adapters.r1, "ACGTACGT");
+        assert_eq!(cfg.adapters.r2, "TGCATGCA");
+    }
+
+    #[test]
+    fn test_adapters_reject_long_reads_combo() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = write_cfg(
+            dir.path(),
+            "long_reads: true\nadapters:\n  enabled: true\n  preset: truseq\n",
+        );
+        assert!(RunConfiguration::from_yaml_file(&yaml).is_err());
+    }
+
+    #[test]
+    fn test_adapters_reject_custom_missing_seq() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = write_cfg(dir.path(), "adapters:\n  enabled: true\n  preset: custom\n");
+        assert!(RunConfiguration::from_yaml_file(&yaml).is_err());
+    }
+
+    #[test]
+    fn test_adapters_reject_non_acgt() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = write_cfg(
+            dir.path(),
+            "adapters:\n  enabled: true\n  preset: custom\n  r1: ACGTX\n  r2: ACGT\n",
+        );
+        assert!(RunConfiguration::from_yaml_file(&yaml).is_err());
     }
 
     #[test]

--- a/rneat/src/gen_reads/utils/config.rs
+++ b/rneat/src/gen_reads/utils/config.rs
@@ -106,6 +106,13 @@ pub struct RunConfiguration {
     // when true, fragments shorter than read_len are kept and produce truncated reads
     // (long-read platforms); when false, such fragments are discarded (short-read default)
     pub long_reads: bool,
+    // when true, short-read PE keeps fragments whose insert < read_len and emits
+    // insert-length GENOMIC reads (no adapter). This is the short-insert library WITHOUT
+    // modeling 3' adapter readthrough — the isolation control for adapter validation
+    // (#125). adapters.enabled implies this (readthrough needs short fragments kept);
+    // set it on its own to get the adapter-free short-insert arm. Default off →
+    // short fragments discarded, output byte-identical to before.
+    pub keep_short_fragments: bool,
     // Scale applied to the SvModel's per-base SV rate at generation time.
     // 0.0 (default) disables de novo SV generation entirely — only SVs
     // from `input_vcf` flow through. Values > 0 enable sampling from
@@ -158,6 +165,7 @@ impl Default for RunConfiguration {
             num_threads: None,
             chunk_size: None,
             long_reads: false,
+            keep_short_fragments: false,
             sv_rate_scale: 0.0,
             sv_max_length_fraction: 0.25,
             adapters: AdapterConfig::default(),
@@ -502,6 +510,14 @@ impl RunConfiguration {
                             )
                         })?;
                     }
+                    "keep_short_fragments" => {
+                        config.keep_short_fragments = value.as_bool().ok_or_else(|| {
+                            GenerateReadsError::ConfigReadError(
+                                "keep_short_fragments".to_string(),
+                                "boolean".to_string(),
+                            )
+                        })?;
+                    }
                     "sv_rate_scale" => {
                         config.sv_rate_scale = value.as_f64().ok_or_else(|| {
                             GenerateReadsError::ConfigReadError(
@@ -585,6 +601,18 @@ impl RunConfiguration {
         info!("\t>paired ended: {}", config.paired_ended);
         if config.long_reads {
             info!("\t>long reads mode: enabled (short fragments produce truncated reads)");
+        }
+        if config.keep_short_fragments {
+            if config.long_reads {
+                error!(
+                    "Invalid config: keep_short_fragments=true is redundant/incompatible with \
+                     long_reads=true (long-read mode already keeps short fragments). Set one."
+                );
+                return Err(GenerateReadsError::ConfigError);
+            }
+            info!(
+                "\t>keep short fragments: enabled (short inserts kept as genomic reads, no adapter)"
+            );
         }
         if config.adapters.enabled {
             if config.long_reads {
@@ -788,6 +816,7 @@ mod tests {
             num_threads: None,
             chunk_size: None,
             long_reads: false,
+            keep_short_fragments: false,
             sv_rate_scale: 0.0,
             sv_max_length_fraction: 0.25,
             adapters: AdapterConfig::default(),

--- a/rneat/src/gen_reads/utils/generate_fragments.rs
+++ b/rneat/src/gen_reads/utils/generate_fragments.rs
@@ -21,6 +21,9 @@ pub fn generate_fragments(
     coverage: usize,
     paired_ended: bool,
     long_reads: bool,
+    // when true, KEEP short fragments (insert < read_len) instead of discarding them,
+    // so adapter readthrough can pad them to read_len in write_block_fastq (#125).
+    adapters: bool,
     fragment_model: &FragmentLengthModel,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
@@ -70,7 +73,7 @@ pub fn generate_fragments(
             // In long-read mode accept all fragments; in short-read paired-end mode require
             // frag >= read_length + 10 so that R1 and R2 don't fully overlap (matching
             // NEAT Python's min_frag = read_len + 10 for paired-end).
-            if long_reads || frag >= read_length + 10 {
+            if long_reads || adapters || frag >= read_length + 10 {
                 fragment_pool.push(frag);
             }
             attempts += 1;
@@ -215,6 +218,8 @@ pub fn generate_weighted_fragments(
     normalize: bool,
     paired_ended: bool,
     long_reads: bool,
+    // keep short fragments for adapter readthrough (#125); see generate_fragments.
+    adapters: bool,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
     const MAX_COVERAGE_MULTIPLIER: usize = 100;
@@ -287,14 +292,14 @@ pub fn generate_weighted_fragments(
         let start = region_start + offset;
         let frag_len = fragment_model.generate_fragment(rng.random()?)?;
         attempts += 1;
-        if !long_reads && frag_len < read_length {
+        if !long_reads && !adapters && frag_len < read_length {
             continue;
         }
         let end = (start + frag_len).min(region_end);
         if end == start {
             continue;
         }
-        if !long_reads && end - start < read_length {
+        if !long_reads && !adapters && end - start < read_length {
             continue;
         }
         fragments.push((start, end));
@@ -505,6 +510,7 @@ mod tests {
             coverage,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -534,6 +540,7 @@ mod tests {
             coverage,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -555,6 +562,7 @@ mod tests {
             coverage,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &fragment_model,
             &mut rng2,
         )
@@ -583,6 +591,7 @@ mod tests {
             coverage,
             true,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -622,6 +631,7 @@ mod tests {
             coverage,
             true,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -657,6 +667,7 @@ mod tests {
             false,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -689,6 +700,7 @@ mod tests {
             false,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -718,6 +730,7 @@ mod tests {
             false,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -748,6 +761,7 @@ mod tests {
             false,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -787,6 +801,7 @@ mod tests {
             false,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng1,
         )
         .unwrap();
@@ -804,6 +819,7 @@ mod tests {
             false,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng2,
         )
         .unwrap();
@@ -835,6 +851,7 @@ mod tests {
             false,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -852,6 +869,7 @@ mod tests {
             true,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -891,6 +909,7 @@ mod tests {
             true,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -933,6 +952,7 @@ mod tests {
             false,
             false,
             false,
+            false, // adapters (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -1076,6 +1096,7 @@ mod tests {
             coverage,
             true,  // paired_ended
             false, // long_reads
+            false, // adapters (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -1132,6 +1153,7 @@ mod tests {
             true,  // normalize
             true,  // paired_ended
             false, // long_reads
+            false, // adapters
             &mut rng,
         )
         .unwrap();
@@ -1187,6 +1209,7 @@ mod tests {
             true,  // normalize=true should bring coverage back to 10
             true,  // paired_ended
             false, // long_reads
+            false, // adapters
             &mut rng,
         )
         .unwrap();

--- a/rneat/src/gen_reads/utils/generate_fragments.rs
+++ b/rneat/src/gen_reads/utils/generate_fragments.rs
@@ -21,9 +21,10 @@ pub fn generate_fragments(
     coverage: usize,
     paired_ended: bool,
     long_reads: bool,
-    // when true, KEEP short fragments (insert < read_len) instead of discarding them,
-    // so adapter readthrough can pad them to read_len in write_block_fastq (#125).
-    adapters: bool,
+    // when true, KEEP short fragments (insert < read_len) instead of discarding them:
+    // adapter readthrough pads them to read_len, or the adapter-free short-insert
+    // control emits them as insert-length genomic reads, in write_block_fastq (#125).
+    keep_short: bool,
     fragment_model: &FragmentLengthModel,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
@@ -73,7 +74,7 @@ pub fn generate_fragments(
             // In long-read mode accept all fragments; in short-read paired-end mode require
             // frag >= read_length + 10 so that R1 and R2 don't fully overlap (matching
             // NEAT Python's min_frag = read_len + 10 for paired-end).
-            if long_reads || adapters || frag >= read_length + 10 {
+            if long_reads || keep_short || frag >= read_length + 10 {
                 fragment_pool.push(frag);
             }
             attempts += 1;
@@ -218,8 +219,8 @@ pub fn generate_weighted_fragments(
     normalize: bool,
     paired_ended: bool,
     long_reads: bool,
-    // keep short fragments for adapter readthrough (#125); see generate_fragments.
-    adapters: bool,
+    // keep short fragments (readthrough or the adapter-free control); see generate_fragments.
+    keep_short: bool,
     rng: &mut NeatRng,
 ) -> Result<Vec<(usize, usize)>, GenerateReadsError> {
     const MAX_COVERAGE_MULTIPLIER: usize = 100;
@@ -292,14 +293,14 @@ pub fn generate_weighted_fragments(
         let start = region_start + offset;
         let frag_len = fragment_model.generate_fragment(rng.random()?)?;
         attempts += 1;
-        if !long_reads && !adapters && frag_len < read_length {
+        if !long_reads && !keep_short && frag_len < read_length {
             continue;
         }
         let end = (start + frag_len).min(region_end);
         if end == start {
             continue;
         }
-        if !long_reads && !adapters && end - start < read_length {
+        if !long_reads && !keep_short && end - start < read_length {
             continue;
         }
         fragments.push((start, end));
@@ -510,7 +511,7 @@ mod tests {
             coverage,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -540,7 +541,7 @@ mod tests {
             coverage,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -562,7 +563,7 @@ mod tests {
             coverage,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &fragment_model,
             &mut rng2,
         )
@@ -591,7 +592,7 @@ mod tests {
             coverage,
             true,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -631,7 +632,7 @@ mod tests {
             coverage,
             true,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -667,7 +668,7 @@ mod tests {
             false,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -700,7 +701,7 @@ mod tests {
             false,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -730,7 +731,7 @@ mod tests {
             false,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -761,7 +762,7 @@ mod tests {
             false,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -801,7 +802,7 @@ mod tests {
             false,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng1,
         )
         .unwrap();
@@ -819,7 +820,7 @@ mod tests {
             false,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng2,
         )
         .unwrap();
@@ -851,7 +852,7 @@ mod tests {
             false,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -869,7 +870,7 @@ mod tests {
             true,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -909,7 +910,7 @@ mod tests {
             true,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -952,7 +953,7 @@ mod tests {
             false,
             false,
             false,
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &mut rng,
         )
         .unwrap();
@@ -1096,7 +1097,7 @@ mod tests {
             coverage,
             true,  // paired_ended
             false, // long_reads
-            false, // adapters (off in these fragment-placement tests)
+            false, // keep_short (off in these fragment-placement tests)
             &fragment_model,
             &mut rng,
         )
@@ -1153,7 +1154,7 @@ mod tests {
             true,  // normalize
             true,  // paired_ended
             false, // long_reads
-            false, // adapters
+            false, // keep_short
             &mut rng,
         )
         .unwrap();
@@ -1209,7 +1210,7 @@ mod tests {
             true,  // normalize=true should bring coverage back to 10
             true,  // paired_ended
             false, // long_reads
-            false, // adapters
+            false, // keep_short
             &mut rng,
         )
         .unwrap();

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -714,6 +714,7 @@ fn process_chunk(
                         scaled,
                         ctx.config.paired_ended,
                         ctx.config.long_reads,
+                        ctx.config.adapters.enabled,
                         ctx.fragment_length_model,
                         &mut rng,
                     )?
@@ -730,6 +731,7 @@ fn process_chunk(
                         ctx.config.gc_bias_normalize_coverage,
                         ctx.config.paired_ended,
                         ctx.config.long_reads,
+                        ctx.config.adapters.enabled,
                         &mut rng,
                     )?
                 };

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -782,6 +782,18 @@ fn process_chunk(
 
     let read_name_prefix = format!("RNEAT_generated_{}", current_block.contig);
 
+    // Resolve 3' adapter sequences once (#125). Empty vecs = disabled, which makes
+    // write_block_fastq take its unchanged code path (output byte-identical when off).
+    let (r1_adapter, r2_adapter): (Vec<Nucleotide>, Vec<Nucleotide>) =
+        if ctx.config.adapters.enabled {
+            (
+                ctx.config.adapters.r1.chars().map(Nucleotide::from).collect(),
+                ctx.config.adapters.r2.chars().map(Nucleotide::from).collect(),
+            )
+        } else {
+            (Vec::new(), Vec::new())
+        };
+
     if ctx.config.produce_fastq {
         let mut file_to_write_1 = PathBuf::from(ctx.working_dir);
         file_to_write_1.push(format!(
@@ -819,6 +831,8 @@ fn process_chunk(
                 &mut rng,
                 bam_stager,
                 &mut ad_counter,
+                &r1_adapter,
+                &r2_adapter,
             )?;
             contig_files_r1.push(file_to_write_1);
             contig_files_r2.push(file_to_write_2);
@@ -841,6 +855,8 @@ fn process_chunk(
                 &mut rng,
                 bam_stager,
                 &mut ad_counter,
+                &r1_adapter,
+                &r2_adapter,
             )?;
             contig_files_r1.push(file_to_write_1);
         }
@@ -870,6 +886,8 @@ fn process_chunk(
             &mut rng,
             bam_stager,
             &mut ad_counter,
+            &r1_adapter,
+            &r2_adapter,
         )?;
     }
 

--- a/rneat/src/gen_reads/utils/runner.rs
+++ b/rneat/src/gen_reads/utils/runner.rs
@@ -685,6 +685,11 @@ fn process_chunk(
     })?;
     let max_del_len = *ctx.max_del_lens.get(&contig_name).unwrap_or(&0);
 
+    // Keep short inserts when adapters are on (readthrough pads them) OR when the
+    // adapter-free short-insert control is requested. Drives both fragment retention
+    // (below) and the insert-length read cap in write_block_fastq.
+    let keep_short = ctx.config.adapters.enabled || ctx.config.keep_short_fragments;
+
     let block_fragments: Vec<(usize, usize)> = {
         let mut block_frags = Vec::new();
         // SV coverage multipliers are needed here to scale fragment counts.
@@ -714,7 +719,7 @@ fn process_chunk(
                         scaled,
                         ctx.config.paired_ended,
                         ctx.config.long_reads,
-                        ctx.config.adapters.enabled,
+                        keep_short,
                         ctx.fragment_length_model,
                         &mut rng,
                     )?
@@ -731,7 +736,7 @@ fn process_chunk(
                         ctx.config.gc_bias_normalize_coverage,
                         ctx.config.paired_ended,
                         ctx.config.long_reads,
-                        ctx.config.adapters.enabled,
+                        keep_short,
                         &mut rng,
                     )?
                 };
@@ -827,6 +832,7 @@ fn process_chunk(
                 &mut buffer2,
                 ctx.config.read_len,
                 ctx.config.long_reads,
+                keep_short,
                 &read_name_prefix,
                 ctx.quality_score_model,
                 ctx.seq_error_model,
@@ -851,6 +857,7 @@ fn process_chunk(
                 &mut buffer2,
                 ctx.config.read_len,
                 ctx.config.long_reads,
+                keep_short,
                 &read_name_prefix,
                 ctx.quality_score_model,
                 ctx.seq_error_model,
@@ -882,6 +889,7 @@ fn process_chunk(
             &mut buf2,
             ctx.config.read_len,
             ctx.config.long_reads,
+            keep_short,
             &read_name_prefix,
             ctx.quality_score_model,
             ctx.seq_error_model,

--- a/scripts/delta/collect_adapter_validation.sh
+++ b/scripts/delta/collect_adapter_validation.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 # Aggregate the adapter-validation matrix (run_adapter_validation.sh) into a
-# documented PASS/NOTABLE report. For each condition (off / on_raw / on_trim) it
-# collects, across reps, the variant-caller fidelity (hap.py recall/precision/F1
-# for SNP+INDEL) and the realism signals (realism.tsv), reduces them to mean±sd,
-# then diffs on_* vs the off baseline and flags any difference that exceeds
-# replication noise (the regression-protocol convention: replication sd = tolerance).
+# documented PASS/NOTABLE report. For each condition it collects, across reps,
+# the variant-caller fidelity (hap.py recall/precision/F1 for SNP+INDEL) and the
+# realism signals (realism.tsv), reduces them to mean±sd, then reports a set of
+# CONTRASTS designed to isolate the adapter effect from the insert-size effect.
+#
+# Arms (run_adapter_validation.sh emits off/on_raw/on_trim always, short_ctrl when
+# CONTROL=1):
+#   off        adapters disabled, long inserts (short fragments rejected) — baseline
+#   short_ctrl short fragments KEPT, NO adapter (genomic reads) — isolates the
+#              short-insert coverage effect (needs rneat keep_short_fragments)
+#   on_raw     adapters on (readthrough), aligned raw (adapter tails soft-clipped)
+#   on_trim    adapters on (readthrough), fastp-trimmed (realistic Illumina)
+#
+# The callability verdict rests on ADAPTER-ONLY contrasts (on_trim vs short_ctrl,
+# on_raw vs on_trim) — same inserts, differ only in adapter handling — so it is NOT
+# confounded by the fact that `off` uses a different (longer) insert distribution.
 #
 # Usage:
 #   bash scripts/delta/collect_adapter_validation.sh $MANIFEST
 #   OUT=adapter_report.md bash scripts/delta/collect_adapter_validation.sh $MANIFEST
 #
-# Writes the markdown report to $OUT (default
-# $RESULTS_DIR/ADAPTER_VALIDATION.md) and echoes it to stdout.
+# Writes the markdown report to $OUT (default $RESULTS_DIR/ADAPTER_VALIDATION.md)
+# and echoes it to stdout.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -88,17 +99,21 @@ def parse_realism(path):
     return out
 
 # ── 4. gather: data[cond][metric] = [values across reps] ─────────────────────
-CONDS = ["off", "on_raw", "on_trim"]
+COND_ORDER = ["off", "short_ctrl", "on_raw", "on_trim"]
+COND_LABEL = {
+    "off":        "adapters disabled, long inserts (short fragments rejected) — baseline",
+    "short_ctrl": "short fragments KEPT, no adapter (genomic reads) — isolates the short-insert coverage effect",
+    "on_raw":     "adapters on (readthrough), aligned raw (adapter tails soft-clipped)",
+    "on_trim":    "adapters on (readthrough), fastp-trimmed before alignment (realistic Illumina)",
+}
 FIDELITY = ["snp_recall", "snp_precision", "snp_f1",
             "indel_recall", "indel_precision", "indel_f1"]
-data = {c: {} for c in CONDS}
-nreps = {c: 0 for c in CONDS}
-missing = []
+
+data, nreps, missing = {}, {}, []
 for row in rows:
     c = row["cond"]
-    if c not in data:
-        data.setdefault(c, {})
-        nreps.setdefault(c, 0)
+    data.setdefault(c, {})
+    nreps.setdefault(c, 0)
     od = row["outdir"]
     hp = parse_happy(os.path.join(od, "rneat_scored.summary.csv"))
     rz = parse_realism(os.path.join(od, "rneat_realism.tsv"))
@@ -108,6 +123,10 @@ for row in rows:
     nreps[c] += 1
     for k, v in {**hp, **rz}.items():
         data[c].setdefault(k, []).append(v)
+
+CONDS = [c for c in COND_ORDER if nreps.get(c, 0) > 0]
+CONDS += [c for c in data if c not in COND_ORDER and nreps.get(c, 0) > 0]
+has_ctrl = "short_ctrl" in CONDS
 
 def stats(vals):
     n = len(vals)
@@ -122,131 +141,166 @@ def fmt(m, sd, n, prec=4):
         return "—"
     return f"{m:.{prec}f}±{sd:.{prec}f}" if n > 1 else f"{m:.{prec}f}"
 
-# Per-metric tolerance floor for the NOTABLE screen (used when sd≈0, e.g. n=1 or
-# a perfectly reproducible metric). Rates on 0–1; counts/sizes scale-relative.
-RATE_FLOOR = 0.005          # 0.5 percentage points
-def tolerance(metric, m_off, sd_off, sd_cond):
-    base = max(sd_off, sd_cond)
+# Per-metric tolerance floor for the NOTABLE screen (used when sd≈0). Rates on
+# 0–1; counts/sizes scale-relative. Convention: replication sd = tolerance.
+RATE_FLOOR = 0.005
+def tolerance(metric, m_ref, sd_ref, sd_cond):
+    base = max(sd_ref, sd_cond)
     if metric.endswith(("recall", "precision", "f1", "_rate", "frac", "content")):
         return max(base, RATE_FLOOR)
-    # scale-relative floor for sizes/counts/qualities
-    return max(base, abs(m_off) * 0.02)
+    return max(base, abs(m_ref) * 0.02)
 
-# Realism metrics that are EXPECTED to move when adapters are enabled — flagging
-# these as "notable" is the feature working, not a regression.
+def prec_for(k):
+    return 0 if k in ("fastp_adapter_reads", "fastp_adapter_bases", "fastp_insert_peak") else 4
+
+# Realism metrics EXPECTED to move when adapters are enabled (feature working).
 EXPECTED_MOVE = {"fastp_adapter_reads", "fastp_adapter_bases", "softclip_frac"}
+REALISM_PRESENT = [k for k in REALISM_KEYS if any(k in data.get(c, {}) for c in CONDS)]
 
 # ── 5. emit markdown ─────────────────────────────────────────────────────────
 L = []
 def w(s=""):
     L.append(s)
 
-ts = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 ref = rows[0]["ref"] if rows else "NA"
 preset = rows[0]["preset"] if rows else "NA"
-w(f"# Adapter readthrough validation (#125)")
+w("# Adapter readthrough validation (#125)")
 w()
 w(f"_Generated {ts} from `{os.path.basename(manifest)}`_  ")
-w(f"Reference: `{os.path.basename(ref)}` · adapter preset: `{preset}` · "
-  f"reps/condition: off={nreps.get('off',0)}, on_raw={nreps.get('on_raw',0)}, "
-  f"on_trim={nreps.get('on_trim',0)}")
+w(f"Reference: `{os.path.basename(ref)}` · adapter preset: `{preset}` · reps/condition: "
+  + ", ".join(f"{c}={nreps.get(c, 0)}" for c in CONDS))
 w()
-w("Conditions: **off** = adapters disabled (baseline) · **on_raw** = adapters on, "
-  "aligned raw · **on_trim** = adapters on, fastp-trimmed before alignment "
-  "(realistic Illumina pipeline). Paired by seed → identical truth set per rep.")
+w("Conditions:")
+for c in CONDS:
+    w(f"- **{c}** — {COND_LABEL.get(c, '(custom arm)')}")
 w()
-
-# Fidelity table
-w("## 1. Variant-caller fidelity (GATK HaplotypeCaller vs truth, hap.py)")
-w()
-w("| Metric | off | on_raw | on_trim |")
-w("|---|---|---|---|")
-for k in FIDELITY:
-    cells = []
-    for c in CONDS:
-        m, sd, n = stats(data.get(c, {}).get(k, []))
-        cells.append(fmt(m, sd, n))
-    w(f"| {k} | {cells[0]} | {cells[1]} | {cells[2]} |")
+w("Paired by seed → identical truth set per rep.")
 w()
 
-# Realism table
-w("## 2. Realism signals (fastp + samtools stats)")
-w()
-w("| Metric | off | on_raw | on_trim |")
-w("|---|---|---|---|")
-for k in REALISM_KEYS:
-    if not any(k in data.get(c, {}) for c in CONDS):
-        continue
-    prec = 0 if k in ("fastp_adapter_reads", "fastp_adapter_bases",
-                      "fastp_insert_peak") else 4
-    cells = []
-    for c in CONDS:
-        m, sd, n = stats(data.get(c, {}).get(k, []))
-        cells.append(fmt(m, sd, n, prec))
-    w(f"| {k} | {cells[0]} | {cells[1]} | {cells[2]} |")
-w()
-
-# Delta analysis vs off
-w("## 3. Difference vs baseline (off)")
-w()
-w("`Δ = mean(on) − mean(off)`. **NOTABLE** = |Δ| exceeds replication noise "
-  "(tolerance = max(sd_off, sd_cond, floor)). Metrics expected to move when "
-  "adapters are enabled are tagged _(expected)_.")
-w()
-w("| Metric | condition | Δ | tolerance | flag |")
-w("|---|---|---|---|---|")
-notable_fidelity = []
-for k in FIDELITY + [r for r in REALISM_KEYS if any(r in data.get(c, {}) for c in CONDS)]:
-    m_off, sd_off, n_off = stats(data.get("off", {}).get(k, []))
-    if n_off == 0:
-        continue
-    for c in ("on_raw", "on_trim"):
-        m_c, sd_c, n_c = stats(data.get(c, {}).get(k, []))
-        if n_c == 0:
+def table(title, metrics):
+    w(title)
+    w()
+    w("| Metric | " + " | ".join(CONDS) + " |")
+    w("|---|" + "---|" * len(CONDS))
+    for k in metrics:
+        if not any(k in data.get(c, {}) for c in CONDS):
             continue
-        delta = m_c - m_off
-        tol = tolerance(k, m_off, sd_off, sd_c)
-        is_notable = abs(delta) > tol
-        if k in EXPECTED_MOVE:
-            flag = "NOTABLE _(expected)_" if is_notable else "—"
-        elif is_notable:
-            flag = "**NOTABLE**"
-            if k in FIDELITY:
-                notable_fidelity.append((k, c, delta))
-        else:
-            flag = "ok"
-        prec = 0 if k in ("fastp_adapter_reads", "fastp_adapter_bases",
-                          "fastp_insert_peak") else 4
-        w(f"| {k} | {c} | {delta:+.{prec}f} | {tol:.{prec}f} | {flag} |")
-w()
+        cells = [fmt(*stats(data.get(c, {}).get(k, [])), prec_for(k)) for c in CONDS]
+        w(f"| {k} | " + " | ".join(cells) + " |")
+    w()
 
-# Verdict
+table("## 1. Variant-caller fidelity (GATK HaplotypeCaller vs truth, hap.py)", FIDELITY)
+table("## 2. Realism signals (fastp + samtools stats)", REALISM_PRESENT)
+
+# ── contrasts: isolate the adapter effect from the insert-size effect ────────
+# kind drives the verdict:
+#   "adapter" = A vs B differ ONLY in adapter handling -> must stay within noise (PASS)
+#   "char"    = characterization (short-insert coverage cost) -> reported, not pass/fail
+#   "confounded" = A vs B mixes adapter + insert size -> flagged as not a clean test
+contrasts = []
+if has_ctrl:
+    contrasts.append(("short_ctrl", "off",
+                      "short-insert coverage effect (NO adapter on either side)", "char"))
+    contrasts.append(("on_trim", "short_ctrl",
+                      "PURE adapter effect — readthrough (trimmed) vs none, SAME inserts", "adapter"))
+    contrasts.append(("on_raw", "on_trim",
+                      "adapter handling — soft-clipped (raw) vs trimmed", "adapter"))
+else:
+    contrasts.append(("on_raw", "on_trim",
+                      "adapter handling — soft-clipped (raw) vs trimmed", "adapter"))
+    contrasts.append(("on_trim", "off",
+                      "adapter + insert-size COMBINED (confounded: off rejects short inserts)", "confounded"))
+contrasts = [ct for ct in contrasts if nreps.get(ct[0], 0) > 0 and nreps.get(ct[1], 0) > 0]
+
+def contrast_fidelity(a, b):
+    """List of (metric, delta, tol, notable) over FIDELITY for A vs B (Δ = A − B)."""
+    out = []
+    for k in FIDELITY:
+        m_b, sd_b, n_b = stats(data.get(b, {}).get(k, []))
+        m_a, sd_a, n_a = stats(data.get(a, {}).get(k, []))
+        if n_a == 0 or n_b == 0:
+            continue
+        d = m_a - m_b
+        tol = tolerance(k, m_b, sd_b, sd_a)
+        out.append((k, d, tol, abs(d) > tol))
+    return out
+
+w("## 3. Contrasts (Δ = mean(A) − mean(B); NOTABLE = |Δ| > replication noise)")
+w()
+for a, b, desc, kind in contrasts:
+    w(f"### {a} − {b}")
+    w(f"_{desc}_")
+    w()
+    w("| Metric | Δ | tolerance | flag |")
+    w("|---|---|---|---|")
+    for k, d, tol, notable in contrast_fidelity(a, b):
+        w(f"| {k} | {d:+.4f} | {tol:.4f} | {'**NOTABLE**' if notable else 'ok'} |")
+    for k in REALISM_PRESENT:
+        m_b, sd_b, n_b = stats(data.get(b, {}).get(k, []))
+        m_a, sd_a, n_a = stats(data.get(a, {}).get(k, []))
+        if n_a == 0 or n_b == 0:
+            continue
+        d = m_a - m_b
+        tol = tolerance(k, m_b, sd_b, sd_a)
+        notable = abs(d) > tol
+        if k in EXPECTED_MOVE:
+            flag = "NOTABLE _(expected)_" if notable else "—"
+        else:
+            flag = "**NOTABLE**" if notable else "ok"
+        p = prec_for(k)
+        w(f"| {k} | {d:+.{p}f} | {tol:.{p}f} | {flag} |")
+    w()
+
+# ── 6. verdict (data-driven) ─────────────────────────────────────────────────
 w("## 4. Verdict")
 w()
-trim_fidelity_issues = [x for x in notable_fidelity if x[1] == "on_trim"]
 if missing:
     w(f"> ⚠️ {len(missing)} run(s) had no outputs — results incomplete. See list below.")
     w()
-if not trim_fidelity_issues:
-    w("- ✅ **on_trim fidelity matches baseline** within replication noise — the "
-      "realistic adapter-trim pipeline recovers the same SNP/indel recall/precision/F1 "
-      "as the no-adapter run. Adapters are callable.")
+
+def notable_fid(a, b):
+    return [(k, d) for (k, d, tol, notable) in contrast_fidelity(a, b) if notable]
+
+adapter_contrasts = [ct for ct in contrasts if ct[3] == "adapter"]
+adapter_issues = [(a, b, k, d) for a, b, _, _ in adapter_contrasts for k, d in notable_fid(a, b)]
+
+if adapter_contrasts and not adapter_issues:
+    w("- ✅ **Adapters are callable.** Every adapter-only contrast ("
+      + "; ".join(f"{a} vs {b}" for a, b, _, _ in adapter_contrasts)
+      + ") is within replication noise on all SNP/indel recall/precision/F1 — 3' adapter "
+        "readthrough costs no fidelity whether it is fastp-trimmed or left for BWA-MEM2 to "
+        "soft-clip.")
+elif adapter_issues:
+    w("- ❌ **An adapter-only contrast shows a fidelity difference** beyond replication noise:")
+    for a, b, k, d in adapter_issues:
+        w(f"  - {a} vs {b} — {k}: Δ={d:+.4f}")
 else:
-    w("- ❌ **on_trim fidelity differs from baseline** beyond replication noise:")
-    for k, c, d in trim_fidelity_issues:
-        w(f"  - {k}: Δ={d:+.4f}")
-raw_issues = [x for x in notable_fidelity if x[1] == "on_raw"]
-if raw_issues:
-    w("- ⚠️ **on_raw** (untrimmed) shows fidelity differences — quantifies the cost of "
-      "NOT trimming adapters before calling:")
-    for k, c, d in raw_issues:
-        w(f"  - {k}: Δ={d:+.4f}")
+    w("- ⚠️ No adapter-only contrast available (need on_raw/on_trim, ideally short_ctrl too).")
+
+if has_ctrl:
+    cov_issues = notable_fid("short_ctrl", "off")
+    if cov_issues:
+        w("- ℹ️ **Short-insert coverage effect (expected — NOT an adapter problem).** "
+          "`short_ctrl` (short fragments kept, adapters entirely absent) already differs "
+          "from the long-insert `off` baseline:")
+        for k, d in cov_issues:
+            w(f"  - {k}: Δ={d:+.4f}")
+        w("  This is the reduced effective depth of short-insert libraries (R1/R2 overlap), "
+          "reproduced faithfully. Because it is present with no adapters at all, it is not "
+          "attributable to readthrough — so a raw off-vs-on gap of similar size is coverage, "
+          "not a calling failure.")
+    else:
+        w("- ✅ **short_ctrl ≈ off** — short inserts alone did not move fidelity in this run.")
 else:
-    w("- ✅ **on_raw** (untrimmed) fidelity also within noise — BWA-MEM2 soft-clips the "
-      "adapter tails and the caller is unaffected even without trimming.")
-w("- Realism: adapter content present only when enabled (fastp_adapter_reads), and "
-  "soft-clip fraction elevated on_raw then recovered on_trim — confirms the readthrough "
-  "is real, detectable, and trimmable by a standard QC tool.")
+    w("- ⚠️ **No `short_ctrl` arm.** A raw off-vs-on fidelity gap here would be confounded: "
+      "`off` rejects short fragments while the `on` arms keep them, so off-vs-on mixes the "
+      "adapter effect with an insert-size (coverage) difference. Re-run with CONTROL=1 to add "
+      "the short_ctrl arm and isolate the two.")
+
+w("- Realism: adapter content (fastp_adapter_reads/bases) rises only when readthrough is "
+  "enabled, and soft-clip fraction is elevated in on_raw then recovered in on_trim — "
+  "confirming the readthrough is real, detectable, and trimmable by a standard QC tool.")
 w()
 
 if missing:

--- a/scripts/delta/collect_adapter_validation.sh
+++ b/scripts/delta/collect_adapter_validation.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Aggregate the adapter-validation matrix (run_adapter_validation.sh) into a
+# documented PASS/NOTABLE report. For each condition (off / on_raw / on_trim) it
+# collects, across reps, the variant-caller fidelity (hap.py recall/precision/F1
+# for SNP+INDEL) and the realism signals (realism.tsv), reduces them to mean±sd,
+# then diffs on_* vs the off baseline and flags any difference that exceeds
+# replication noise (the regression-protocol convention: replication sd = tolerance).
+#
+# Usage:
+#   bash scripts/delta/collect_adapter_validation.sh $MANIFEST
+#   OUT=adapter_report.md bash scripts/delta/collect_adapter_validation.sh $MANIFEST
+#
+# Writes the markdown report to $OUT (default
+# $RESULTS_DIR/ADAPTER_VALIDATION.md) and echoes it to stdout.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"
+
+MANIFEST="${1:?usage: collect_adapter_validation.sh <manifest>}"
+[[ -f "$MANIFEST" ]] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
+OUT="${OUT:-$RESULTS_DIR/ADAPTER_VALIDATION.md}"
+mkdir -p "$(dirname "$OUT")"
+
+python3 - "$MANIFEST" "$OUT" <<'PY'
+import csv, os, sys, math, datetime
+
+manifest, out_path = sys.argv[1], sys.argv[2]
+
+# ── 1. read manifest: condition rep jobid outdir reference preset ───────────
+rows = []
+with open(manifest) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        p = line.split()
+        if len(p) < 4:
+            continue
+        rows.append({"cond": p[0], "rep": p[1], "jobid": p[2], "outdir": p[3],
+                     "ref": p[4] if len(p) > 4 else "NA",
+                     "preset": p[5] if len(p) > 5 else "NA"})
+
+# ── 2. parse hap.py summary.csv (column lookup by header name) ───────────────
+def parse_happy(path):
+    """{snp_recall, snp_precision, snp_f1, indel_*} from PASS rows; {} if absent."""
+    if not os.path.isfile(path):
+        return {}
+    out = {}
+    with open(path, newline="") as fh:
+        r = csv.DictReader(fh)
+        for row in r:
+            typ = (row.get("Type") or "").strip().upper()
+            filt = (row.get("Filter") or "").strip().upper()
+            if filt != "PASS" or typ not in ("SNP", "INDEL"):
+                continue
+            pfx = "snp" if typ == "SNP" else "indel"
+            for metric, key in (("Recall", "recall"), ("Precision", "precision"),
+                                ("F1_Score", "f1")):
+                v = row.get("METRIC." + metric, "")
+                try:
+                    out[f"{pfx}_{key}"] = float(v)
+                except (ValueError, TypeError):
+                    pass
+    return out
+
+# ── 3. parse realism.tsv (key<TAB>value) ────────────────────────────────────
+REALISM_KEYS = ["mapping_rate", "properly_paired_rate", "error_rate",
+                "softclip_frac", "insert_size_avg", "insert_size_sd",
+                "avg_read_len", "avg_base_qual", "fastp_adapter_reads",
+                "fastp_adapter_bases", "fastp_q30_rate", "fastp_gc_content",
+                "fastp_dup_rate", "fastp_insert_peak"]
+def parse_realism(path):
+    if not os.path.isfile(path):
+        return {}
+    out = {}
+    with open(path) as fh:
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) != 2:
+                continue
+            k, v = parts
+            if k in REALISM_KEYS:
+                try:
+                    out[k] = float(v)
+                except ValueError:
+                    pass
+    return out
+
+# ── 4. gather: data[cond][metric] = [values across reps] ─────────────────────
+CONDS = ["off", "on_raw", "on_trim"]
+FIDELITY = ["snp_recall", "snp_precision", "snp_f1",
+            "indel_recall", "indel_precision", "indel_f1"]
+data = {c: {} for c in CONDS}
+nreps = {c: 0 for c in CONDS}
+missing = []
+for row in rows:
+    c = row["cond"]
+    if c not in data:
+        data.setdefault(c, {})
+        nreps.setdefault(c, 0)
+    od = row["outdir"]
+    hp = parse_happy(os.path.join(od, "rneat_scored.summary.csv"))
+    rz = parse_realism(os.path.join(od, "rneat_realism.tsv"))
+    if not hp and not rz:
+        missing.append(f"{c} rep{row['rep']} (job {row['jobid']}): no outputs in {od}")
+        continue
+    nreps[c] += 1
+    for k, v in {**hp, **rz}.items():
+        data[c].setdefault(k, []).append(v)
+
+def stats(vals):
+    n = len(vals)
+    if n == 0:
+        return (float("nan"), float("nan"), 0)
+    m = sum(vals) / n
+    sd = math.sqrt(sum((x - m) ** 2 for x in vals) / (n - 1)) if n > 1 else 0.0
+    return (m, sd, n)
+
+def fmt(m, sd, n, prec=4):
+    if n == 0 or m != m:  # nan
+        return "—"
+    return f"{m:.{prec}f}±{sd:.{prec}f}" if n > 1 else f"{m:.{prec}f}"
+
+# Per-metric tolerance floor for the NOTABLE screen (used when sd≈0, e.g. n=1 or
+# a perfectly reproducible metric). Rates on 0–1; counts/sizes scale-relative.
+RATE_FLOOR = 0.005          # 0.5 percentage points
+def tolerance(metric, m_off, sd_off, sd_cond):
+    base = max(sd_off, sd_cond)
+    if metric.endswith(("recall", "precision", "f1", "_rate", "frac", "content")):
+        return max(base, RATE_FLOOR)
+    # scale-relative floor for sizes/counts/qualities
+    return max(base, abs(m_off) * 0.02)
+
+# Realism metrics that are EXPECTED to move when adapters are enabled — flagging
+# these as "notable" is the feature working, not a regression.
+EXPECTED_MOVE = {"fastp_adapter_reads", "fastp_adapter_bases", "softclip_frac"}
+
+# ── 5. emit markdown ─────────────────────────────────────────────────────────
+L = []
+def w(s=""):
+    L.append(s)
+
+ts = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+ref = rows[0]["ref"] if rows else "NA"
+preset = rows[0]["preset"] if rows else "NA"
+w(f"# Adapter readthrough validation (#125)")
+w()
+w(f"_Generated {ts} from `{os.path.basename(manifest)}`_  ")
+w(f"Reference: `{os.path.basename(ref)}` · adapter preset: `{preset}` · "
+  f"reps/condition: off={nreps.get('off',0)}, on_raw={nreps.get('on_raw',0)}, "
+  f"on_trim={nreps.get('on_trim',0)}")
+w()
+w("Conditions: **off** = adapters disabled (baseline) · **on_raw** = adapters on, "
+  "aligned raw · **on_trim** = adapters on, fastp-trimmed before alignment "
+  "(realistic Illumina pipeline). Paired by seed → identical truth set per rep.")
+w()
+
+# Fidelity table
+w("## 1. Variant-caller fidelity (GATK HaplotypeCaller vs truth, hap.py)")
+w()
+w("| Metric | off | on_raw | on_trim |")
+w("|---|---|---|---|")
+for k in FIDELITY:
+    cells = []
+    for c in CONDS:
+        m, sd, n = stats(data.get(c, {}).get(k, []))
+        cells.append(fmt(m, sd, n))
+    w(f"| {k} | {cells[0]} | {cells[1]} | {cells[2]} |")
+w()
+
+# Realism table
+w("## 2. Realism signals (fastp + samtools stats)")
+w()
+w("| Metric | off | on_raw | on_trim |")
+w("|---|---|---|---|")
+for k in REALISM_KEYS:
+    if not any(k in data.get(c, {}) for c in CONDS):
+        continue
+    prec = 0 if k in ("fastp_adapter_reads", "fastp_adapter_bases",
+                      "fastp_insert_peak") else 4
+    cells = []
+    for c in CONDS:
+        m, sd, n = stats(data.get(c, {}).get(k, []))
+        cells.append(fmt(m, sd, n, prec))
+    w(f"| {k} | {cells[0]} | {cells[1]} | {cells[2]} |")
+w()
+
+# Delta analysis vs off
+w("## 3. Difference vs baseline (off)")
+w()
+w("`Δ = mean(on) − mean(off)`. **NOTABLE** = |Δ| exceeds replication noise "
+  "(tolerance = max(sd_off, sd_cond, floor)). Metrics expected to move when "
+  "adapters are enabled are tagged _(expected)_.")
+w()
+w("| Metric | condition | Δ | tolerance | flag |")
+w("|---|---|---|---|---|")
+notable_fidelity = []
+for k in FIDELITY + [r for r in REALISM_KEYS if any(r in data.get(c, {}) for c in CONDS)]:
+    m_off, sd_off, n_off = stats(data.get("off", {}).get(k, []))
+    if n_off == 0:
+        continue
+    for c in ("on_raw", "on_trim"):
+        m_c, sd_c, n_c = stats(data.get(c, {}).get(k, []))
+        if n_c == 0:
+            continue
+        delta = m_c - m_off
+        tol = tolerance(k, m_off, sd_off, sd_c)
+        is_notable = abs(delta) > tol
+        if k in EXPECTED_MOVE:
+            flag = "NOTABLE _(expected)_" if is_notable else "—"
+        elif is_notable:
+            flag = "**NOTABLE**"
+            if k in FIDELITY:
+                notable_fidelity.append((k, c, delta))
+        else:
+            flag = "ok"
+        prec = 0 if k in ("fastp_adapter_reads", "fastp_adapter_bases",
+                          "fastp_insert_peak") else 4
+        w(f"| {k} | {c} | {delta:+.{prec}f} | {tol:.{prec}f} | {flag} |")
+w()
+
+# Verdict
+w("## 4. Verdict")
+w()
+trim_fidelity_issues = [x for x in notable_fidelity if x[1] == "on_trim"]
+if missing:
+    w(f"> ⚠️ {len(missing)} run(s) had no outputs — results incomplete. See list below.")
+    w()
+if not trim_fidelity_issues:
+    w("- ✅ **on_trim fidelity matches baseline** within replication noise — the "
+      "realistic adapter-trim pipeline recovers the same SNP/indel recall/precision/F1 "
+      "as the no-adapter run. Adapters are callable.")
+else:
+    w("- ❌ **on_trim fidelity differs from baseline** beyond replication noise:")
+    for k, c, d in trim_fidelity_issues:
+        w(f"  - {k}: Δ={d:+.4f}")
+raw_issues = [x for x in notable_fidelity if x[1] == "on_raw"]
+if raw_issues:
+    w("- ⚠️ **on_raw** (untrimmed) shows fidelity differences — quantifies the cost of "
+      "NOT trimming adapters before calling:")
+    for k, c, d in raw_issues:
+        w(f"  - {k}: Δ={d:+.4f}")
+else:
+    w("- ✅ **on_raw** (untrimmed) fidelity also within noise — BWA-MEM2 soft-clips the "
+      "adapter tails and the caller is unaffected even without trimming.")
+w("- Realism: adapter content present only when enabled (fastp_adapter_reads), and "
+  "soft-clip fraction elevated on_raw then recovered on_trim — confirms the readthrough "
+  "is real, detectable, and trimmable by a standard QC tool.")
+w()
+
+if missing:
+    w("## Missing runs")
+    w()
+    for m in missing:
+        w(f"- {m}")
+    w()
+
+report = "\n".join(L) + "\n"
+with open(out_path, "w") as fh:
+    fh.write(report)
+sys.stdout.write(report)
+sys.stderr.write(f"\n[wrote] {out_path}\n")
+PY

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -101,6 +101,11 @@ PRUNE="${PRUNE:-0}"
 HAPPY_SIF="${HAPPY_SIF:-$SCRATCH/sif/happy_v0.3.12.sif}"
 NEAT_ENV="${NEAT_ENV:-neat4}"         # conda env with NEAT 4
 THREADS=$SLURM_CPUS_PER_TASK
+# fastp's reader/worker/writer pipeline is built for a small thread pool; at very
+# high counts (e.g. THREADS=64 on a Delta cpu node) it livelocks — barely any CPU,
+# zero output — so cap it. Observed 2026-07-01: fastp sat at 38% CPU with 0-byte
+# trimmed output for 30+ min until capped. Override with FASTP_THREADS=.
+FASTP_THREADS="${FASTP_THREADS:-$(( THREADS < 16 ? THREADS : 16 ))}"
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
 RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
 
@@ -295,7 +300,7 @@ run_fastp() {
     fi
     echo "  [fastp] adapter detect/trim + QC report..."
     conda run -n bioinf fastp -i "$r1" -I "$r2" -o "$tr1" -O "$tr2" \
-        --detect_adapter_for_pe --thread "$THREADS" \
+        --detect_adapter_for_pe --thread "$FASTP_THREADS" \
         -j "$wd/fastp.json" -h "$wd/fastp.html" 2>"$wd/fastp.log"
 }
 

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -89,6 +89,11 @@ ADAPTERS="${ADAPTERS:-0}"
 ADAPTER_PRESET="${ADAPTER_PRESET:-truseq}"
 TRIM="${TRIM:-0}"
 MEASURE_REALISM="${MEASURE_REALISM:-0}"
+# KEEP_SHORT=1 keeps short inserts as genomic reads WITHOUT adapter readthrough
+# (rneat keep_short_fragments) — the adapter-free short-insert control arm that
+# isolates the coverage effect from the adapter effect (#125). Independent of
+# ADAPTERS; leave both off for the default long-insert baseline.
+KEEP_SHORT="${KEEP_SHORT:-0}"
 
 # PRUNE=1 deletes the bulky FASTQ + BAM + gVCF intermediates after a SUCCESSFUL
 # score (per-tool scored.summary.csv present), keeping the small scores/VCFs/QC.
@@ -211,6 +216,10 @@ adapters:
   enabled: true
   preset: $ADAPTER_PRESET
 YAML
+    elif [[ "$KEEP_SHORT" == "1" ]]; then
+        # Adapter-free short-insert control: keep short fragments as genomic reads.
+        # (Only when ADAPTERS!=1 — adapters.enabled already implies keeping them.)
+        echo "keep_short_fragments: true" >> "$wd/sim.yml"
     fi
     "$RNEAT_BIN" gen-reads -c "$wd/sim.yml"
 }

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -27,6 +27,12 @@
 #   SHUFFLE=1 TOOLS=rneat sbatch ...   # randomize read order before alignment
 #       (off by default; run once shuffled vs unshuffled to confirm the caller
 #        is read-order-independent — same recall expected)
+#   ADAPTERS=1 MEASURE_REALISM=1 TOOLS=rneat sbatch ...   # 3' adapter readthrough
+#       on, aligned raw, with adapter/insert/soft-clip QC captured (#125).
+#   ADAPTERS=1 TRIM=1 MEASURE_REALISM=1 TOOLS=rneat sbatch ...  # + fastp-trim
+#       before alignment (the realistic Illumina pipeline).
+#       Drive the off/on-untrimmed/on-trimmed A/B/C matrix with
+#       scripts/delta/run_adapter_validation.sh (REPS for mean±sd).
 
 #SBATCH --job-name=rneat-germline
 #SBATCH --partition=cpu
@@ -67,6 +73,22 @@ FRAG_SD="${FRAG_SD:-50}"
 # seqkit in the bioinf env (setup.sh installs it).
 SHUFFLE="${SHUFFLE:-0}"
 SHUFFLE_SEED="${SHUFFLE_SEED:-11}"
+
+# ── 3' adapter readthrough (#125) + adapter-aware QC ──────────────────────
+# All three default OFF → sim.yml carries no `adapters:` block and no extra
+# stages run, so output is byte-identical to pre-adapter runs (the variety and
+# regression jobs that call this script are unaffected).
+#   ADAPTERS=1        enable rneat 3' adapter readthrough (adapters.enabled=true)
+#   ADAPTER_PRESET    truseq|nextera|custom (only used when ADAPTERS=1)
+#   TRIM=1            fastp adapter-trim BEFORE alignment (the realistic Illumina
+#                     pipeline). Off = align raw reads, exposing soft-clipped
+#                     adapter tails so we can measure the untrimmed penalty.
+#   MEASURE_REALISM=1 capture adapter/insert/soft-clip/mapping QC → realism.tsv
+#                     (fastp report + samtools stats). Independent of TRIM.
+ADAPTERS="${ADAPTERS:-0}"
+ADAPTER_PRESET="${ADAPTER_PRESET:-truseq}"
+TRIM="${TRIM:-0}"
+MEASURE_REALISM="${MEASURE_REALISM:-0}"
 
 HAPPY_SIF="${HAPPY_SIF:-$SCRATCH/sif/happy_v0.3.12.sif}"
 NEAT_ENV="${NEAT_ENV:-neat4}"         # conda env with NEAT 4
@@ -124,6 +146,15 @@ rng_seed: $SEED
 sv_rate_scale: 0
 num_threads: $THREADS
 YAML
+    # 3' adapter readthrough (#125). Appended only when enabled so the default
+    # config is byte-identical to the pre-adapter sim.yml.
+    if [[ "$ADAPTERS" == "1" ]]; then
+        cat >> "$wd/sim.yml" <<YAML
+adapters:
+  enabled: true
+  preset: $ADAPTER_PRESET
+YAML
+    fi
     "$RNEAT_BIN" gen-reads -c "$wd/sim.yml"
 }
 
@@ -190,6 +221,103 @@ align_call_score() {
     fi
 }
 
+# ── Adapter-aware QC helpers (only used when MEASURE_REALISM/TRIM set) ─────
+# fastp isn't a Delta module and may post-date the bioinf env; ensure it the
+# same just-in-time way setup.sh ensures seqkit, so this runs even if setup.sh
+# wasn't re-run after fastp was added.
+ensure_fastp() {
+    conda run -n bioinf which fastp >/dev/null 2>&1 && return 0
+    echo "  [setup] installing fastp into bioinf env (one-time)..."
+    conda install -y -n bioinf -c bioconda -c conda-forge fastp >/dev/null 2>&1
+    conda run -n bioinf which fastp >/dev/null 2>&1
+}
+
+# run_fastp <wd> <r1> <r2>  — adapter detect/trim + QC report (idempotent).
+# Always writes fastp.json/.log and trimmed_r{1,2}.fastq.gz; the caller decides
+# whether to feed the trimmed reads to alignment (TRIM=1) or just keep the report.
+run_fastp() {
+    local wd="$1" r1="$2" r2="$3"
+    local tr1="$wd/trimmed_r1.fastq.gz" tr2="$wd/trimmed_r2.fastq.gz"
+    if [[ -f "$wd/fastp.json" && -s "$tr1" && -s "$tr2" ]]; then
+        echo "  [fastp] report present — skipping."; return 0
+    fi
+    echo "  [fastp] adapter detect/trim + QC report..."
+    conda run -n bioinf fastp -i "$r1" -I "$r2" -o "$tr1" -O "$tr2" \
+        --detect_adapter_for_pe --thread "$THREADS" \
+        -j "$wd/fastp.json" -h "$wd/fastp.html" 2>"$wd/fastp.log"
+}
+
+# capture_realism <tool> <wd> — adapter/insert/soft-clip/mapping signals from
+# samtools stats (BAM) + fastp.json into realism.tsv (key<TAB>value). These are
+# the metrics adapter readthrough is expected to move; the collector diffs them
+# off-vs-on. Soft-clip fraction = 1 - bases_mapped(cigar)/total_length, the clean
+# signal for untrimmed adapter tails getting clipped at the read 3' end.
+capture_realism() {
+    local tool="$1" wd="$2"
+    local bam="$wd/aligned.bam" st="$wd/samstats.txt" out="$wd/realism.tsv"
+    [[ -f "$bam" ]] || { echo "  [$tool realism] no BAM — skipping." >&2; return 0; }
+    [[ -s "$st" ]] || samtools stats -@ "$THREADS" "$bam" > "$st"
+
+    # samtools-stats SN scalar by label (value is field 3, may carry a trailing comment).
+    sn() { awk -F'\t' -v k="$1" '$1=="SN" && $2==k {v=$3; sub(/[ \t].*/,"",v); print v+0; exit}' "$st"; }
+    local total mapped paired_pct errrate isize isd avlen avqual tlen bmapcig softclip
+    total=$(sn "raw total sequences:")
+    mapped=$(sn "reads mapped:")
+    errrate=$(sn "error rate:")
+    isize=$(sn "insert size average:")
+    isd=$(sn "insert size standard deviation:")
+    avlen=$(sn "average length:")
+    avqual=$(sn "average quality:")
+    tlen=$(sn "total length:")
+    bmapcig=$(sn "bases mapped (cigar):")
+    paired_pct=$(awk -v m="$(sn 'reads properly paired:')" -v t="$total" \
+        'BEGIN{printf "%.4f", (t>0)? m/t : 0}')
+    mapped=$(awk -v m="$mapped" -v t="$total" 'BEGIN{printf "%.4f", (t>0)? m/t : 0}')
+    softclip=$(awk -v b="$bmapcig" -v t="$tlen" 'BEGIN{printf "%.4f", (t>0)? 1-(b/t) : 0}')
+
+    # fastp.json scalars (robust JSON parse; python3 is always present on Delta).
+    local fj="$wd/fastp.json"
+    local adp_reads=0 adp_bases=0 dup=0 q30=0 gc=0 ipeak=0
+    if [[ -f "$fj" ]]; then
+        read -r adp_reads adp_bases dup q30 gc ipeak < <(python3 - "$fj" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+ac = d.get("adapter_cutting", {})
+af = d.get("summary", {}).get("after_filtering", {})
+print(ac.get("adapter_trimmed_reads", 0),
+      ac.get("adapter_trimmed_bases", 0),
+      d.get("duplication", {}).get("rate", 0),
+      af.get("q30_rate", 0),
+      af.get("gc_content", 0),
+      d.get("insert_size", {}).get("peak", 0))
+PY
+)
+    fi
+
+    {
+        printf '%s\t%s\n' \
+            tool                 "$tool" \
+            adapters             "$ADAPTERS" \
+            trimmed              "$TRIM" \
+            adapter_preset       "$ADAPTER_PRESET" \
+            mapping_rate         "${mapped:-0}" \
+            properly_paired_rate "${paired_pct:-0}" \
+            error_rate           "${errrate:-0}" \
+            softclip_frac        "${softclip:-0}" \
+            insert_size_avg      "${isize:-0}" \
+            insert_size_sd       "${isd:-0}" \
+            avg_read_len         "${avlen:-0}" \
+            avg_base_qual        "${avqual:-0}" \
+            fastp_adapter_reads  "${adp_reads:-0}" \
+            fastp_adapter_bases  "${adp_bases:-0}" \
+            fastp_q30_rate       "${q30:-0}" \
+            fastp_gc_content     "${gc:-0}" \
+            fastp_dup_rate       "${dup:-0}" \
+            fastp_insert_peak    "${ipeak:-0}"
+    } > "$out"
+    echo "  [$tool realism] wrote $(basename "$out")"
+}
+
 # ── Per-tool pipeline ─────────────────────────────────────────────────────
 for tool in $TOOLS; do
     wd="$OUTDIR/$tool"; mkdir -p "$wd"
@@ -235,9 +363,29 @@ for tool in $TOOLS; do
         r1="$sh1"; r2="$sh2"
     fi
 
+    # Adapter-aware QC + optional trim. fastp runs once (report + trimmed reads);
+    # TRIM=1 feeds the trimmed reads to alignment (realistic pipeline), TRIM=0
+    # keeps the raw reads for alignment but still records the adapter report.
+    if [[ "$MEASURE_REALISM" == "1" || "$TRIM" == "1" ]]; then
+        ensure_fastp || { echo "  [$tool] fastp unavailable — skipping QC/trim." >&2; }
+        if conda run -n bioinf which fastp >/dev/null 2>&1; then
+            run_fastp "$wd" "$r1" "$r2"
+            if [[ "$TRIM" == "1" && -s "$wd/trimmed_r1.fastq.gz" ]]; then
+                echo "  [$tool trim] aligning fastp-trimmed reads."
+                r1="$wd/trimmed_r1.fastq.gz"; r2="$wd/trimmed_r2.fastq.gz"
+            fi
+        fi
+    fi
+
     align_call_score "$tool" "$wd" "$r1" "$r2" "$truth"
     # Stage the summary at the top level with a tool tag for the report.
     [[ -f "$wd/scored.summary.csv" ]] && cp -f "$wd/scored.summary.csv" "$OUTDIR/${tool}_scored.summary.csv"
+
+    # Realism signals (depends on the aligned BAM, so after align_call_score).
+    if [[ "$MEASURE_REALISM" == "1" ]]; then
+        capture_realism "$tool" "$wd"
+        [[ -f "$wd/realism.tsv" ]] && cp -f "$wd/realism.tsv" "$OUTDIR/${tool}_realism.tsv"
+    fi
 done
 
 # ── Side-by-side summary ──────────────────────────────────────────────────
@@ -253,4 +401,6 @@ for tool in $TOOLS; do
 done
 
 # Persist report artifacts off scratch + record provenance/resources.
-archive_run germline "$OUTDIR" rneat_scored.summary.csv neat_scored.summary.csv
+archive_run germline "$OUTDIR" \
+    rneat_scored.summary.csv neat_scored.summary.csv \
+    rneat_realism.tsv neat_realism.tsv

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -90,6 +90,14 @@ ADAPTER_PRESET="${ADAPTER_PRESET:-truseq}"
 TRIM="${TRIM:-0}"
 MEASURE_REALISM="${MEASURE_REALISM:-0}"
 
+# PRUNE=1 deletes the bulky FASTQ + BAM + gVCF intermediates after a SUCCESSFUL
+# score (per-tool scored.summary.csv present), keeping the small scores/VCFs/QC.
+# Matches cancer_pipeline.sbatch; default off so variety/regression runs are
+# unchanged. The adapter matrix (3 conditions × reps, plus trimmed read copies)
+# is data-heavy on the shared scratch PROJECT quota — run_adapter_validation.sh
+# defaults it on.
+PRUNE="${PRUNE:-0}"
+
 HAPPY_SIF="${HAPPY_SIF:-$SCRATCH/sif/happy_v0.3.12.sif}"
 NEAT_ENV="${NEAT_ENV:-neat4}"         # conda env with NEAT 4
 THREADS=$SLURM_CPUS_PER_TASK
@@ -404,3 +412,21 @@ done
 archive_run germline "$OUTDIR" \
     rneat_scored.summary.csv neat_scored.summary.csv \
     rneat_realism.tsv neat_realism.tsv
+
+# Optional cleanup of bulky intermediates once scored + archived, so the
+# adapter matrix / large sweeps don't exhaust the shared scratch project quota.
+# Per tool, only prune when THAT tool scored successfully (scored.summary.csv
+# present) so a failed/partial arm keeps its inputs for resume. Keeps the small
+# durable bits: scores, called/truth VCFs, realism.tsv, samstats, fastp report.
+if [[ "$PRUNE" == "1" ]]; then
+    for tool in $TOOLS; do
+        wd="$OUTDIR/$tool"
+        [[ -f "$wd/scored.summary.csv" ]] || { echo "[prune] $tool not scored — keeping inputs."; continue; }
+        echo "[prune] $tool — removing FASTQ/BAM/gVCF (keeping scores, VCFs, QC)..."
+        rm -f "$wd"/sample_r1.fastq.gz "$wd"/sample_r2.fastq.gz \
+              "$wd"/trimmed_r1.fastq.gz "$wd"/trimmed_r2.fastq.gz \
+              "$wd"/shuf_r1.fastq.gz "$wd"/shuf_r2.fastq.gz \
+              "$wd"/aligned.bam "$wd"/aligned.bam.bai \
+              "$wd"/raw.g.vcf.gz "$wd"/raw.g.vcf.gz.tbi
+    done
+fi

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -120,6 +120,30 @@ echo "Reference: $REFERENCE   Coverage: ${COVERAGE}x   Read: ${READ_LEN}bp   Thr
 echo "Tools:     $TOOLS"
 echo "Output:    $OUTDIR"
 
+# ── Node-local staging (LOCAL_STAGE=1) ────────────────────────────────────
+# Run all heavy per-tool I/O (FASTQ/BAM/gVCF) — plus the reference index reads,
+# rneat binary, and hap.py SIF — on the compute node's LOCAL disk, copying only
+# the small durable artifacts (scores, VCFs, QC) back to $OUTDIR on Lustre at
+# stage-out. A shared-filesystem OST dropping mid-run can then no longer wedge
+# the job in uninterruptible I/O wait (the failure that stalled the 2026-07-01
+# adapter matrix ~15h in the fastp step): Lustre is touched only briefly at
+# stage-in/out. Default OFF (work directly in $OUTDIR, cross-submit resume
+# preserved); run_adapter_validation.sh turns it on. Override the local root
+# with LOCAL_SCRATCH=..., keep the local tree for debugging with KEEP_LOCAL=1.
+LOCAL_STAGE="${LOCAL_STAGE:-0}"
+if [[ "$LOCAL_STAGE" == "1" ]]; then
+    LOCAL_ROOT="${LOCAL_SCRATCH:-${SLURM_TMPDIR:-${TMPDIR:-/tmp}}}/rneat_e2e_${SLURM_JOB_ID:-$$}"
+    mkdir -p "$LOCAL_ROOT" || { echo "ERROR: cannot create local scratch $LOCAL_ROOT" >&2; exit 1; }
+    [[ "${KEEP_LOCAL:-0}" == "1" ]] || trap 'rm -rf "$LOCAL_ROOT"' EXIT
+    # Tool workdirs go under work/ so they can't collide with the staged assets
+    # ($LOCAL_ROOT/ref, .../rneat binary, .../happy.sif) — the "rneat" tool dir
+    # would otherwise clash with the staged "rneat" binary of the same name.
+    WORK_ROOT="$LOCAL_ROOT/work"
+    echo "Local stage: $LOCAL_ROOT  (durable outputs copied back to $OUTDIR)"
+else
+    WORK_ROOT="$OUTDIR"
+fi
+
 # ── Shared one-time reference indexing ───────────────────────────────────
 # Guard on -s (exists AND non-empty), not -f: an index build killed mid-write
 # leaves a 0-byte .bwt.2bit.64 that -f treats as "present", so every later run
@@ -131,6 +155,26 @@ if [[ ! -s "${REFERENCE}.bwt.2bit.64" && ! -s "${REFERENCE}.bwt" ]]; then
 fi
 REF_DICT="${REFERENCE%.fa}.dict"
 [[ -f "$REF_DICT" ]] || gatk CreateSequenceDictionary -R "$REFERENCE" 2>&1 | tail -2
+
+# ── Node-local stage-in of the reference + tools (LOCAL_STAGE=1) ───────────
+# After the shared one-time Lustre index build above, copy the reference and all
+# its sidecar indexes (fai/dict + bwa-mem2 .0123/.amb/.ann/.bwt.2bit.64/.pac) —
+# plus the rneat binary and hap.py SIF — onto local disk and repoint at them, so
+# alignment/calling/scoring stream them from the node instead of Lustre.
+if [[ "$LOCAL_STAGE" == "1" ]]; then
+    echo "Staging reference + tools to $LOCAL_ROOT ..."
+    mkdir -p "$LOCAL_ROOT/ref"
+    cp -f "$REFERENCE" "$LOCAL_ROOT/ref/" 2>/dev/null || true
+    for ext in .fai .0123 .amb .ann .bwt.2bit.64 .pac; do
+        [[ -e "${REFERENCE}${ext}" ]] && cp -f "${REFERENCE}${ext}" "$LOCAL_ROOT/ref/" || true
+    done
+    [[ -e "$REF_DICT" ]] && cp -f "$REF_DICT" "$LOCAL_ROOT/ref/" || true
+    REFERENCE="$LOCAL_ROOT/ref/$REF_NAME"; REF_DIR="$LOCAL_ROOT/ref"; REF_DICT="${REFERENCE%.fa}.dict"
+    [[ -s "$REFERENCE" ]] || { echo "ERROR: reference stage-in failed ($REFERENCE)" >&2; exit 1; }
+    [[ -x "$RNEAT_BIN" ]] && cp -f "$RNEAT_BIN" "$LOCAL_ROOT/rneat"     && RNEAT_BIN="$LOCAL_ROOT/rneat"     || true
+    [[ -f "$HAPPY_SIF" ]] && cp -f "$HAPPY_SIF" "$LOCAL_ROOT/happy.sif" && HAPPY_SIF="$LOCAL_ROOT/happy.sif" || true
+    df -h "$LOCAL_ROOT" | tail -1
+fi
 
 # ── Simulators (each writes <wd>/sample_r1/r2.fastq.gz + a truth VCF) ─────
 # rneat: SNP/indel only via sv_rate_scale=0; truth = sample.vcf.gz
@@ -328,7 +372,7 @@ PY
 
 # ── Per-tool pipeline ─────────────────────────────────────────────────────
 for tool in $TOOLS; do
-    wd="$OUTDIR/$tool"; mkdir -p "$wd"
+    wd="$WORK_ROOT/$tool"; mkdir -p "$wd"
     r1="$wd/sample_r1.fastq.gz"; r2="$wd/sample_r2.fastq.gz"
     echo
     echo "──────── $tool ────────"
@@ -394,6 +438,21 @@ for tool in $TOOLS; do
         capture_realism "$tool" "$wd"
         [[ -f "$wd/realism.tsv" ]] && cp -f "$wd/realism.tsv" "$OUTDIR/${tool}_realism.tsv"
     fi
+
+    # Stage durable per-tool artifacts back to Lustre when working locally: drop
+    # the bulky FASTQ/BAM/gVCF (kept only on the node's local disk, discarded with
+    # it), then copy the small remainder (scores, called/truth VCFs, QC, logs) to
+    # $OUTDIR/$tool for provenance. The two files the collector needs were already
+    # copied to $OUTDIR top-level above; this makes PRUNE=1 a no-op here.
+    if [[ "$LOCAL_STAGE" == "1" ]]; then
+        rm -f "$wd"/sample_r1.fastq.gz "$wd"/sample_r2.fastq.gz \
+              "$wd"/trimmed_r1.fastq.gz "$wd"/trimmed_r2.fastq.gz \
+              "$wd"/shuf_r1.fastq.gz "$wd"/shuf_r2.fastq.gz \
+              "$wd"/aligned.bam "$wd"/aligned.bam.bai \
+              "$wd"/raw.g.vcf.gz "$wd"/raw.g.vcf.gz.tbi
+        mkdir -p "$OUTDIR/$tool"
+        cp -rf "$wd/." "$OUTDIR/$tool/" 2>/dev/null || true
+    fi
 done
 
 # ── Side-by-side summary ──────────────────────────────────────────────────
@@ -418,7 +477,7 @@ archive_run germline "$OUTDIR" \
 # Per tool, only prune when THAT tool scored successfully (scored.summary.csv
 # present) so a failed/partial arm keeps its inputs for resume. Keeps the small
 # durable bits: scores, called/truth VCFs, realism.tsv, samstats, fastp report.
-if [[ "$PRUNE" == "1" ]]; then
+if [[ "$PRUNE" == "1" && "$LOCAL_STAGE" != "1" ]]; then
     for tool in $TOOLS; do
         wd="$OUTDIR/$tool"
         [[ -f "$wd/scored.summary.csv" ]] || { echo "[prune] $tool not scored — keeping inputs."; continue; }

--- a/scripts/delta/run_adapter_validation.sh
+++ b/scripts/delta/run_adapter_validation.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Adapter-readthrough validation (#125): does enabling 3' sequencing-adapter
+# readthrough keep the data realistic AND keep it callable by a standard germline
+# pipeline? Submits the germline_e2e variant-caller pipeline (rneat → BWA-MEM2 →
+# GATK HaplotypeCaller → hap.py) under three conditions, each replicated REPS
+# times for mean±sd, then collect_adapter_validation.sh tabulates and flags any
+# statistical difference vs the no-adapter baseline.
+#
+#   off       adapters disabled (baseline = the path the regression already gates)
+#   on_raw    adapters enabled, reads aligned RAW (exposes soft-clipped adapter tails)
+#   on_trim   adapters enabled, fastp-trimmed before alignment (realistic Illumina)
+#
+# Paired by seed: rep r uses the SAME rng_seed across all three conditions, so the
+# truth variant set is identical (adapters don't touch variant generation — proven
+# in-tree) and differences are attributable to adapter handling, not seed draw.
+#
+# Usage (from repo root, on Delta after setup.sh):
+#   bash scripts/delta/run_adapter_validation.sh
+#   REPS=5 COVERAGE=50 ADAPTER_PRESET=nextera \
+#     REFERENCE=$SCRATCH/neat_data/chr22.fa \
+#     bash scripts/delta/run_adapter_validation.sh
+#
+# Re-runnable: germline_e2e is idempotent per outdir, so re-submitting only
+# recomputes missing stages. When all jobs finish:
+#   bash scripts/delta/collect_adapter_validation.sh $MANIFEST
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"
+
+REFERENCE="${REFERENCE:-$SCRATCH/neat_data/chr22.fa}"
+COVERAGE="${COVERAGE:-30}"
+REPS="${REPS:-3}"
+ADAPTER_PRESET="${ADAPTER_PRESET:-truseq}"
+MANIFEST="${MANIFEST:-${RESULTS_DIR:-$HOME}/adapter_validation.manifest}"
+
+[[ -f "$REFERENCE" ]] || { echo "REFERENCE not found: $REFERENCE" >&2; exit 1; }
+mkdir -p "$(dirname "$MANIFEST")"
+echo "# condition rep jobid outdir reference preset" > "$MANIFEST"
+
+# condition -> "ADAPTERS TRIM" env values
+submit() {
+    local cond="$1" adapters="$2" trim="$3" rep="$4"
+    local out="$SCRATCH/adapter_${cond}_rep${rep}"
+    local jid
+    jid=$(REFERENCE="$REFERENCE" TOOLS=rneat COVERAGE="$COVERAGE" OUTDIR="$out" \
+          SEED="adapter-validation rep$rep" \
+          ADAPTERS="$adapters" TRIM="$trim" ADAPTER_PRESET="$ADAPTER_PRESET" \
+          MEASURE_REALISM=1 \
+          sbatch --parsable "$REPO_ROOT/scripts/delta/germline_e2e.sbatch")
+    echo "$cond $rep $jid $out $REFERENCE $ADAPTER_PRESET" | tee -a "$MANIFEST"
+}
+
+echo "Adapter validation: ref=$(basename "$REFERENCE") cov=${COVERAGE}x reps=$REPS preset=$ADAPTER_PRESET"
+for r in $(seq 1 "$REPS"); do
+    submit off     0 0 "$r"
+    submit on_raw  1 0 "$r"
+    submit on_trim 1 1 "$r"
+done
+
+echo
+echo "Manifest: $MANIFEST   (watch: squeue --me)"
+echo "When all finish: bash scripts/delta/collect_adapter_validation.sh $MANIFEST"

--- a/scripts/delta/run_adapter_validation.sh
+++ b/scripts/delta/run_adapter_validation.sh
@@ -46,7 +46,7 @@ submit() {
     jid=$(REFERENCE="$REFERENCE" TOOLS=rneat COVERAGE="$COVERAGE" OUTDIR="$out" \
           SEED="adapter-validation rep$rep" \
           ADAPTERS="$adapters" TRIM="$trim" ADAPTER_PRESET="$ADAPTER_PRESET" \
-          MEASURE_REALISM=1 PRUNE="${PRUNE:-1}" \
+          MEASURE_REALISM=1 PRUNE="${PRUNE:-1}" LOCAL_STAGE="${LOCAL_STAGE:-1}" \
           sbatch --parsable "$REPO_ROOT/scripts/delta/germline_e2e.sbatch")
     echo "$cond $rep $jid $out $REFERENCE $ADAPTER_PRESET" | tee -a "$MANIFEST"
 }

--- a/scripts/delta/run_adapter_validation.sh
+++ b/scripts/delta/run_adapter_validation.sh
@@ -48,25 +48,32 @@ MANIFEST="${MANIFEST:-${RESULTS_DIR:-$HOME}/adapter_validation.manifest}"
 mkdir -p "$(dirname "$MANIFEST")"
 echo "# condition rep jobid outdir reference preset" > "$MANIFEST"
 
-# condition -> "ADAPTERS TRIM" env values
+# CONTROL=1 (default) adds the short_ctrl arm: short inserts KEPT but NO adapter
+# (genomic reads), which isolates the short-insert coverage effect from the adapter
+# effect. Set CONTROL=0 for the 3-arm off/on_raw/on_trim matrix only.
+CONTROL="${CONTROL:-1}"
+
+# submit <cond> <adapters> <trim> <keep_short> <rep>
 submit() {
-    local cond="$1" adapters="$2" trim="$3" rep="$4"
+    local cond="$1" adapters="$2" trim="$3" keep_short="$4" rep="$5"
     local out="$SCRATCH/adapter_${cond}_rep${rep}"
     local jid
     jid=$(REFERENCE="$REFERENCE" TOOLS=rneat COVERAGE="$COVERAGE" OUTDIR="$out" \
           SEED="adapter-validation rep$rep" \
-          ADAPTERS="$adapters" TRIM="$trim" ADAPTER_PRESET="$ADAPTER_PRESET" \
+          ADAPTERS="$adapters" TRIM="$trim" KEEP_SHORT="$keep_short" ADAPTER_PRESET="$ADAPTER_PRESET" \
           FRAG_MEAN="$FRAG_MEAN" FRAG_SD="$FRAG_SD" \
           MEASURE_REALISM=1 PRUNE="${PRUNE:-1}" LOCAL_STAGE="${LOCAL_STAGE:-1}" \
           sbatch --parsable "$REPO_ROOT/scripts/delta/germline_e2e.sbatch")
     echo "$cond $rep $jid $out $REFERENCE $ADAPTER_PRESET" | tee -a "$MANIFEST"
 }
 
-echo "Adapter validation: ref=$(basename "$REFERENCE") cov=${COVERAGE}x reps=$REPS preset=$ADAPTER_PRESET frag=${FRAG_MEAN}±${FRAG_SD} (short-insert → readthrough active)"
+echo "Adapter validation: ref=$(basename "$REFERENCE") cov=${COVERAGE}x reps=$REPS preset=$ADAPTER_PRESET frag=${FRAG_MEAN}±${FRAG_SD} control=$CONTROL (short-insert → readthrough active)"
 for r in $(seq 1 "$REPS"); do
-    submit off     0 0 "$r"
-    submit on_raw  1 0 "$r"
-    submit on_trim 1 1 "$r"
+    #      cond        adapters trim keep_short rep
+    submit off        0 0 0 "$r"
+    [[ "$CONTROL" == "1" ]] && submit short_ctrl 0 0 1 "$r"
+    submit on_raw     1 0 0 "$r"
+    submit on_trim    1 1 0 "$r"
 done
 
 echo

--- a/scripts/delta/run_adapter_validation.sh
+++ b/scripts/delta/run_adapter_validation.sh
@@ -46,7 +46,7 @@ submit() {
     jid=$(REFERENCE="$REFERENCE" TOOLS=rneat COVERAGE="$COVERAGE" OUTDIR="$out" \
           SEED="adapter-validation rep$rep" \
           ADAPTERS="$adapters" TRIM="$trim" ADAPTER_PRESET="$ADAPTER_PRESET" \
-          MEASURE_REALISM=1 \
+          MEASURE_REALISM=1 PRUNE="${PRUNE:-1}" \
           sbatch --parsable "$REPO_ROOT/scripts/delta/germline_e2e.sbatch")
     echo "$cond $rep $jid $out $REFERENCE $ADAPTER_PRESET" | tee -a "$MANIFEST"
 }

--- a/scripts/delta/run_adapter_validation.sh
+++ b/scripts/delta/run_adapter_validation.sh
@@ -32,6 +32,16 @@ REFERENCE="${REFERENCE:-$SCRATCH/neat_data/chr22.fa}"
 COVERAGE="${COVERAGE:-30}"
 REPS="${REPS:-3}"
 ADAPTER_PRESET="${ADAPTER_PRESET:-truseq}"
+# SHORT-INSERT library — REQUIRED for this test to mean anything. 3' adapter
+# readthrough only occurs when the insert is shorter than the read length
+# (generate_fragments.rs:76 keeps frag < read_len only when adapters=1), so with
+# the germline default FRAG_MEAN=350 >> read_len=151 NO readthrough ever happens
+# and off/on_raw/on_trim produce identical reads (the 2026-07-01 null run). At
+# 180±60 with 151 bp reads ~30% of inserts fall below the read length → real
+# readthrough for the `on` arms, while ~63% stay >=161 so the `off` baseline can
+# still fill its fragment pool.
+FRAG_MEAN="${FRAG_MEAN:-180}"
+FRAG_SD="${FRAG_SD:-60}"
 MANIFEST="${MANIFEST:-${RESULTS_DIR:-$HOME}/adapter_validation.manifest}"
 
 [[ -f "$REFERENCE" ]] || { echo "REFERENCE not found: $REFERENCE" >&2; exit 1; }
@@ -46,12 +56,13 @@ submit() {
     jid=$(REFERENCE="$REFERENCE" TOOLS=rneat COVERAGE="$COVERAGE" OUTDIR="$out" \
           SEED="adapter-validation rep$rep" \
           ADAPTERS="$adapters" TRIM="$trim" ADAPTER_PRESET="$ADAPTER_PRESET" \
+          FRAG_MEAN="$FRAG_MEAN" FRAG_SD="$FRAG_SD" \
           MEASURE_REALISM=1 PRUNE="${PRUNE:-1}" LOCAL_STAGE="${LOCAL_STAGE:-1}" \
           sbatch --parsable "$REPO_ROOT/scripts/delta/germline_e2e.sbatch")
     echo "$cond $rep $jid $out $REFERENCE $ADAPTER_PRESET" | tee -a "$MANIFEST"
 }
 
-echo "Adapter validation: ref=$(basename "$REFERENCE") cov=${COVERAGE}x reps=$REPS preset=$ADAPTER_PRESET"
+echo "Adapter validation: ref=$(basename "$REFERENCE") cov=${COVERAGE}x reps=$REPS preset=$ADAPTER_PRESET frag=${FRAG_MEAN}±${FRAG_SD} (short-insert → readthrough active)"
 for r in $(seq 1 "$REPS"); do
     submit off     0 0 "$r"
     submit on_raw  1 0 "$r"

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -89,11 +89,14 @@ if conda env list | grep -q "^${BIOINF_ENV_NAME} "; then
         || conda install -y -n "$BIOINF_ENV_NAME" -c conda-forge mimalloc jemalloc
     conda run -n "$BIOINF_ENV_NAME" which seqkit >/dev/null 2>&1 \
         || conda install -y -n "$BIOINF_ENV_NAME" -c bioconda seqkit
+    # fastp drives the adapter-readthrough QC/trim arm (germline_e2e MEASURE_REALISM/TRIM, #125).
+    conda run -n "$BIOINF_ENV_NAME" which fastp >/dev/null 2>&1 \
+        || conda install -y -n "$BIOINF_ENV_NAME" -c bioconda -c conda-forge fastp
 else
-    echo "[3/4] Creating bioinf conda env (bcftools, bwa-mem2, gatk4, seqkit, mimalloc, jemalloc)..."
+    echo "[3/4] Creating bioinf conda env (bcftools, bwa-mem2, gatk4, seqkit, fastp, mimalloc, jemalloc)..."
     conda create -y -n "$BIOINF_ENV_NAME" \
         -c bioconda -c conda-forge \
-        bcftools bwa-mem2 gatk4 seqkit mimalloc jemalloc
+        bcftools bwa-mem2 gatk4 seqkit fastp mimalloc jemalloc
     echo "      Tools installed:"
     # `|| true`: head -1 closes the pipe after one line, so the tool gets
     # SIGPIPE (exit 141) and `set -o pipefail` would otherwise abort setup.


### PR DESCRIPTION
Release **rneat v1.19.0** (develop → main). Workspace bumped 1.18.0 → 1.19.0; CHANGELOG v1.19.0 finalized.

Minor release: adds a new backward-compatible feature (**default off**, output byte-identical to v1.18.0 when unused), plus a correctness fix and validation surfaced while building it.

## Headline: optional 3′ adapter readthrough (#125)
Short-insert reads are padded at their 3′ end with adapter sequence, matching real Illumina data and exercising downstream adapter-trim QC. `adapters: {enabled, preset: truseq|nextera|custom, r1, r2}`. Sibling flag `keep_short_fragments` keeps short inserts as genomic reads without adapters.

## Correctness fix (found by the validation)
The adapter path emitted a **malformed FASTQ record** (quality one char longer than the sequence) for zero-length inserts — invisible to `zcat`/`wc` but bwa-mem2 halts at the first such record, silently truncating alignment. Fixed + regression-tested. Never shipped (the feature is new), so this ships as part of the feature.

## Validated on Delta (chr22, 30×, TruSeq, 3 reps/arm)
Four-arm matrix isolating the adapter effect from the short-insert coverage effect. Result: adapter readthrough is **detectable and fully callable** — GATK SNP/indel fidelity unchanged (within replication noise) whether adapters are fastp-trimmed or left for BWA-MEM2 to soft-clip; the only difference vs a long-insert baseline is the reduced effective coverage of short inserts (present with adapters absent). Full write-up in `docs/access_report_draft.md` §3.11 (and §3.5 defect table).

## Also in this release
- Delta harness: 4-arm `run_adapter_validation.sh` + contrast-based collector; node-local staging (Lustre-OST-drop immune) and fastp thread cap in `germline_e2e.sbatch`.
- README: "3′ Adapter Readthrough" section (config, presets, use cases, validated behavior).

## After merge
Tag `v1.19.0` on main; then bump the in-repo conda recipe with the release sha256 (separate follow-up, per prior releases).

closes #125 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
