### PR TITLE
chore(conda-recipe): bump in-repo recipe to v1.19.0 + sha256

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.18.0" %}
+{% set version = "1.19.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: b2258f5cb38ad99cf8eca8dc571f18751ee42006520dc4a01e8fa2cf1ee9f01e
+  sha256: 1419fe83570fc393779d0642fce103e234244c968821930914dc36094b9755e0
 
 build:
   number: 0


### PR DESCRIPTION
Points the in-repo conda recipe at the released v1.19.0 tag tarball and updates the sha256 (`1419fe83…`, from `curl -sL .../v1.19.0.tar.gz | sha256sum`). Build number stays 0. Mirrors the v1.18.0 recipe bump (#334); open now that #337 has merged v1.19.0 to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)