### PR TITLE
fix(delta): correct shard-packing defaults to the fixed-build optimum

### DIFF
--- a/scripts/delta/genome_array.sbatch
+++ b/scripts/delta/genome_array.sbatch
@@ -5,20 +5,20 @@
 # SHARDS_PER_NODE windows on it concurrently, one single-threaded rneat process
 # per window. This is the key to predictable performance on Delta:
 #
-#   rneat is memory-bandwidth-bound. On the SHARED `cpu` partition, a per-shard
-#   16-cpu slice lands our process on a node alongside other tenants' jobs, and
-#   they steal the memory bandwidth rneat needs — we measured 8-min windows
-#   blowing out to 100-170 min (10-20x) purely from co-tenant contention, with
-#   a bimodal time distribution (median ~2.5 min, p90 ~131 min) that made the
-#   whole-genome wall-clock unreproducible (one run: 3h41m, almost all of it
-#   stragglers on contended nodes).
+#   Use the SHARED `cpu` partition and a per-shard core slice lands our process
+#   alongside other tenants' jobs; they steal memory bandwidth and make per-window
+#   time (and thus the whole-genome wall-clock) unpredictable. So we take whole
+#   nodes with --exclusive: the only contention is our own SHARDS_PER_NODE
+#   processes, which is controllable and reproducible.
 #
-#   --exclusive removes the strangers: we hold the entire node, so the ONLY
-#   contention is our own SHARDS_PER_NODE processes competing for the node's
-#   bandwidth — and that is controllable and reproducible. The procs-per-node
-#   sweep put the efficient zone at <=8 procs/node (>=29% per-proc efficiency);
-#   raise SHARDS_PER_NODE for more per-node throughput (fewer nodes, cheaper),
-#   lower it for faster per-shard (more nodes, faster wall-clock).
+#   Packing density: the procs-per-node sweep on the FIXED build (v1.19.1, #340 —
+#   the earlier "efficient zone <=8" number was an artifact of per-process trace-log
+#   I/O, since corrected) shows K independent single-thread processes pack
+#   NEAR-LINEARLY — ~99% per-process efficiency to 64/node on a real 25 Mb window,
+#   dropping to ~75% at 128 (hyperthread oversubscription). So the default is 64
+#   (one per physical core): whole human genome = 306 windows -> ~5 node-tasks.
+#   Use 128 for the fewest nodes (~75% eff), or lower K if a genome's largest contig
+#   is big and RAM is tight (peak RSS/node ~= K * largest-contig-loaded).
 #
 # Reads/variants come out in absolute genome coordinates (target_bed is a
 # generation-time filter), so merge_shards.sh concatenates the per-shard outputs
@@ -27,7 +27,7 @@
 # Workflow:
 #   samtools faidx REF.fa
 #   N=$(bash scripts/delta/make_shard_beds.sh REF.fa.fai 25000000 $SCRATCH/shards)
-#   K=8; T=$(( (N + K - 1) / K ))          # node-tasks = ceil(N / SHARDS_PER_NODE)
+#   K=64; T=$(( (N + K - 1) / K ))         # node-tasks = ceil(N / SHARDS_PER_NODE)
 #   SHARD_DIR=$SCRATCH/shards OUTROOT=$SCRATCH/wg_$(date +%s) REFERENCE=REF.fa \
 #     SHARDS_PER_NODE=$K \
 #     sbatch --array=0-$((T-1))%20 scripts/delta/genome_array.sbatch
@@ -37,10 +37,11 @@
 # For replicated / swept runs, drive it with run_genome_reps.sh instead.
 #
 # The `%20` throttle caps concurrently-running NODES (each task = 1 exclusive
-# node), tune to your node availability. Straggler-proofing: --time is tight
-# (a healthy K<=8 batch finishes well inside it) and --requeue is set, so a task
-# stuck on a sick node is killed and rescheduled elsewhere — finished shards in
+# node), tune to your node availability. Straggler-proofing: --requeue is set, so a
+# task stuck on a sick node is killed and rescheduled elsewhere — finished shards in
 # the batch are skipped on the retry (idempotent), only the unfinished ones rerun.
+# On the fixed build a batch finishes in minutes (windows run in ~1-2 min even
+# packed 64-deep), so the 1 h --time is generous headroom, not a tight ceiling.
 
 #SBATCH --job-name=rneat-wgshard
 #SBATCH --partition=cpu
@@ -62,7 +63,7 @@ source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH resolution
 REFERENCE="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
 SHARD_DIR="${SHARD_DIR:-$SCRATCH/shards}"
 OUTROOT="${OUTROOT:-$SCRATCH/wg_$SLURM_ARRAY_JOB_ID}"
-SHARDS_PER_NODE="${SHARDS_PER_NODE:-8}"    # windows packed onto each exclusive node
+SHARDS_PER_NODE="${SHARDS_PER_NODE:-64}"   # windows packed per exclusive node (~99% eff on the fixed build; see header)
 COVERAGE="${COVERAGE:-30}"
 READ_LEN="${READ_LEN:-151}"
 FRAG_MEAN="${FRAG_MEAN:-350}"

--- a/scripts/delta/run_genome_reps.sh
+++ b/scripts/delta/run_genome_reps.sh
@@ -28,7 +28,7 @@ source "$REPO_ROOT/scripts/delta/lib_report.sh"
 
 REFERENCE="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
 SHARD_DIR="${SHARD_DIR:-$SCRATCH/shards_hg38}"
-KS="${KS:-4 8 16}"           # shards-per-node values to sweep (the packing knob)
+KS="${KS:-16 32 64}"         # shards-per-node values to sweep (fixed build packs ~99% to 64)
 REPS="${REPS:-3}"            # replicates per K
 MAXNODES="${MAXNODES:-20}"   # concurrent exclusive nodes (the %throttle)
 TAG="${TAG:-hg38}"
@@ -51,13 +51,11 @@ echo "NOTE: ~$(( $(echo "$KS" | wc -w) * REPS * 38 )) GB of FASTQ total across a
 
 for K in $KS; do
     T=$(( (N + K - 1) / K ))               # node-tasks = ceil(N / K)
-    # Per-task walltime. --exclusive already removes the cross-tenant straggler
-    # that motivated a tight ceiling, so this must be GENEROUS: a heavy 25 Mb
-    # window runs ~8 min alone but slows ~linearly under packing (~0.8*K), and a
-    # ceiling below that silently kills legitimate slow shards (the first sweep
-    # capped every heavy window exactly at a 10+6K ceiling -> incomplete runs).
-    # Override with WALL_MINUTES if needed.
-    MINUTES="${WALL_MINUTES:-$(( 30 + K * 20 ))}"
+    # Per-task walltime. On the fixed build (#340) packing is ~99% efficient to
+    # 64/node — windows run in ~1-2 min even packed deep, no superlinear slowdown —
+    # so a flat 1 h is generous headroom (the old 30+20K ask scaled multi-hour on a
+    # false premise and just hurt scheduling). Override with WALL_MINUTES if needed.
+    MINUTES="${WALL_MINUTES:-60}"
     WALL=$(printf '%02d:%02d:00' $(( MINUTES / 60 )) $(( MINUTES % 60 )))
     for r in $(seq 1 "$REPS"); do
         OUTROOT="$SCRATCH/wg_${TAG}_k${K}_rep${r}"

--- a/scripts/delta/run_whole_genome.sh
+++ b/scripts/delta/run_whole_genome.sh
@@ -25,19 +25,20 @@
 #     bash scripts/delta/run_whole_genome.sh
 #
 #   # bigger/messier genome, smaller shards, timing-only (no merge):
-#   REFERENCE=$SCRATCH/neat_data/soy.fa TAG=soy SHARD_BP=10000000 K=4 DO_MERGE=0 \
+#   REFERENCE=$SCRATCH/neat_data/soy.fa TAG=soy SHARD_BP=10000000 DO_MERGE=0 \
 #     bash scripts/delta/run_whole_genome.sh
 #
-# KNOBS (env): REFERENCE TAG SHARD_BP(25M) K(4=shards/node) MAXNODES(20) COVERAGE(30)
+# KNOBS (env): REFERENCE TAG SHARD_BP(25M) K(64=shards/node) MAXNODES(20) COVERAGE(30)
 #   READ_LEN(151) FRAG_MEAN(350) FRAG_SD(50) PLOIDY(2) SV_RATE_SCALE(0)
-#   WALL_MINUTES(auto=30+20K) DO_MERGE(1) SKIP_SMOKE(0) OUTROOT(auto)
+#   WALL_MINUTES(auto=60) DO_MERGE(1) SKIP_SMOKE(0) OUTROOT(auto)
 #
-# PACKING (K) — see docs/hpc_guide.md §5. rneat is memory-bandwidth-bound, so the
-#   node saturates by K≈2; low K = fastest per-window but wants many whole nodes
-#   (hard to schedule on a busy cluster); high K = slower per-window but schedules
-#   sooner. K=4 is a schedulable default with no deadline; use K=1–2 only with a
-#   reservation / idle cluster. For big/messy genomes lower SHARD_BP so no single
-#   window's wall-clock blows past the per-task walltime.
+# PACKING (K) — see docs/hpc_guide.md §5. On the fixed build (#340) independent
+#   single-thread shards pack NEAR-LINEARLY: ~99% per-process efficiency to 64/node
+#   on a real 25 Mb window, ~75% at 128. So K=64 (one per physical core) is the
+#   default — whole human genome (306 windows) -> ~5 node-tasks. Use K=128 for the
+#   fewest nodes (~75% eff); lower K only if a genome's largest contig is big and
+#   RAM is tight (peak RSS/node ~= K * largest-contig-loaded). Windows run in ~1-2
+#   min even packed 64-deep, so packing no longer trades per-window speed.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -47,7 +48,7 @@ D="$REPO_ROOT/scripts/delta"
 REFERENCE="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
 TAG="${TAG:-wg}"
 SHARD_BP="${SHARD_BP:-25000000}"
-K="${K:-4}"                       # shards per exclusive node
+K="${K:-64}"                      # shards per exclusive node (~99% eff on the fixed build)
 MAXNODES="${MAXNODES:-20}"        # concurrent exclusive nodes (%throttle)
 COVERAGE="${COVERAGE:-30}"
 READ_LEN="${READ_LEN:-151}"
@@ -76,7 +77,9 @@ module load samtools/1.22-cce19.0.0 2>/dev/null || true
 N=$(bash "$D/make_shard_beds.sh" "$REFERENCE.fai" "$SHARD_BP" "$SHARD_DIR")
 [[ "$N" =~ ^[0-9]+$ && "$N" -gt 0 ]] || { echo "make_shard_beds produced no shards" >&2; exit 1; }
 T=$(( (N + K - 1) / K ))                              # node-tasks
-MINUTES="${WALL_MINUTES:-$(( 30 + K * 20 ))}"
+# Windows run in ~1-2 min even packed 64-deep on the fixed build, so a flat 1 h is
+# generous headroom (and schedules far easier than the old K-scaled multi-hour ask).
+MINUTES="${WALL_MINUTES:-60}"
 WALL=$(printf '%02d:%02d:00' $(( MINUTES / 60 )) $(( MINUTES % 60 )))
 
 echo "════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
**Impact-analysis item (a).** The shard-packing defaults were set from the pre-fix procs-per-node sweep, whose "efficient zone ≤8 / bandwidth saturates at K≈2" was an artifact of per-process trace-log I/O (#340). The fixed-build sweep on a **real 25 MB window** shows independent single-thread shards pack **near-linearly — ~99% efficiency to 64/node, ~75% at 128**.

| file | was | now |
|---|---|---|
| `genome_array.sbatch` | `SHARDS_PER_NODE=8` | **64** + rewritten header |
| `run_whole_genome.sh` | `K=4`, walltime `30+20K` | **K=64**, flat **60 m** |
| `run_genome_reps.sh` | `KS="4 8 16"`, `30+20K` | **`KS="16 32 64"`**, flat **60 m** |

The old default **under-packed ~8×** (used 8 of ~128 cores per exclusive node). A whole human genome (306 × 25 MB windows) is now **~5 node-tasks at 64/node** instead of ~39 at 8/node. RSS caveat documented (peak ≈ K × largest-contig-loaded → lower K if a genome has huge contigs and RAM is tight). The exclusive-nodes recommendation is unchanged — cross-tenant contention is real, not a logging artifact.

`gitnexus detect_changes`: 0 execution flows (scripts only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)