### PR TITLE
docs(delta): HPC guide + re-freeze protocol + whole-genome & model-builder harnesses

### DIFF
--- a/docs/hpc_guide.md
+++ b/docs/hpc_guide.md
@@ -1,0 +1,284 @@
+# Running rneat on an HPC cluster
+
+This guide is for users who want to run `rneat` at scale — from a bacterial genome
+on one node up to a whole human (or larger) genome across many nodes — on a SLURM
+cluster. It distills what we learned validating rneat on NCSA Delta (see
+`docs/access_report_draft.md` §3.6 for the underlying measurements) into
+cluster-agnostic guidance.
+
+The SLURM scripts referenced here live in `scripts/delta/`. They carry Delta
+specifics (module names, an `--account`, conda env names); adapt those three
+things to your site and the rest is portable.
+
+---
+
+## 1. The one-paragraph mental model
+
+rneat is **single-thread efficient and memory-bandwidth-bound**, with **low, flat
+memory**. In-process (rayon) threading is *break-even at best* — a single rneat
+process already saturates a surprising amount of a node's memory bandwidth, so
+adding threads to one process buys little and can even regress. The way to use a
+big machine is therefore **not** "one process, many threads" but **many
+single-threaded processes**, each simulating a different region of the genome,
+spread across nodes. This is *region sharding*, and it is the entire HPC story.
+
+Three practical consequences follow, and the rest of this guide is just their
+detail:
+
+1. **Run one thread per process** (`num_threads: 1`). Pack multiple processes onto
+   a node instead of threading one.
+2. **Run on exclusive nodes.** rneat competes for memory bandwidth; a co-tenant's
+   bandwidth-hungry job on a shared node can inflate an 8-minute window to 170
+   minutes with no warning (measured — see §5).
+3. **Match packing density to node availability**, not to core count. More
+   processes per node ≠ proportionally more throughput past ~2 (the bandwidth
+   ceiling); it just makes each one slower.
+
+---
+
+## 2. Before anything at scale: the log-level footgun
+
+**Set `--log-level info` (the default as of v1.19.1) and never run a large job at
+`debug` or `trace`.**
+
+rneat's per-base `debug!`/`trace!` events fire on the order of
+`coverage × read_length × reference_bp` times. At `trace`, a single chromosome-22
+run wrote a multi-gigabyte `.neat.log` and spent *most of its wall-clock on log
+I/O*. Before v1.19.1 the default was `trace`; if you are on an older build, pass
+`--log-level info` explicitly on every run. On any version, only turn up verbosity
+for a *small* debugging run, never a production one.
+
+```bash
+rneat --log-level info gen-reads -c sim.yml    # good for production
+# rneat --log-level debug ...                  # ONLY on a tiny debugging input
+```
+
+---
+
+## 3. Quickstart: a small genome on one node
+
+For anything that fits comfortably in one node's memory and finishes in a
+reasonable single-process wall-clock (bacteria, fungi, small invertebrates), you
+do not need sharding at all. One single-threaded process:
+
+```yaml
+# sim.yml
+reference: /path/to/genome.fa
+read_len: 151
+coverage: 30
+ploidy: 2
+paired_ended: true
+fragment_mean: 350
+fragment_st_dev: 50
+produce_fastq: true
+produce_vcf: true
+produce_bam: false
+overwrite_output: true
+output_dir: /scratch/$USER/run1
+output_filename: sample
+rng_seed: my run 1
+num_threads: 1
+```
+
+```bash
+#SBATCH --partition=<your-cpu-partition>
+#SBATCH --nodes=1
+#SBATCH --exclusive          # or a generous --cpus-per-task + --mem if you can't get exclusive
+#SBATCH --time=01:00:00
+rneat --log-level info gen-reads -c sim.yml
+```
+
+If you want more throughput on that node, do not raise `num_threads` — instead run
+several of these processes concurrently on different regions (see the sharding
+approach below), or several independent samples at once.
+
+**Memory:** rneat's resident memory is dominated by the reference contigs it loads,
+not by coverage. Reference loading is `target_bed`-aware and loads only the contigs
+a run touches, so peak RSS per process ≈ *the size of the largest contig that
+process simulates* plus a small overhead. Budget accordingly: a 25 Mb window on
+human chr1 still loads all of chr1 (~250 MB); a whole small genome loads all of it.
+
+---
+
+## 4. Whole-genome scale: region-sharded array jobs
+
+The genome is partitioned into contiguous **anchor-windows**. rneat's `target_bed`
+is a *generation-time* filter in absolute reference coordinates that anchors each
+fragment to exactly one window (reads may extend past a window edge; ownership is
+by anchor point), so the union of all shards reconstructs a whole-genome run **with
+no double-counting and no gaps**, and the per-shard outputs **merge by simple
+concatenation**. Each window is one single-threaded rneat process; a SLURM array
+spreads them across nodes.
+
+The tooling (in `scripts/delta/`):
+
+| Script | Role |
+|---|---|
+| `make_shard_beds.sh` | partition `REF.fa.fai` into `shard_NNNN.bed` windows; prints the shard count |
+| `genome_array.sbatch` | SLURM array; each task owns one **exclusive node** and runs `SHARDS_PER_NODE` windows on it concurrently. Idempotent + `--requeue`. |
+| `run_genome_reps.sh` | driver: sweep packing density `K` and/or run replicates with distinct seeds |
+| `aggregate_reps.sh` | fold rep manifests into mean ± sd wall-clock tables |
+| `merge_shards.sh` | concatenate per-shard FASTQ + `bcftools concat|sort` the truth VCF into one dataset |
+
+**Do a fail-fast smoke test first** (see §7) so you never commit a big node
+request to a config that dies in the first shard.
+
+Then the full run:
+
+```bash
+# 1. index + partition (25 Mb windows → ~124 shards for GRCh38 primary assembly)
+samtools faidx REF.fa
+N=$(bash scripts/delta/make_shard_beds.sh REF.fa.fai 25000000 $SCRATCH/shards)
+
+# 2. choose packing density K and derive node-tasks
+K=8; T=$(( (N + K - 1) / K ))
+
+# 3. submit the exclusive-node array (%20 caps concurrent nodes — tune to availability)
+SHARD_DIR=$SCRATCH/shards OUTROOT=$SCRATCH/wg_run REFERENCE=REF.fa SHARDS_PER_NODE=$K \
+  sbatch --array=0-$((T-1))%20 scripts/delta/genome_array.sbatch
+
+# 4. after the array finishes, merge (on a compute node — it's I/O-heavy)
+SHARD_OUTROOT=$SCRATCH/wg_run sbatch scripts/delta/merge_shards.sh
+```
+
+For a **simulation-only timing** run (no downstream alignment/calling — the number
+users actually want to plan around) this is the whole job: steps 1–3 produce the
+FASTQ + truth VCF and the array's `time.txt` files hold the per-window wall-clock.
+
+---
+
+## 5. Choosing packing density (K) and whether to request a reservation
+
+This is the one genuinely non-obvious decision, and it is driven by three
+trade-offs we measured on GRCh38 (306 × 25 Mb shards):
+
+- **Bandwidth saturates by K≈2.** A 25 Mb human window runs in ~8 min alone (K=1),
+  **29 min at K=2, and 101 min at K=4** on the same node — superlinear slowdown.
+  Packing more shards per node does *not* raise node throughput past ~2; it only
+  makes each shard slower.
+- **Low-K-many-nodes is the fastest compute but the hardest to schedule.**
+  `--exclusive` claims a whole node even for a 1-core task, so minimizing
+  wall-clock means grabbing dozens of whole nodes at once — which queues behind
+  everyone on a busy cluster.
+- **A tight per-task walltime is harmful once you're exclusive.** It silently kills
+  legitimately-slow packed windows. Use a *generous* walltime + `--requeue`
+  (`genome_array.sbatch` already does; `run_genome_reps.sh` sizes it `30 + 20K` min).
+
+Measured whole-genome results (each run complete, 306/306 shards):
+
+| Configuration | Whole-genome wall | Heaviest window | Notes |
+|---|---|---|---|
+| Shared partition (16-core slice) | 3 h 41 m | **170 min** | contention-bound, irreproducible — avoid |
+| Exclusive, **K=2** | **2 h 30 m** | 29 min | ~30 nodes in waves; beat shared on every axis |
+| Exclusive, **K=4** | 12 h 32 m | 101 min | slow = *scheduling* (only ~10 nodes free), not compute |
+
+**Rule of thumb:**
+
+- **Cluster busy, no reservation, and you can wait:** exclusive, **K=8–16**. Fewer
+  whole-node grabs schedule sooner; each shard is slower but you're not paying for
+  idle cores and the run completes unattended. This is the pragmatic default.
+- **Cluster idle or you hold a reservation:** exclusive, **K=1–2** across as many
+  nodes as you can get. This is the ~30-min compute floor — a whole human genome at
+  30× in a single ~29-min wave when ~150 nodes are actually available.
+
+**Do you need a reservation?** For most work, **no.** A reservation only buys the
+low-K compute floor (the "30-minute genome" headline). If you have no hard
+deadline and are fine letting a moderate-K run schedule and complete on its own
+time, skip the reservation and run K=8–16 exclusive. Request a reservation only
+when you specifically need many whole nodes *simultaneously* — i.e. you are chasing
+the minimum wall-clock, not just a finished dataset.
+
+**Cost intuition (SLURM node-hours):** a whole-genome 30× simulation is *cheap* —
+on the order of tens of node-hours of actual compute (each 25 Mb window is
+minutes). The binding constraint at scale is **per-run wall-clock and node
+availability, not accounting credits.** Plan around scheduling, not budget.
+
+---
+
+## 6. Reproducibility scope
+
+rneat is deterministic and parallelism-invariant *where it matters*, with one
+documented boundary:
+
+- **Determinism:** same seed + same reference + same params → byte-identical output.
+- **Thread-invariant:** 1 thread vs N threads → byte-identical. Parallelism never
+  perturbs results.
+- **Shard-order independent + disjoint:** the sharded whole-genome path gives the
+  same merged result regardless of shard completion order, with zero duplicate
+  variants across windows. This is why sharding is safe.
+- **Contig-order sensitive (by design, monolithic runs only):** a single
+  *monolithic* (non-sharded) run consumes one global RNG stream in contig order, so
+  reversing contig order in the FASTA changes the realization (even the variant
+  count). **Consequence:** to reproduce a monolithic run exactly, use the
+  *byte-identical* reference (same contig order), not merely the same genome. The
+  sharded path is immune to this — each shard seeds independently from an
+  absolute-coordinate window. (Tracked as #322: optional per-contig seeding to make
+  even monolithic output contig-order-independent.)
+
+Practical guidance: **for reproducible large runs, prefer the sharded path and
+record your seed(s) + the exact reference file** (or its checksum).
+
+---
+
+## 7. Fail-fast before you commit big node requests
+
+A large array that dies on a bad config or a malformed-output bug wastes both your
+time and your queue priority. Two cheap guards:
+
+1. **Smoke-test one window first.** `scripts/delta/wg_smoke.sh` runs a single small
+   window as a normal (non-exclusive, few-minute) job and then *validates the output
+   the way a downstream aligner would* — it checks that every FASTQ record has
+   `len(seq) == len(qual)` and that reads and truth variants were actually produced.
+   This is the exact class of defect (a malformed FASTQ that `wc -l` can't see but
+   bwa-mem2 silently truncates on) that cost us a full at-scale run during adapter
+   validation. Run it whenever you change the build, the config, or the reference:
+
+   ```bash
+   REFERENCE=$SCRATCH/neat_data/genome.fa bash scripts/delta/wg_smoke.sh
+   ```
+
+2. **Throttle the first real array** (`--array=...%N` with a small `N`) so a
+   systematic problem surfaces on the first few nodes, not all of them at once.
+
+`genome_array.sbatch` is idempotent (a completed shard is skipped on retry) and
+uses `--requeue`, so a task killed by a sick node reruns elsewhere and only the
+unfinished windows in its batch redo — you never lose completed work.
+
+---
+
+## 8. Shared-filesystem hygiene (Lustre / GPFS)
+
+Large simulation runs move a lot of FASTQ/BAM. On a shared parallel filesystem:
+
+- **Stage heavy I/O on node-local disk** (`$SLURM_TMPDIR` / local NVMe) when your
+  site provides it, and copy only the small final artifacts back. A dropped Lustre
+  OST otherwise wedges jobs in uninterruptible I/O wait. (`germline_e2e.sbatch`
+  demonstrates this pattern.)
+- **Keep manifests and bookkeeping on durable storage, never scratch** — scratch can
+  throw transient EIO or hit quota mid-run, and you don't want a driver half-submit
+  because a tiny write failed. (`run_genome_reps.sh` writes its manifest to `$HOME`.)
+- **Prune intermediates.** Whole-genome 30× FASTQ is ~35–40 GB per run; delete BAMs
+  and FASTQ after scoring if you only need the metrics (`PRUNE=1` in the harnesses).
+- **Watch your scratch quota** — on Delta it is a *project* quota, not per-user, so a
+  teammate's data counts against yours.
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Run is far slower than expected, huge `.neat.log` | `--log-level trace/debug` | use `--log-level info` (default ≥ v1.19.1) |
+| Whole-genome wall-clock wildly variable, some windows 10–20× slow | shared-partition co-tenant contention | request `--exclusive` nodes |
+| Array tasks stuck `PD (Resources/Priority)` forever | low-K wants too many whole nodes at once | raise K (8–16), or request a reservation |
+| Packed windows all hit the walltime and finish incomplete | walltime ceiling below packed-window time | raise `--time` (never a tight ceiling once exclusive) |
+| Downstream aligner recovers almost no reads despite full read count | malformed FASTQ record | run `wg_smoke.sh`'s integrity check; upgrade to ≥ v1.19.0 |
+| Can't reproduce a previous run's variants | different reference contig order | use the byte-identical reference; or use the sharded path |
+| Peak RSS higher than expected | a shard's largest contig is large | lower K so fewer big contigs load per node simultaneously |
+
+---
+
+*Measurements in this guide come from the rneat validation campaign on NCSA Delta;
+see `docs/access_report_draft.md` (§3.6 for scaling, §3.10 for reproducibility,
+§3.11 for the malformed-FASTQ story) and `docs/regression_protocol.md` for how the
+performance and fidelity baselines are frozen and gated.*

--- a/docs/regression_protocol.md
+++ b/docs/regression_protocol.md
@@ -126,6 +126,39 @@ fragment-generation code, or pre-release.
 - `regression_gate.sh` diffs the two, applies the gates + tolerances above, prints
   a PASS/FAIL table, and **exits non-zero on any FAIL** (CI / `--dependency`-friendly).
 
+### Re-freezing PERF rows without disturbing fidelity (the v1.19.1 logging fix)
+
+A change can be **output-preserving but performance-changing** — the v1.19.1
+logging fix (#340) is the canonical case. Every Phase-1/2 run used the old default
+log level `trace`, whose per-base debug events fire ~`coverage × read_len ×
+ref_bp` times and burned most of the wall-clock on log I/O; so the frozen
+`*_wall_s` / `*_rss_mb` rows were captured **under that handicap and are now
+stale** (the fixed build is faster). The fix does **not** change output bytes, so
+every fidelity / determinism / recall row stays valid — only the perf rows must be
+re-measured and re-frozen. Two steps:
+
+1. **Prove the change is output-preserving** (before trusting the split above). Run
+   `baseline_capture.sbatch` on the fixed build and compare its `baseline.json`
+   `fastq_md5` / `vcf_records_md5` against a pre-fix run's:
+   ```bash
+   bash scripts/delta/rebaseline_perf.sh --check-identity OLD.json NEW.json
+   ```
+   If this is not `PASS`, the change altered output and the fidelity rows must be
+   re-validated too — it is not a pure perf/logging change.
+
+2. **Re-freeze only the perf rows** from a fresh benchmark on the fixed build:
+   ```bash
+   MODE=submit TIER=0 LABEL=logfix bash scripts/delta/regression_suite.sh   # TIER=1 also re-freezes chr22_*
+   # …when the perf job finishes…
+   MODE=collect MANIFEST=$HOME/regression_logfix.manifest \
+     bash scripts/delta/regression_suite.sh > $HOME/logfix.candidate.tsv
+   bash scripts/delta/rebaseline_perf.sh $HOME/logfix.candidate.tsv          # rewrites *_wall_s / *_rss_mb only
+   ```
+   `rebaseline_perf.sh` touches **only** rows ending in `_wall_s` / `_rss_mb`
+   (preserving their gate + tier), writes a `.bak`, and leaves every other row
+   untouched — so a stray fidelity value in the candidate can never overwrite a
+   fidelity baseline. Commit the result with the fixed build's git SHA.
+
 ## Automation (built)
 
 Three files implement this, thin wrappers over the existing harnesses — no new

--- a/scripts/delta/model_builders.sbatch
+++ b/scripts/delta/model_builders.sbatch
@@ -1,0 +1,220 @@
+#!/bin/bash
+# SLURM job: exercise rneat's MODEL-BUILDER subcommands on REAL, full-size,
+# messy inputs — the half of rneat the read-generation validation never touches.
+#
+# WHY
+#   All Phase-1/2 Delta validation ran gen-reads / gen-cancer-reads against the
+#   BUNDLED models. The builders that a real user runs on THEIR OWN data first —
+#   gen-mut-model, gen-seq-error-model, gen-frag-length-model, gen-gc-bias-model,
+#   gen-bam-models — are only covered by `rneat/tests/model_parity.rs`, which runs
+#   them on FIXED TINY fixtures (a 1.7 kb H1N1 reference, ~50 reads) and checks
+#   byte-parity. That proves the algorithm doesn't drift; it proves NOTHING about
+#   behavior on a 30 GB BAM, a real quality profile, a messy multi-thousand-contig
+#   reference, or a VCF full of odd contigs — exactly where a first-contact user
+#   failure (OOM, panic on an unexpected record, pathological runtime) hides.
+#
+# WHAT THIS DOES
+#   1. Runs each builder for which an input is provided, under `/usr/bin/time -v`
+#      (captures wall-clock + peak RSS — the resource behavior we have no data on).
+#   2. Validates each output model: gzip-decodes, parses as JSON, is non-empty.
+#   3. ROUND-TRIP: feeds the freshly-built models back into gen-reads and validates
+#      the simulated FASTQ the way an aligner would (seq/qual length parity). This
+#      is the real test — it proves a model built from real data is USABLE, not
+#      merely parseable.
+#
+# INPUTS (provide whichever you have; each builder is skipped if its input is unset)
+#   REFERENCE     reference FASTA                (gc-bias, mut-model, round-trip)
+#   INPUT_BAM     a real aligned BAM             (frag-length, gc-bias, bam-models)
+#   INPUT_FASTQ   a real FASTQ(.gz)              (seq-error-model)
+#   INPUT_VCF     a real VCF(.gz) of variants    (mut-model)
+#
+# STRESS-TEST DATA — pick inputs that are big AND messy (see docs discussion):
+#   * a full-size real Illumina BAM (tens of GB, real MAPQ/TLEN/dup/supplementary,
+#     multiple read groups, unmapped reads) — not a toy alignment;
+#   * a messy reference: many contigs / scaffolds, long N runs, IUPAC codes
+#     (a less-vetted non-model organism assembly is ideal — soybean, or a
+#     fragmented draft — precisely the reference that also stresses gen-reads);
+#   * a population/clinical VCF with diverse variant types and contig naming.
+#
+# USAGE
+#   REFERENCE=$SCRATCH/neat_data/genome.fa INPUT_BAM=$SCRATCH/data/real.bam \
+#   INPUT_FASTQ=$SCRATCH/data/real_R1.fastq.gz INPUT_VCF=$SCRATCH/data/real.vcf.gz \
+#     sbatch scripts/delta/model_builders.sbatch
+
+#SBATCH --job-name=rneat-modelbuild
+#SBATCH --partition=cpu
+#SBATCH --account=bhrd-delta-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=128G
+#SBATCH --time=08:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -uo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH + archive_run
+
+REFERENCE="${REFERENCE:-}"
+INPUT_BAM="${INPUT_BAM:-}"
+INPUT_FASTQ="${INPUT_FASTQ:-}"
+INPUT_VCF="${INPUT_VCF:-}"
+OUTDIR="${OUTDIR:-$SCRATCH/modelbuild_$SLURM_JOB_ID}"
+MODELS="$OUTDIR/models"; mkdir -p "$MODELS"
+
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
+RNEAT_BIN="${RNEAT_BIN:-$CARGO_TARGET_DIR/release/rneat}"
+source "$HOME/.cargo/env" 2>/dev/null || true
+module load samtools/1.22-cce19.0.0 2>/dev/null || true
+
+echo "=== rneat model-builder stress test: $SLURM_JOB_ID ==="
+echo "rneat: $("$RNEAT_BIN" --version 2>/dev/null || echo '??')   git: $(git -C "$REPO_ROOT" describe --tags --always --dirty 2>/dev/null || echo '?')"
+echo "ref=$REFERENCE  bam=$INPUT_BAM  fastq=$INPUT_FASTQ  vcf=$INPUT_VCF"
+[[ -x "$RNEAT_BIN" ]] || { echo "rneat binary missing: $RNEAT_BIN" >&2; exit 1; }
+
+SUMMARY="$OUTDIR/summary.tsv"; : > "$SUMMARY"
+overall=0
+
+# Run one builder: name, subcommand, config-body (heredoc content), output model path.
+run_builder() {
+    local name="$1" sub="$2" cfg_body="$3" out="$4"
+    local cfg="$MODELS/$name.yml" tlog="$MODELS/$name.time.txt"
+    printf '%s\n' "$cfg_body" > "$cfg"
+    echo "── $name ($sub) ──"
+    if /usr/bin/time -v -o "$tlog" "$RNEAT_BIN" --log-level info "$sub" -c "$cfg" \
+            > "$MODELS/$name.run.log" 2>&1; then
+        local wall rss
+        wall=$(awk -F': ' '/Elapsed \(wall/{print $2}' "$tlog")
+        rss=$(awk -F': ' '/Maximum resident/{printf "%.0f", $2/1024}' "$tlog")
+        # validate: gzip-decodes to non-empty valid JSON
+        if [[ -f "$out" ]] && zcat "$out" 2>/dev/null | python3 -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+            echo "   PASS  wall=$wall  peakRSS=${rss}MB  -> $out"
+            printf '%s\tPASS\t%s\t%s\n' "$name" "$wall" "${rss}MB" >> "$SUMMARY"
+        else
+            echo "   FAIL  builder exited 0 but output is missing/invalid JSON: $out" >&2
+            printf '%s\tFAIL-OUTPUT\t%s\t%s\n' "$name" "$wall" "${rss}MB" >> "$SUMMARY"; overall=1
+        fi
+    else
+        echo "   FAIL  builder exited non-zero (see $MODELS/$name.run.log):" >&2
+        tail -8 "$MODELS/$name.run.log" >&2
+        printf '%s\tFAIL-RUN\t-\t-\n' "$name" >> "$SUMMARY"; overall=1
+    fi
+}
+
+# ── seq-error-model (FASTQ) ────────────────────────────────────────────────────
+if [[ -n "$INPUT_FASTQ" && -f "$INPUT_FASTQ" ]]; then
+    run_builder seq_error gen-seq-error-model \
+"fastq_file: $INPUT_FASTQ
+output_file: $MODELS/seq_error.json.gz
+overwrite_output: true" "$MODELS/seq_error.json.gz"
+fi
+
+# ── frag-length-model (BAM) ─────────────────────────────────────────────────────
+if [[ -n "$INPUT_BAM" && -f "$INPUT_BAM" ]]; then
+    run_builder frag_length gen-frag-length-model \
+"input_file: $INPUT_BAM
+output_file: $MODELS/frag_length.json.gz
+overwrite_output: true
+min_reads: 100" "$MODELS/frag_length.json.gz"
+fi
+
+# ── gc-bias-model (reference + BAM) ─────────────────────────────────────────────
+if [[ -n "$INPUT_BAM" && -f "$INPUT_BAM" && -n "$REFERENCE" && -f "$REFERENCE" ]]; then
+    run_builder gc_bias gen-gc-bias-model \
+"reference: $REFERENCE
+bam_file: $INPUT_BAM
+output_file: $MODELS/gc_bias.json.gz
+overwrite_output: true
+min_mapq: 20
+bed_file: .
+window_size: 1000
+window_stride: 1000
+min_windows_per_bin: 5" "$MODELS/gc_bias.json.gz"
+fi
+
+# ── mut-model (reference + VCF) ─────────────────────────────────────────────────
+if [[ -n "$INPUT_VCF" && -f "$INPUT_VCF" && -n "$REFERENCE" && -f "$REFERENCE" ]]; then
+    run_builder mut_model gen-mut-model \
+"reference: $REFERENCE
+vcf_file: $INPUT_VCF
+output_file: $MODELS/mut_model.json.gz
+overwrite_output: true
+bed_file: ." "$MODELS/mut_model.json.gz"
+fi
+
+# ── bam-models (unified frag-length + GC in one pass over the BAM) ──────────────
+if [[ -n "$INPUT_BAM" && -f "$INPUT_BAM" && -n "$REFERENCE" && -f "$REFERENCE" ]]; then
+    run_builder bam_models gen-bam-models \
+"bam_file: $INPUT_BAM
+min_mapq: 20
+frag_length:
+  output_file: $MODELS/bam_frag.json.gz
+  overwrite_output: true
+  min_reads: 100
+gc_bias:
+  reference: $REFERENCE
+  output_file: $MODELS/bam_gc.json.gz
+  overwrite_output: true
+  window_size: 1000
+  window_stride: 1000
+  min_windows_per_bin: 5" "$MODELS/bam_gc.json.gz"
+fi
+
+# ── ROUND-TRIP: simulate FROM the freshly-built models, validate the output ─────
+# The real proof: a model built from real data is usable by gen-reads and yields
+# valid reads. Wire in whichever models were built successfully.
+if [[ -n "$REFERENCE" && -f "$REFERENCE" ]] && grep -q 'PASS' "$SUMMARY"; then
+    echo "── round-trip: gen-reads using the built models ──"
+    RT="$OUTDIR/roundtrip"; mkdir -p "$RT"
+    [[ -f "$REFERENCE.fai" ]] || samtools faidx "$REFERENCE"
+    read -r CTG LEN _ < "$REFERENCE.fai"
+    END=$(( 2000000 < LEN ? 2000000 : LEN ))          # one small window is plenty
+    printf '%s\t0\t%d\n' "$CTG" "$END" > "$RT/rt.bed"
+    {
+        echo "reference: $REFERENCE"
+        echo "read_len: 151"
+        echo "coverage: 30"
+        echo "ploidy: 2"
+        echo "paired_ended: true"
+        echo "produce_fastq: true"
+        echo "produce_vcf: true"
+        echo "produce_bam: false"
+        echo "overwrite_output: true"
+        echo "output_dir: $RT"
+        echo "output_filename: rt"
+        echo "rng_seed: rneat modelbuild roundtrip"
+        echo "target_bed: $RT/rt.bed"
+        echo "num_threads: 1"
+        [[ -f "$MODELS/seq_error.json.gz" ]]  && echo "sequence_error_model: $MODELS/seq_error.json.gz"
+        [[ -f "$MODELS/frag_length.json.gz" ]] && echo "fragment_model: $MODELS/frag_length.json.gz"
+        [[ -f "$MODELS/gc_bias.json.gz" ]]    && echo "gc_bias_model: $MODELS/gc_bias.json.gz"
+        [[ -f "$MODELS/mut_model.json.gz" ]]  && echo "mutation_model: $MODELS/mut_model.json.gz"
+    } > "$RT/rt.yml"
+    if "$RNEAT_BIN" --log-level info gen-reads -c "$RT/rt.yml" > "$RT/run.log" 2>&1; then
+        bad=$(zcat "$RT/rt_r1.fastq.gz" 2>/dev/null | awk 'NR%4==2{s=length($0)} NR%4==0{if(length($0)!=s)b++} END{print b+0}')
+        reads=$(( $(zcat "$RT/rt_r1.fastq.gz" 2>/dev/null | wc -l) / 4 ))
+        if [[ "$bad" == "0" && "$reads" -gt 0 ]]; then
+            echo "   PASS  round-trip produced $reads valid read pairs from built models"
+            printf 'roundtrip\tPASS\treads=%s\t-\n' "$reads" >> "$SUMMARY"
+        else
+            echo "   FAIL  round-trip output invalid (bad-length records=$bad reads=$reads)" >&2
+            printf 'roundtrip\tFAIL\treads=%s\tbadlen=%s\n' "$reads" "$bad" >> "$SUMMARY"; overall=1
+        fi
+    else
+        echo "   FAIL  gen-reads from built models exited non-zero (see $RT/run.log):" >&2
+        tail -8 "$RT/run.log" >&2
+        printf 'roundtrip\tFAIL-RUN\t-\t-\n' >> "$SUMMARY"; overall=1
+    fi
+fi
+
+echo
+echo "════════════════════════════════════════════════════════════════"
+echo "Model-builder stress test summary (name / status / wall / peakRSS):"
+column -t -s$'\t' "$SUMMARY" | sed 's/^/  /'
+echo "  artifacts: $OUTDIR"
+echo "  overall: $([ "$overall" -eq 0 ] && echo PASS || echo FAIL)"
+echo "════════════════════════════════════════════════════════════════"
+archive_run modelbuild "$OUTDIR" summary.tsv 2>/dev/null || true
+exit "$overall"

--- a/scripts/delta/rebaseline_perf.sh
+++ b/scripts/delta/rebaseline_perf.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Re-freeze the PERFORMANCE rows of baseline_metrics.tsv from a fresh benchmark
+# run on the CURRENT build — without disturbing the fidelity/determinism rows.
+#
+# WHY THIS EXISTS
+#   The v1.19.1 logging fix (#340) is the motivating case. Every Phase-1/2 Delta
+#   run used the old default log level `trace`, whose per-base debug events fire
+#   ~coverage*read_len*ref_bp times and burned most of the wall-clock on log I/O.
+#   So the frozen `*_wall_s` / `*_rss_mb` baselines were captured UNDER that
+#   handicap and are now stale (too slow). The fix does NOT change output bytes,
+#   so the fidelity/determinism/recall baselines stay valid — only the perf rows
+#   must be re-measured on the fixed build and re-frozen. This script does exactly
+#   that: it rewrites only the `*_wall_s` and `*_rss_mb` rows and leaves every
+#   other row untouched.
+#
+# USAGE
+#   1) Build the fixed binary on Delta and run the perf harness (n=3 median):
+#        bash scripts/delta/setup.sh
+#        MODE=submit TIER=0 LABEL=logfix bash scripts/delta/regression_suite.sh
+#        # (TIER=1 if you also want chr22 perf re-frozen; TIER=0 = ecoli only)
+#   2) When it finishes, collect the candidate metrics:
+#        MODE=collect MANIFEST=$HOME/regression_logfix.manifest \
+#          bash scripts/delta/regression_suite.sh > $HOME/logfix.candidate.tsv
+#   3) Splice the fresh perf rows into the baseline (writes a .bak first):
+#        bash scripts/delta/rebaseline_perf.sh $HOME/logfix.candidate.tsv
+#   4) Review the printed diff, then commit baseline_metrics.tsv with a note that
+#      the perf rows were re-frozen on the fixed build (git SHA / rneat --version).
+#
+# SAFETY CHECK (recommended, separate): confirm the logging fix left OUTPUT
+#   byte-identical. Run baseline_capture.sbatch on the fixed build and compare its
+#   baseline.json `fastq_md5` / `vcf_records_md5` to a pre-fix run's. This script
+#   can diff two such files for you:
+#        bash scripts/delta/rebaseline_perf.sh --check-identity OLD.json NEW.json
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BASELINE="${BASELINE:-$REPO_ROOT/scripts/delta/baseline_metrics.tsv}"
+
+# ── --check-identity mode: assert two baseline.json files agree on output md5 ──
+if [[ "${1:-}" == "--check-identity" ]]; then
+    old="${2:?usage: --check-identity OLD.json NEW.json}"
+    new="${3:?usage: --check-identity OLD.json NEW.json}"
+    get() { grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[0-9a-f]+\"" "$2" | grep -oE '[0-9a-f]{32}' | head -1; }
+    rc=0
+    for key in fastq_md5 vcf_records_md5; do
+        o=$(get "$key" "$old"); n=$(get "$key" "$new")
+        if [[ -n "$o" && "$o" == "$n" ]]; then
+            echo "  $key: IDENTICAL ($o)"
+        else
+            echo "  $key: MISMATCH  old=$o  new=$n" >&2; rc=1
+        fi
+    done
+    if [[ "$rc" -eq 0 ]]; then
+        echo "OUTPUT-IDENTITY: PASS — the change did not alter simulator output."
+    else
+        echo "OUTPUT-IDENTITY: FAIL — the change altered output; this is NOT a pure perf/logging change." >&2
+    fi
+    exit "$rc"
+fi
+
+# ── perf-row splice mode ───────────────────────────────────────────────────────
+CAND="${1:?usage: rebaseline_perf.sh CANDIDATE.tsv   (from regression_suite.sh MODE=collect)}"
+[[ -f "$BASELINE" ]] || { echo "baseline not found: $BASELINE" >&2; exit 1; }
+[[ -f "$CAND" ]]     || { echo "candidate not found: $CAND" >&2; exit 1; }
+
+# A perf metric is any row whose name ends in _wall_s or _rss_mb.
+is_perf() { [[ "$1" == *_wall_s || "$1" == *_rss_mb ]]; }
+
+# Pull the fresh value for a perf metric out of the candidate TSV (col 2).
+cand_val() { awk -F'\t' -v m="$1" '$1==m {print $2; exit}' "$CAND"; }
+
+TMP="$(mktemp)"
+CHANGED=0; MISSING=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # pass through comments / blanks unchanged
+    if [[ "$line" == \#* || -z "${line// }" ]]; then echo "$line" >> "$TMP"; continue; fi
+    IFS=$'\t' read -r metric value sd gate tier <<< "$line"
+    if is_perf "$metric"; then
+        new_val="$(cand_val "$metric")"
+        if [[ -n "$new_val" && "$new_val" != "NA" ]]; then
+            printf '%s\t%s\t%s\t%s\t%s\n' "$metric" "$new_val" "$sd" "$gate" "$tier" >> "$TMP"
+            [[ "$new_val" != "$value" ]] && { echo "  $metric: $value -> $new_val"; CHANGED=$((CHANGED+1)); }
+        else
+            echo "$line" >> "$TMP"                 # no fresh value → keep old, warn
+            MISSING="$MISSING $metric"
+        fi
+    else
+        echo "$line" >> "$TMP"                     # non-perf row: never touch
+    fi
+done < "$BASELINE"
+
+echo
+if [[ -n "$MISSING" ]]; then
+    echo "WARNING: no fresh candidate value for:$MISSING (kept old value)." >&2
+    echo "         (run a TIER that produces these — TIER=1 adds chr22_*.)" >&2
+fi
+if [[ "$CHANGED" -eq 0 ]]; then
+    echo "No perf rows changed — baseline left as-is. (Nothing written.)"
+    rm -f "$TMP"; exit 0
+fi
+cp -p "$BASELINE" "$BASELINE.bak"
+mv "$TMP" "$BASELINE"
+echo
+echo "Re-froze $CHANGED perf row(s) in $BASELINE  (backup: $BASELINE.bak)"
+echo "Fidelity/determinism/recall rows were NOT touched."
+echo "Now: git diff scripts/delta/baseline_metrics.tsv ; commit with the build's git SHA."

--- a/scripts/delta/run_whole_genome.sh
+++ b/scripts/delta/run_whole_genome.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# ONE-COMMAND staged whole-genome simulation on Delta — fail-fast, fire-and-forget.
+#
+# Chains the whole pipeline with SLURM dependencies so a bad build/config/reference
+# dies on a tiny smoke job in minutes instead of wasting a big exclusive-node grab:
+#
+#   [1] smoke   — one small window + FASTQ integrity check (wg_smoke.sh).
+#                 A non-exclusive ~few-minute job. If it FAILS, every downstream
+#                 job is auto-cancelled (afterok) — you never burn nodes on a
+#                 config that produces malformed output (cf. the #125 collapse).
+#   [2] array   — the sharded whole-genome run (genome_array.sbatch), exclusive
+#                 nodes, K windows/node, depends on afterok:[1].
+#   [3] timing  — per-window wall-clock summary (wg_timing_summary.sh), afterany:[2].
+#                 This is the "simulation-only timing" deliverable — throughput
+#                 numbers users can plan around, with NO downstream align/call.
+#   [4] merge   — concatenate shards into one whole-genome FASTQ + truth VCF
+#                 (merge_shards.sh), afterok:[2]. Skip with DO_MERGE=0 for a
+#                 pure timing run.
+#
+# Everything is idempotent + --requeue (genome_array), so a task killed on a sick
+# node reruns elsewhere and only the unfinished windows redo.
+#
+# USAGE (from repo root, after setup.sh has built the binary + staged the reference):
+#   REFERENCE=$SCRATCH/neat_data/GRCh38.fa TAG=hg38 \
+#     bash scripts/delta/run_whole_genome.sh
+#
+#   # bigger/messier genome, smaller shards, timing-only (no merge):
+#   REFERENCE=$SCRATCH/neat_data/soy.fa TAG=soy SHARD_BP=10000000 K=4 DO_MERGE=0 \
+#     bash scripts/delta/run_whole_genome.sh
+#
+# KNOBS (env): REFERENCE TAG SHARD_BP(25M) K(4=shards/node) MAXNODES(20) COVERAGE(30)
+#   READ_LEN(151) FRAG_MEAN(350) FRAG_SD(50) PLOIDY(2) SV_RATE_SCALE(0)
+#   WALL_MINUTES(auto=30+20K) DO_MERGE(1) SKIP_SMOKE(0) OUTROOT(auto)
+#
+# PACKING (K) — see docs/hpc_guide.md §5. rneat is memory-bandwidth-bound, so the
+#   node saturates by K≈2; low K = fastest per-window but wants many whole nodes
+#   (hard to schedule on a busy cluster); high K = slower per-window but schedules
+#   sooner. K=4 is a schedulable default with no deadline; use K=1–2 only with a
+#   reservation / idle cluster. For big/messy genomes lower SHARD_BP so no single
+#   window's wall-clock blows past the per-task walltime.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH + RESULTS_DIR
+D="$REPO_ROOT/scripts/delta"
+
+REFERENCE="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
+TAG="${TAG:-wg}"
+SHARD_BP="${SHARD_BP:-25000000}"
+K="${K:-4}"                       # shards per exclusive node
+MAXNODES="${MAXNODES:-20}"        # concurrent exclusive nodes (%throttle)
+COVERAGE="${COVERAGE:-30}"
+READ_LEN="${READ_LEN:-151}"
+FRAG_MEAN="${FRAG_MEAN:-350}"
+FRAG_SD="${FRAG_SD:-50}"
+PLOIDY="${PLOIDY:-2}"
+SV_RATE_SCALE="${SV_RATE_SCALE:-0}"
+DO_MERGE="${DO_MERGE:-1}"
+SKIP_SMOKE="${SKIP_SMOKE:-0}"
+ACCT="${ACCESS_ACCOUNT:-bhrd-delta-cpu}"
+PART="${PARTITION:-cpu}"
+RD="${RESULTS_DIR:-$HOME}"
+OUTROOT="${OUTROOT:-$SCRATCH/wg_${TAG}}"
+SHARD_DIR="${SHARD_DIR:-$SCRATCH/shards_${TAG}}"
+
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
+RNEAT_BIN="${RNEAT_BIN:-$CARGO_TARGET_DIR/release/rneat}"
+source "$HOME/.cargo/env" 2>/dev/null || true
+module load samtools/1.22-cce19.0.0 2>/dev/null || true
+
+[[ -x "$RNEAT_BIN" ]] || { echo "rneat binary missing: $RNEAT_BIN (run setup.sh)" >&2; exit 1; }
+[[ -f "$REFERENCE" ]] || { echo "reference not found: $REFERENCE" >&2; exit 1; }
+
+# ── prep (login node — light: index + write small BED files) ────────────────────
+[[ -f "$REFERENCE.fai" ]] || { echo "indexing reference..."; samtools faidx "$REFERENCE"; }
+N=$(bash "$D/make_shard_beds.sh" "$REFERENCE.fai" "$SHARD_BP" "$SHARD_DIR")
+[[ "$N" =~ ^[0-9]+$ && "$N" -gt 0 ]] || { echo "make_shard_beds produced no shards" >&2; exit 1; }
+T=$(( (N + K - 1) / K ))                              # node-tasks
+MINUTES="${WALL_MINUTES:-$(( 30 + K * 20 ))}"
+WALL=$(printf '%02d:%02d:00' $(( MINUTES / 60 )) $(( MINUTES % 60 )))
+
+echo "════════════════════════════════════════════════════════════════"
+echo "Whole-genome run '$TAG'"
+echo "  reference : $REFERENCE ($("$RNEAT_BIN" --version 2>/dev/null || echo '?'))"
+echo "  shards    : $N  (${SHARD_BP} bp windows)   packing K=$K -> $T node-tasks"
+echo "  nodes     : up to $MAXNODES concurrent (exclusive)   per-task walltime $WALL"
+echo "  coverage  : ${COVERAGE}x  sv_rate_scale=$SV_RATE_SCALE  ploidy=$PLOIDY"
+echo "  outroot   : $OUTROOT     merge=$DO_MERGE  smoke=$([ "$SKIP_SMOKE" = 1 ] && echo skip || echo yes)"
+echo "════════════════════════════════════════════════════════════════"
+
+# ── [1] smoke — fail-fast gate ──────────────────────────────────────────────────
+DEP=""
+if [[ "$SKIP_SMOKE" != "1" ]]; then
+    smoke_jid=$(sbatch --parsable --job-name="wg-smoke-${TAG}" --account="$ACCT" --partition="$PART" \
+        --nodes=1 --ntasks=1 --cpus-per-task=4 --mem=16G --time=00:30:00 \
+        --output="$RD/wg-smoke_${TAG}_%j.out" \
+        --wrap="cd '$REPO_ROOT' && REFERENCE='$REFERENCE' COVERAGE=$COVERAGE READ_LEN=$READ_LEN \
+                FRAG_MEAN=$FRAG_MEAN FRAG_SD=$FRAG_SD PLOIDY=$PLOIDY SV_RATE_SCALE=$SV_RATE_SCALE \
+                bash scripts/delta/wg_smoke.sh")
+    echo "[1] smoke   -> job $smoke_jid  (gate: downstream runs only afterok)"
+    DEP="--dependency=afterok:$smoke_jid"
+fi
+
+# ── [2] array — the whole-genome sharded run ────────────────────────────────────
+array_jid=$(SHARD_DIR="$SHARD_DIR" OUTROOT="$OUTROOT" REFERENCE="$REFERENCE" \
+    SHARDS_PER_NODE="$K" COVERAGE="$COVERAGE" READ_LEN="$READ_LEN" \
+    FRAG_MEAN="$FRAG_MEAN" FRAG_SD="$FRAG_SD" PLOIDY="$PLOIDY" \
+    SV_RATE_SCALE="$SV_RATE_SCALE" SEED_ROOT="rneat wg ${TAG} shard" \
+    sbatch --parsable $DEP --job-name="wg-array-${TAG}" \
+           --time="$WALL" --array=0-$((T-1))%${MAXNODES} \
+           "$D/genome_array.sbatch")
+echo "[2] array   -> job $array_jid  ($T tasks%$MAXNODES)$([ -n "$DEP" ] && echo '  afterok smoke')"
+
+# ── [3] timing summary — simulation-only throughput (deliverable #5) ────────────
+timing_jid=$(sbatch --parsable --dependency=afterany:"$array_jid" \
+    --job-name="wg-timing-${TAG}" --account="$ACCT" --partition="$PART" \
+    --nodes=1 --ntasks=1 --cpus-per-task=1 --mem=4G --time=00:20:00 \
+    --output="$RD/wg-timing_${TAG}_%j.out" \
+    --wrap="bash '$D/wg_timing_summary.sh' '$OUTROOT' $N")
+echo "[3] timing  -> job $timing_jid  (afterany array)   summary: $RD/wg-timing_${TAG}_${timing_jid}.out"
+
+# ── [4] merge — one whole-genome dataset ────────────────────────────────────────
+if [[ "$DO_MERGE" == "1" ]]; then
+    merge_jid=$(SHARD_OUTROOT="$OUTROOT" EXPECT_SHARDS="$N" \
+        sbatch --parsable --dependency=afterok:"$array_jid" \
+               --job-name="wg-merge-${TAG}" "$D/merge_shards.sh")
+    echo "[4] merge   -> job $merge_jid  (afterok array)   -> $OUTROOT/merged_*"
+else
+    echo "[4] merge   -> skipped (DO_MERGE=0; timing-only run)"
+fi
+
+echo
+echo "Fire-and-forget. Watch: squeue --me"
+echo "If smoke FAILS, the array/merge auto-cancel (DependencyNeverSatisfied) — nothing wasted."

--- a/scripts/delta/wg_smoke.sh
+++ b/scripts/delta/wg_smoke.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# FAIL-FAST smoke test: prove a build + config + reference actually produce VALID
+# output on ONE small window before you commit a big exclusive-node array to it.
+#
+# Runs a single small gen-reads window (a few minutes, one core, no --exclusive)
+# and then validates the output THE WAY A DOWNSTREAM ALIGNER WOULD — most
+# importantly that every FASTQ record has len(seq) == len(qual). That exact defect
+# (a malformed FASTQ that `zcat | wc -l` cannot see, but bwa-mem2 silently
+# truncates on) cost a full at-scale run during adapter validation (#125). This
+# catches it in minutes, for the price of one small window.
+#
+# Run it whenever you change the build, the config knobs, or the reference:
+#   REFERENCE=$SCRATCH/neat_data/GRCh38.fa bash scripts/delta/wg_smoke.sh
+#   REFERENCE=... COVERAGE=30 ADAPTERS=1 WINDOW_BP=2000000 bash scripts/delta/wg_smoke.sh
+#
+# Runnable on a small interactive allocation (salloc/srun --pty) or as the payload
+# of a tiny sbatch. Exits non-zero (loudly) on any problem so you find out now.
+set -uo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH resolution
+
+REFERENCE="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
+WINDOW_BP="${WINDOW_BP:-2000000}"        # size of the single test window
+COVERAGE="${COVERAGE:-30}"
+READ_LEN="${READ_LEN:-151}"
+FRAG_MEAN="${FRAG_MEAN:-350}"
+FRAG_SD="${FRAG_SD:-50}"
+PLOIDY="${PLOIDY:-2}"
+SV_RATE_SCALE="${SV_RATE_SCALE:-0}"
+ADAPTERS="${ADAPTERS:-0}"                # 1 → exercise the 3' adapter readthrough path too
+OUTDIR="${OUTDIR:-$SCRATCH/wg_smoke_$$}"
+
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
+RNEAT_BIN="${RNEAT_BIN:-$CARGO_TARGET_DIR/release/rneat}"
+source "$HOME/.cargo/env" 2>/dev/null || true
+module load samtools/1.22-cce19.0.0 2>/dev/null || true
+
+fail() { echo "SMOKE: FAIL — $*" >&2; exit 1; }
+
+[[ -x "$RNEAT_BIN" ]] || fail "rneat binary not found/executable: $RNEAT_BIN (run setup.sh / cargo build --release)"
+[[ -f "$REFERENCE" ]] || fail "reference not found: $REFERENCE"
+[[ -f "$REFERENCE.fai" ]] || samtools faidx "$REFERENCE" 2>/dev/null || fail "cannot index reference (need samtools)"
+
+echo "=== rneat smoke test ==="
+echo "  binary:    $RNEAT_BIN ($("$RNEAT_BIN" --version 2>/dev/null || echo '??'))"
+echo "  reference: $REFERENCE"
+echo "  window:    first ${WINDOW_BP} bp of the first contig   cov=${COVERAGE}x  adapters=$ADAPTERS"
+
+# One small window on the first contig — the cheapest possible representative run.
+read -r CTG LEN _ < "$REFERENCE.fai"
+END=$(( WINDOW_BP < LEN ? WINDOW_BP : LEN ))
+mkdir -p "$OUTDIR"
+BED="$OUTDIR/smoke.bed"
+printf '%s\t0\t%d\n' "$CTG" "$END" > "$BED"
+
+CFG="$OUTDIR/smoke.yml"
+cat > "$CFG" <<YAML
+reference: $REFERENCE
+read_len: $READ_LEN
+coverage: $COVERAGE
+ploidy: $PLOIDY
+paired_ended: true
+fragment_mean: $FRAG_MEAN
+fragment_st_dev: $FRAG_SD
+produce_fastq: true
+produce_vcf: true
+produce_bam: false
+overwrite_output: true
+output_dir: $OUTDIR
+output_filename: smoke
+rng_seed: rneat smoke $CTG
+sv_rate_scale: $SV_RATE_SCALE
+target_bed: $BED
+num_threads: 1
+YAML
+# Exercise the adapter readthrough path (where the malformed-FASTQ bug lived) when
+# asked. Short inserts (mean < read_len) are what actually trigger 3' readthrough.
+if [[ "$ADAPTERS" == "1" ]]; then
+    cat >> "$CFG" <<YAML
+keep_short_fragments: true
+adapters:
+  enabled: true
+  preset: truseq
+YAML
+    # re-point the fragment size short so readthrough fires (overrides above)
+    sed -i 's/^fragment_mean:.*/fragment_mean: 120/; s/^fragment_st_dev:.*/fragment_st_dev: 60/' "$CFG"
+fi
+
+echo "  running gen-reads (log-level info)..."
+if ! "$RNEAT_BIN" --log-level info gen-reads -c "$CFG" > "$OUTDIR/run.log" 2>&1; then
+    tail -20 "$OUTDIR/run.log" >&2
+    fail "gen-reads exited non-zero (see $OUTDIR/run.log)"
+fi
+
+R1="$OUTDIR/smoke_r1.fastq.gz"; R2="$OUTDIR/smoke_r2.fastq.gz"; VCF="$OUTDIR/smoke.vcf.gz"
+[[ -f "$R1" && -f "$R2" ]] || fail "expected FASTQ not produced ($R1 / $R2)"
+[[ -f "$VCF" ]] || fail "expected truth VCF not produced ($VCF)"
+
+# ── The critical check: seq/qual length parity on EVERY record ──────────────────
+# (a too-long qual line is the malformed-FASTQ signature; 4-line count stays intact
+#  so wc can't see it, but an aligner stops at the first offending record.)
+check_fastq() {
+    local f="$1" label="$2"
+    zcat "$f" | awk -v L="$label" '
+        NR%4==1 { if ($0 !~ /^@/) { print "  "L": record "int(NR/4)+1" header missing @" > "/dev/stderr"; bad++ } }
+        NR%4==2 { s=length($0) }
+        NR%4==0 { q=length($0); recs++; if (q!=s) { badlen++; if (badlen<=3) printf "  %s: record %d seq=%d qual=%d\n", L, recs, s, q > "/dev/stderr" } }
+        END {
+            printf "  %s: %d records, %d bad-length, %d bad-header\n", L, recs, badlen+0, bad+0
+            if (recs==0)   { print "ZERO_RECORDS" }
+            else if (badlen>0 || bad>0) { print "MALFORMED" }
+            else           { print "OK" }
+        }'
+}
+echo "  validating FASTQ record integrity..."
+v1=$(check_fastq "$R1" R1); s1=$(echo "$v1" | tail -1); echo "$v1" | sed '$d'
+v2=$(check_fastq "$R2" R2); s2=$(echo "$v2" | tail -1); echo "$v2" | sed '$d'
+[[ "$s1" == "OK" && "$s2" == "OK" ]] || fail "FASTQ integrity check failed (R1=$s1 R2=$s2) — DO NOT run this config at scale"
+
+# ── Sanity: reads and truth variants actually exist ─────────────────────────────
+n_reads=$(( $(zcat "$R1" | wc -l) / 4 ))
+n_vars=$(zcat "$VCF" | grep -vc '^#' || true)
+(( n_reads > 0 )) || fail "zero read pairs produced"
+(( n_vars  > 0 )) || echo "  NOTE: 0 truth variants in this small window (can be legitimate for a low-mutation region)"
+echo "  reads=$n_reads pairs   truth variants=$n_vars"
+
+echo
+echo "════════════════════════════════════════════════════════════════"
+echo "SMOKE: PASS — build+config+reference produce valid output."
+echo "  Safe to scale up (make_shard_beds.sh + genome_array.sbatch)."
+echo "  Artifacts: $OUTDIR   (rm -rf when done)"
+echo "════════════════════════════════════════════════════════════════"

--- a/scripts/delta/wg_timing_summary.sh
+++ b/scripts/delta/wg_timing_summary.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Summarize per-window wall-clock for a sharded whole-genome run — the
+# "simulation-only timing" number (no downstream align/call). Reads the
+# /usr/bin/time -v `time.txt` each shard writes under SHARD_OUTROOT.
+#
+#   bash scripts/delta/wg_timing_summary.sh SHARD_OUTROOT [EXPECT_SHARDS]
+#
+# Prints: completeness, per-window min/median/mean/max, total compute (sum of
+# window wall-clocks = the single-core work), and the heaviest few windows with
+# their region (the tail that sets the per-task walltime).
+set -uo pipefail
+
+OUTROOT="${1:?usage: wg_timing_summary.sh SHARD_OUTROOT [EXPECT_SHARDS]}"
+EXPECT="${2:-}"
+[[ -d "$OUTROOT" ]] || { echo "not a directory: $OUTROOT" >&2; exit 1; }
+
+mapfile -t DIRS < <(find "$OUTROOT" -maxdepth 1 -type d -name 'shard_*' | sort)
+n_dirs=${#DIRS[@]}
+complete=0
+TMP="$(mktemp)"                         # rows: seconds<TAB>shard<TAB>region
+for d in "${DIRS[@]}"; do
+    sh=$(basename "$d")
+    [[ -f "$d/s_r1.fastq.gz" && -f "$d/s.vcf.gz" ]] && complete=$(( complete + 1 ))
+    t="$d/time.txt"; [[ -f "$t" ]] || continue
+    el=$(awk -F': ' '/Elapsed \(wall clock\)/{print $NF}' "$t")
+    [[ -n "$el" ]] || continue
+    region=$(cat "$d"/*.bed 2>/dev/null | head -1 | tr '\t' ':')
+    awk -v e="$el" -v s="$sh" -v r="$region" '
+        BEGIN{ n=split(e,a,":"); sec=(n==3)?a[1]*3600+a[2]*60+a[3]:(n==2)?a[1]*60+a[2]:a[1];
+               printf "%.1f\t%s\t%s\n", sec, s, r }' >> "$TMP"
+done
+
+echo "════════════════════════════════════════════════════════════════"
+echo "Whole-genome simulation timing — $OUTROOT"
+echo "  shards found: $n_dirs   complete (FASTQ+VCF): $complete${EXPECT:+ / $EXPECT expected}"
+if [[ -n "$EXPECT" && "$complete" -ne "$EXPECT" ]]; then
+    echo "  WARNING: $(( EXPECT - complete )) shard(s) incomplete — rerun the array before merging." >&2
+fi
+
+if [[ -s "$TMP" ]]; then
+    sort -n "$TMP" | awk -F'\t' '
+        { v[NR]=$1; sum+=$1; sh[NR]=$2; rg[NR]=$3 }
+        END{
+            n=NR; if(n==0) exit
+            med=(n%2)?v[(n+1)/2]:(v[n/2]+v[n/2+1])/2
+            printf "  windows timed : %d\n", n
+            printf "  per-window sec: min=%.1f  median=%.1f  mean=%.1f  max=%.1f\n", v[1], med, sum/n, v[n]
+            printf "  total compute : %.1f core-sec  (%.2f core-hours, single-core sum)\n", sum, sum/3600
+            print  "  heaviest windows (set the per-task walltime):"
+            for(i=n; i>n-5 && i>=1; i--) printf "     %8.1fs  %s  %s\n", v[i], sh[i], rg[i]
+        }'
+else
+    echo "  (no time.txt files found — was the array run with /usr/bin/time?)"
+fi
+echo "════════════════════════════════════════════════════════════════"
+rm -f "$TMP"


### PR DESCRIPTION
Additive verification tooling from the v1.19.1 work. **No Rust code touched; default behavior unchanged.** `gitnexus detect_changes`: 0 execution flows affected (docs + bash only).

## Docs
- **`docs/hpc_guide.md`** (new) — cluster-agnostic guide to running rneat at scale: the memory-bandwidth / multi-process sharding model, the `--log-level` footgun, the region-sharded whole-genome workflow, packing-density (K) & reservation guidance with the measured §3.6 tables, reproducibility scope (#322), filesystem hygiene, troubleshooting.
- **`docs/regression_protocol.md`** — adds a section on re-freezing perf rows *without* disturbing fidelity (the v1.19.1 logging-fix case), plus a `--check-identity` output-preservation check.

## Delta harnesses
| script | role |
|---|---|
| `rebaseline_perf.sh` | splice `*_wall_s`/`*_rss_mb` into the baseline; `--check-identity` mode (used for the #342 re-freeze) |
| `wg_smoke.sh` | fail-fast single-window FASTQ integrity check — guards the #125 malformed-FASTQ class before big node grabs |
| `run_whole_genome.sh` | one-command staged driver: smoke → array → timing → merge, dependency-chained so a smoke failure auto-cancels the rest |
| `wg_timing_summary.sh` | per-window simulation-only wall-clock summary (deliverable #5) |
| `model_builders.sbatch` | run all 5 model builders on real inputs + round-trip the built models through gen-reads (previously only covered on tiny fixtures by `rneat/tests/model_parity.rs`) |

The two docs reference these scripts, so they ship together to avoid dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)