### PR TITLE
fix(delta): model_builders round-trip — set fragment_mean/st_dev so it validates

### DIFF
--- a/scripts/delta/model_builders.sbatch
+++ b/scripts/delta/model_builders.sbatch
@@ -178,6 +178,13 @@ if [[ -n "$REFERENCE" && -f "$REFERENCE" ]] && grep -q 'PASS' "$SUMMARY"; then
         echo "coverage: 30"
         echo "ploidy: 2"
         echo "paired_ended: true"
+        # paired-end config validation currently requires fragment_mean/st_dev even
+        # when a fragment_model is supplied (config.rs check_and_log_config vs the
+        # runner, which prioritizes fragment_model). Set them so the round-trip
+        # validates; the built fragment_model still overrides these at runtime
+        # (runner.rs). Drop these once the validator accepts fragment_model alone.
+        echo "fragment_mean: 350"
+        echo "fragment_st_dev: 50"
         echo "produce_fastq: true"
         echo "produce_vcf: true"
         echo "produce_bam: false"


### PR DESCRIPTION
The first real-data model-builder run (HG002 chr20) had **all 5 builders PASS** but the round-trip `FAIL-RUN` — traced to the round-trip config setting `paired_ended: true` without `fragment_mean/st_dev`. `gen-reads`' `check_and_log_config` requires those for paired-end even when a `fragment_model` is supplied (a validator/runtime mismatch — the runtime prioritizes `fragment_model`).

Fix: set `fragment_mean/st_dev` in the round-trip config so it validates. The built `fragment_model` still overrides them at runtime, so the round-trip keeps genuinely exercising model consumption (confirmed manually — all four built models load and produce valid FASTQ+VCF).

The underlying validator/runtime mismatch is a real `gen-reads` bug (surfaced by this run) and is being tracked/fixed separately; drop these two lines once the validator accepts `fragment_model` alone.

`gitnexus detect_changes`: 0 execution flows (sbatch config only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)