### PR TITLE
ci(delta): run NEAT at WARNING in the benchmark (equal-to-equal logging)

### DIFF
--- a/scripts/delta/benchmark.sbatch
+++ b/scripts/delta/benchmark.sbatch
@@ -141,7 +141,11 @@ run_one() {
         # bad config is recorded (exit!=0) rather than killing the job.
         local ec=0
         if [[ "$tool" == "neat" ]]; then
-            /usr/bin/time -v -o "$tf" "$NEAT_BIN" read-simulator -c "$cfg" \
+            # Match rneat's minimal logging (WARNING) for an equal-to-equal comparison —
+            # NEAT defaults to INFO. NEAT has no per-read logging (its hot-loop debug
+            # lines are commented out), so this barely changes its time; it just makes
+            # both tools rigorously symmetric on log verbosity.
+            /usr/bin/time -v -o "$tf" "$NEAT_BIN" --log-level WARNING read-simulator -c "$cfg" \
                 -o "$run_dir" -p bench > "$log" 2>&1 || ec=$?
         else
             /usr/bin/time -v -o "$tf" "$RNEAT_BIN" --log-level warn gen-reads -c "$cfg" > "$log" 2>&1 || ec=$?


### PR DESCRIPTION
Makes the §3.2 head-to-head symmetric on logging. rneat already ran at `--log-level warn`; NEAT ran at its default `INFO`. This passes NEAT `--log-level WARNING` so both tools are at minimal verbosity.

**Impact on numbers: negligible.** NEAT's per-read hot-loop debug lines are commented out, so its INFO logging is only a few per-contig/thread lines — not the per-base I/O that inflated old rneat. This is a methodology-integrity change, not a correctness fix: it removes any "but NEAT was logging more" objection to the ~9–12× speedup.

`gitnexus detect_changes`: 0 execution flows (bash only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)