### PR TITLE
test(delta): regression-gate the adapter seam (#125)

### DIFF
--- a/docs/regression_protocol.md
+++ b/docs/regression_protocol.md
@@ -79,14 +79,44 @@ Adapters add read-level sequence (3′ adapter readthrough, etc.). Two question 
   no-adapter baseline within 2 sd. Adapters that survive trimming and corrupt
   calls would show up here.
 
-**New-feature checks (adapter-specific, added to Tier 0/1):**
-- Adapters present in raw reads at the configured rate and 3′ position
-  (cutadapt detection count ≈ expected).
-- A standard trimmer recovers the pre-adapter read set (read count + base-level).
-- No adapter bases leak into the aligned, properly soft-clipped fraction.
+**New-feature checks (adapter-specific) — built as a Tier-2 seam:**
+`run_adapter_validation.sh` (CONTROL=1) runs a four-arm matrix that isolates the
+adapter effect from the short-insert coverage effect (`off` rejects short inserts,
+so a naïve off-vs-on comparison is confounded):
 
-**Tier plan for adapters:** Tier 0 on every commit (incl. the adapter-presence
-check), Tier 1 on the PR; Tier 2 only if the same change also touches SVs.
+| arm | inserts | adapter |
+|---|---|---|
+| `off` | long (short rejected) | none — baseline |
+| `short_ctrl` | short (kept) | none — genomic reads (`keep_short_fragments`) |
+| `on_raw` | short | readthrough, aligned raw |
+| `on_trim` | short | readthrough, fastp-trimmed |
+
+The callability check rests on the **adapter-only contrasts** (`on_trim − short_ctrl`,
+`on_raw − on_trim`), not the confounded off-vs-on. `collect_adapter_validation.sh`
+with `CANDIDATE_TSV=…` emits `adapter_*` metrics that `regression_gate.sh` checks
+against the `adapter_*` rows in `baseline_metrics.tsv` — gating callability (recall
+stays high → catches a malformed-FASTQ/collapse regression), readthrough presence
+(`on_raw` soft-clip elevated), trim recovery, and the null adapter effect.
+
+```bash
+# after the 12 jobs finish:
+CANDIDATE_TSV=$RESULTS_DIR/adapter_candidate.tsv \
+  bash scripts/delta/collect_adapter_validation.sh $RESULTS_DIR/adapter_validation.manifest
+bash scripts/delta/regression_gate.sh scripts/delta/baseline_metrics.tsv \
+  $RESULTS_DIR/adapter_candidate.tsv 2
+```
+
+**Result (#125):** adapter readthrough is detectable and fully callable — the pure
+adapter effect is within replication noise; the only fidelity difference vs the
+long-insert baseline is the short-insert coverage effect, present with adapters
+entirely absent (`short_ctrl`). **Lesson:** the collapse bug that motivated this
+seam (a malformed FASTQ record) was invisible to `zcat`/`wc` read counts and only
+surfaced through a real aligner — so the gate keys on *aligned/called* metrics, not
+read counts.
+
+**Tier plan for adapters:** Tier 0/1 (default path, adapters off) on every commit /
+PR; run the Tier-2 adapter seam above when the change touches the adapter or
+fragment-generation code, or pre-release.
 
 ## Baseline management
 

--- a/scripts/delta/baseline_metrics.tsv
+++ b/scripts/delta/baseline_metrics.tsv
@@ -25,3 +25,15 @@ somatic_indel_recall	0.900	0.050	ge2sd	1
 sv_del_recall	0.843	0.106	ge2sd	2
 sv_dup_recall	0.853	0.111	ge2sd	2
 sv_inv_recall	0.916	0.092	ge2sd	2
+# Adapter readthrough seam (#125), from the 4-arm validation (chr22 30x TruSeq, run 6).
+# Checked via: run_adapter_validation.sh (CONTROL=1) -> collect_adapter_validation.sh
+# with CANDIDATE_TSV set -> regression_gate.sh. Gates callability (recall stays high →
+# catches a malformed-FASTQ/collapse regression), readthrough presence (on_raw soft-clip
+# elevated), trim recovery (on_trim soft-clip back to baseline), and the null adapter
+# effect (on_trim − short_ctrl ≈ 0).
+adapter_on_raw_snp_recall	0.9442	0.0012	ge2sd	2
+adapter_on_trim_snp_recall	0.9444	0.0013	ge2sd	2
+adapter_on_trim_indel_recall	0.9302	0.0044	ge2sd	2
+adapter_on_raw_softclip_frac	0.0804	0.0045	band:0.05:0.11	2
+adapter_on_trim_softclip_frac	0.0006	0.0002	band:0.0:0.004	2
+adapter_effect_snp_recall_delta	0.0003	0.0018	band:-0.006:0.006	2

--- a/scripts/delta/collect_adapter_validation.sh
+++ b/scripts/delta/collect_adapter_validation.sh
@@ -310,6 +310,31 @@ if missing:
         w(f"- {m}")
     w()
 
+# ── 7. optional candidate TSV for regression_gate.sh (CANDIDATE_TSV env) ─────
+# Emits metric<TAB>value rows matching the adapter_* baseline in baseline_metrics.tsv,
+# so the adapter seam plugs into the same gate as the rest of the regression suite.
+cand_path = os.environ.get("CANDIDATE_TSV", "")
+if cand_path:
+    def mean_of(cond, metric):
+        m, _sd, n = stats(data.get(cond, {}).get(metric, []))
+        return m if n else None
+    crows = []
+    def put(name, val, prec=4):
+        if val is not None and val == val:
+            crows.append(f"{name}\t{val:.{prec}f}")
+    put("adapter_on_raw_snp_recall",    mean_of("on_raw", "snp_recall"))
+    put("adapter_on_trim_snp_recall",   mean_of("on_trim", "snp_recall"))
+    put("adapter_on_trim_indel_recall", mean_of("on_trim", "indel_recall"))
+    put("adapter_on_raw_softclip_frac", mean_of("on_raw", "softclip_frac"))
+    put("adapter_on_trim_softclip_frac", mean_of("on_trim", "softclip_frac"))
+    ot, sc = mean_of("on_trim", "snp_recall"), mean_of("short_ctrl", "snp_recall")
+    if ot is not None and sc is not None:
+        put("adapter_effect_snp_recall_delta", ot - sc)
+    with open(cand_path, "w") as fh:
+        fh.write("# adapter seam candidate metrics (collect_adapter_validation.sh)\n")
+        fh.write("\n".join(crows) + "\n")
+    sys.stderr.write(f"[wrote candidate] {cand_path}  ({len(crows)} metrics)\n")
+
 report = "\n".join(L) + "\n"
 with open(out_path, "w") as fh:
     fh.write(report)


### PR DESCRIPTION
Adds the adapter readthrough path to the regression baseline so future changes are gated on it (not just the default path).

- `baseline_metrics.tsv`: 6 `adapter_*` rows (tier 2) from the 4-arm validation — callability, readthrough presence, trim recovery, null adapter effect.
- `collect_adapter_validation.sh`: `CANDIDATE_TSV=…` emits `adapter_*` metrics for `regression_gate.sh`.
- `regression_protocol.md`: worked example updated to the built 4-arm seam + gate command.

Verified locally: gate PASSes on the validated numbers and FAILs on a simulated recall-collapse / readthrough-off — i.e. it would have auto-caught this cycle's zero-insert bug.

Follow-up to the v1.19.0 release (#337); test infra only, no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)