### PR TITLE
chore(delta): drop fragment_mean/st_dev workaround from model_builders round-trip

### DIFF
--- a/scripts/delta/model_builders.sbatch
+++ b/scripts/delta/model_builders.sbatch
@@ -178,13 +178,9 @@ if [[ -n "$REFERENCE" && -f "$REFERENCE" ]] && grep -q 'PASS' "$SUMMARY"; then
         echo "coverage: 30"
         echo "ploidy: 2"
         echo "paired_ended: true"
-        # paired-end config validation currently requires fragment_mean/st_dev even
-        # when a fragment_model is supplied (config.rs check_and_log_config vs the
-        # runner, which prioritizes fragment_model). Set them so the round-trip
-        # validates; the built fragment_model still overrides these at runtime
-        # (runner.rs). Drop these once the validator accepts fragment_model alone.
-        echo "fragment_mean: 350"
-        echo "fragment_st_dev: 50"
+        # No fragment_mean/st_dev: the built fragment_model is the fragment-length
+        # source (paired-end now accepts a fragment_model alone — #355). This makes
+        # the round-trip exercise the realistic "user supplies only their model" path.
         echo "produce_fastq: true"
         echo "produce_vcf: true"
         echo "produce_bam: false"


### PR DESCRIPTION
Follow-up to #355 (merged). #354 added `fragment_mean/st_dev` to the round-trip config to satisfy the old paired-end validator; #355 fixed the validator to accept a `fragment_model` alone, so those lines are now redundant — they trigger the new "both set, model wins" warning and prevent the round-trip from exercising the realistic `fragment_model`-only path.

Removes them. The round-trip now tests what a real user does — supply only their built model. Requires a Delta binary built from ≥ #355 (rebuild before the next `model_builders.sbatch` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)