### PR TITLE
fix(logging): default .neat.log to info + drop per-base debug logs (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+Unreleased
+==========
+## Unreleased (targeting rneat v1.19.1)
+
+_Version bump + date land with the develop→main release PR._
+
+### Logging / performance
+- **Default `.neat.log` level is now `info`** (was effectively `trace`). The `--log-level`
+  arg carried `default_value("trace")`, which silently overrode the intended `info`
+  default, so every run wrote a trace-level log. On a human-sized reference the per-base
+  trace/debug events produced a multi-GB `.neat.log` and burned most of the wall-clock on
+  log I/O. Pass `--log-level debug`/`trace` to opt into verbosity; a bare `--log-level`
+  now means `debug`. The on-screen log is unchanged (always `info`). This is the likely
+  cause of the ~2× wall-clock seen in the v1.19.0 regression benchmark (#340).
+- Removed the per-base sequencing-error debug logs (`"Creating sequencing error"`,
+  `"Snp error"`, `"Deletion error"`, `"Insertion error"`, `"Generating basic SNP error"`) —
+  constant strings emitted ~once per erroneous base, no diagnostic value.
+- Delta harnesses (`scripts/delta/*`) now pass `--log-level warn` to `gen-reads` so a
+  benchmark/validation run never writes a large log to the shared filesystem.
+
+### Validation / tooling
+- Adapter readthrough is now part of the regression baseline (adapter_* rows in
+  `baseline_metrics.tsv`; `collect_adapter_validation.sh CANDIDATE_TSV=…` feeds
+  `regression_gate.sh`). See #338.
+
+
 7/2/2026
 ========
 ## rneat v1.19.0

--- a/common/src/file_tools/fastq_tools.rs
+++ b/common/src/file_tools/fastq_tools.rs
@@ -508,23 +508,19 @@ pub fn generate_read(
             let score = quality_scores[quality_index];
             let prob = sequencing_error_model.convert_score(score)?;
             if rng.random()? < prob {
-                debug!("Creating sequencing error");
                 let error =
                     sequencing_error_model.generate_sequencing_error(reference_base, rng)?;
                 match error {
                     SequencingErrorType::SnpError(base) => {
-                        debug!("Snp error");
                         single[0] = base;
                     }
                     SequencingErrorType::DeletionError(length) => {
-                        debug!("Deletion error");
                         if seq_index + length < sequence.len() {
                             seq_index += length;
                             deletion_skip = length;
                         }
                     }
                     SequencingErrorType::InsertionError(vec) => {
-                        debug!("Insertion error");
                         ins_buf.clear();
                         ins_buf.push(reference_base);
                         ins_buf.extend(vec);

--- a/common/src/models/sequencing_error_model.rs
+++ b/common/src/models/sequencing_error_model.rs
@@ -10,7 +10,6 @@ use crate::{
         transition_matrix::{TransitionMatrix, TransitionMatrixError},
     },
 };
-use log::debug;
 use serde::{Deserialize, Serialize};
 use std::{io, path::PathBuf};
 use thiserror::Error;
@@ -165,7 +164,6 @@ impl SequencingErrorModel {
         // This is a basic mutation function for starting us off
         // Pick the weights list for the base that was input
         // We will use this simple model for sequence errors ultimately.
-        debug!("Generating basic SNP error");
         let distro = &self.transition_distros[&reference];
         // Now we create a distribution from the weights and sample our choices.
         // We have constructed things such that this will return a valid u8. But

--- a/rneat/src/main.rs
+++ b/rneat/src/main.rs
@@ -122,15 +122,20 @@ fn main() -> Result<(), NeatErrors> {
                 .subcommand_value_name("SUB-COMMAND")
                 .subcommand_help_heading("SUB-COMMANDS")
                 .arg(
-					// This arg controls the amount of stuff shown in the display log.
+					// Verbosity of the WRITTEN .neat.log (WriteLogger). Default info: the
+					// per-base debug/trace events in gen-reads fire ~coverage×read_len×ref_bp
+					// times, so a default-trace run wrote a multi-GB log and burned most of the
+					// wall-clock on log I/O. Pass --log-level debug/trace to opt into verbosity.
+					// The on-screen log is always info. (default_value must agree with the info
+					// fallback below — a default_value of "trace" here silently overrode it.)
                     Arg::new("log_level")
                         .long("log-level")
-                        .help("Sets the log level for the display log.")
+                        .help("Verbosity of the written .neat.log (trace|debug|info|warn|error|off; default info). The on-screen log is always info.")
                         .action(ArgAction::Set)
                         .num_args(0..=1)
                         .value_parser(["trace", "debug", "info", "warn", "error", "off"])
-                        .default_value("trace")
-                        .default_missing_value("trace")
+                        .default_value("info")
+                        .default_missing_value("debug")
                 )
                 .arg(
 					// This arg controls where the log is written. The default is <current_working_dir>/.neat.log

--- a/scripts/delta/baseline_capture.sbatch
+++ b/scripts/delta/baseline_capture.sbatch
@@ -130,14 +130,14 @@ if [[ -f "$DIR_A/${PREFIX}_r1.fastq.gz" && -f "$DIR_A/${PREFIX}.bam" ]]; then
 else
     echo "[1/5] Simulation run A (threads=$THREADS_A, +BAM)..."
     write_cfg "$DIR_A" "$THREADS_A" true
-    "$RNEAT_BIN" gen-reads -c "$DIR_A/sim.yml"
+    "$RNEAT_BIN" --log-level warn gen-reads -c "$DIR_A/sim.yml"
 fi
 if [[ -f "$DIR_B/${PREFIX}_r1.fastq.gz" ]]; then
     echo "[1/5] Run B outputs present — skipping."
 else
     echo "[1/5] Simulation run B (threads=$THREADS_B)..."
     write_cfg "$DIR_B" "$THREADS_B" false
-    "$RNEAT_BIN" gen-reads -c "$DIR_B/sim.yml"
+    "$RNEAT_BIN" --log-level warn gen-reads -c "$DIR_B/sim.yml"
 fi
 
 TRUTH_VCF="$DIR_A/${PREFIX}.vcf.gz"

--- a/scripts/delta/benchmark.sbatch
+++ b/scripts/delta/benchmark.sbatch
@@ -144,7 +144,7 @@ run_one() {
             /usr/bin/time -v -o "$tf" "$NEAT_BIN" read-simulator -c "$cfg" \
                 -o "$run_dir" -p bench > "$log" 2>&1 || ec=$?
         else
-            /usr/bin/time -v -o "$tf" "$RNEAT_BIN" gen-reads -c "$cfg" > "$log" 2>&1 || ec=$?
+            /usr/bin/time -v -o "$tf" "$RNEAT_BIN" --log-level warn gen-reads -c "$cfg" > "$log" 2>&1 || ec=$?
         fi
 
         local parsed wall rss

--- a/scripts/delta/genome_array.sbatch
+++ b/scripts/delta/genome_array.sbatch
@@ -117,7 +117,7 @@ target_bed: $bed
 num_threads: 1
 YAML
     echo "  shard $id start: $(cat "$bed")"
-    /usr/bin/time -v -o "$outdir/time.txt" "$RNEAT_BIN" gen-reads -c "$outdir/sim.yml" \
+    /usr/bin/time -v -o "$outdir/time.txt" "$RNEAT_BIN" --log-level warn gen-reads -c "$outdir/sim.yml" \
         > "$outdir/run.log" 2>&1
 }
 

--- a/scripts/delta/germline_e2e.sbatch
+++ b/scripts/delta/germline_e2e.sbatch
@@ -221,7 +221,7 @@ YAML
         # (Only when ADAPTERS!=1 — adapters.enabled already implies keeping them.)
         echo "keep_short_fragments: true" >> "$wd/sim.yml"
     fi
-    "$RNEAT_BIN" gen-reads -c "$wd/sim.yml"
+    "$RNEAT_BIN" --log-level warn gen-reads -c "$wd/sim.yml"
 }
 
 # NEAT 4: default variant model is already SNP/indel only (no symbolic SVs);

--- a/scripts/delta/run_order_independence.sbatch
+++ b/scripts/delta/run_order_independence.sbatch
@@ -94,7 +94,7 @@ run_rneat() {
         [[ -n "$bed" ]] && echo "target_bed: $bed"
         echo "num_threads: $threads"
     } > "$wd/sim.yml"
-    "$RNEAT_BIN" gen-reads -c "$wd/sim.yml" > "$wd/run.log" 2>&1
+    "$RNEAT_BIN" --log-level warn gen-reads -c "$wd/sim.yml" > "$wd/run.log" 2>&1
     [[ -f "$wd/sample.vcf.gz" ]] || { echo "  no VCF from $wd (see run.log)" >&2; return 1; }
 }
 

--- a/scripts/delta/tune_procs_per_node.sbatch
+++ b/scripts/delta/tune_procs_per_node.sbatch
@@ -88,7 +88,7 @@ rng_seed: ppn $K $i
 num_threads: 1
 YAML
         # /usr/bin/time per process → per-proc elapsed; run in background.
-        ( /usr/bin/time -f '%e' -o "$d/t" "$RNEAT_BIN" gen-reads -c "$d/sim.yml" >/dev/null 2>"$d/log" ) &
+        ( /usr/bin/time -f '%e' -o "$d/t" "$RNEAT_BIN" --log-level warn gen-reads -c "$d/sim.yml" >/dev/null 2>"$d/log" ) &
     done
     wait
     makespan=$(( SECONDS - start ))

--- a/scripts/delta/tune_sweep.sbatch
+++ b/scripts/delta/tune_sweep.sbatch
@@ -114,7 +114,7 @@ YAML
         rm -rf "$run_dir"; mkdir -p "$run_dir"
         tf="$OUTDIR/${label}_t${nt}_r${rep}.time"
         ec=0
-        /usr/bin/time -v -o "$tf" "${pre[@]}" "${envp[@]}" "$RNEAT_BIN" gen-reads -c "$cfg" \
+        /usr/bin/time -v -o "$tf" "${pre[@]}" "${envp[@]}" "$RNEAT_BIN" --log-level warn gen-reads -c "$cfg" \
             >"$run_dir/log" 2>&1 || ec=$?
         parsed=$(parse_time "$tf")
         printf "%s\t%s\t%s\t%s\t%s\t%s\n" "$label" "$nt" "$rep" "${parsed% *}" "${parsed#* }" "$ec" >> "$TSV"


### PR DESCRIPTION
Part 1 of v1.19.1 (with #338). Addresses the ~2× wall-clock from #340.

**Root cause:** `--log-level` had `default_value("trace")`, which silently overrode the intended `info` default just below it — so every run wrote a **trace-level `.neat.log`**. On a human-sized reference the per-base trace/debug events made it multi-GB and spent most of the wall-clock on log I/O (perf harness writes it to Lustre, no node-local staging).

**Changes:**
- `main.rs`: `default_value` trace→**info** (bare `--log-level`→`debug`); accurate help text.
- Removed 5 constant-string per-base sequencing-error debug logs (no diagnostic value).
- `scripts/delta/*`: every `gen-reads` call passes `--log-level warn` so benchmark/validation runs never write a large log to the shared FS.

**Impact:** default off-path output unchanged; a plain run now writes a 33-line/4K info `.neat.log` (was trace/multi-GB). common 345 + rneat 253 tests green.

Closes #340 (pending a Delta re-benchmark to confirm wall-clock recovers). Version bump lands with the v1.19.1 release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)