### PR TITLE
fix(delta): stop stage_soy.sh aborting mid-subsample; fail model_builders on no input

### DIFF
--- a/scripts/delta/model_builders.sbatch
+++ b/scripts/delta/model_builders.sbatch
@@ -212,6 +212,17 @@ if [[ -n "$REFERENCE" && -f "$REFERENCE" ]] && grep -q 'PASS' "$SUMMARY"; then
     fi
 fi
 
+# No builder ran → every input was missing/unreadable. This is NOT a pass:
+# a stress test that exercises nothing must fail loudly, or a mis-staged run
+# (wrong paths, purged scratch) silently reports green. (see job 19887446)
+if [[ ! -s "$SUMMARY" ]]; then
+    echo "── no builder ran ──" >&2
+    echo "   FAIL  all inputs missing/unreadable — nothing was exercised." >&2
+    echo "         checked: ref=$REFERENCE bam=$INPUT_BAM fastq=$INPUT_FASTQ vcf=$INPUT_VCF" >&2
+    printf 'NONE\tFAIL-NO-INPUT\t-\t-\n' >> "$SUMMARY"
+    overall=1
+fi
+
 echo
 echo "════════════════════════════════════════════════════════════════"
 echo "Model-builder stress test summary (name / status / wall / peakRSS):"

--- a/scripts/delta/stage_soy.sh
+++ b/scripts/delta/stage_soy.sh
@@ -63,10 +63,19 @@ echo "=== stage soy: SRR=$SRR  ref=$REF  max_pairs=$MAX_PAIRS  threads=$THREADS 
 # Optional subsample (head keeps R1/R2 in the same order → pairs stay matched).
 R1="$D/${SRR}_1.fastq.gz"; R2="$D/${SRR}_2.fastq.gz"
 if [[ "$MAX_PAIRS" -gt 0 ]]; then
-    if [[ ! -s "$D/sub_1.fastq.gz" ]]; then
+    # Require BOTH mates: a prior run that died mid-subsample (e.g. the pipefail/
+    # SIGPIPE abort) can leave sub_1 without sub_2 — redo it rather than march on
+    # to bwa-mem2 with a missing R2.
+    if [[ ! -s "$D/sub_1.fastq.gz" || ! -s "$D/sub_2.fastq.gz" ]]; then
         echo "subsampling first $MAX_PAIRS pairs..."
+        # `head` closes the pipe after N lines → `zcat` gets SIGPIPE (exit 141).
+        # That is expected here, not an error, but `set -o pipefail` would promote
+        # it to a pipeline failure and `set -e` would abort mid-subsample (leaving
+        # sub_1 written but sub_2 never created). Disable pipefail for just these.
+        set +o pipefail
         zcat "$R1" | head -n $(( MAX_PAIRS * 4 )) | gzip > "$D/sub_1.fastq.gz"
         zcat "$R2" | head -n $(( MAX_PAIRS * 4 )) | gzip > "$D/sub_2.fastq.gz"
+        set -o pipefail
     fi
     R1="$D/sub_1.fastq.gz"; R2="$D/sub_2.fastq.gz"
 fi


### PR DESCRIPTION
## Problem

Job `19887446` (model-builder stress test) reported **`overall: PASS`** while its `summary.tsv` was **empty** and `core_hours=0.040` — a false pass. Root cause is a chain of two bugs:

1. **`stage_soy.sh` aborted mid-subsample.** The read subsample uses `zcat "$R1" | head -n N | gzip > sub_1.fastq.gz`. When `head` has its N lines it closes the pipe, so `zcat` gets **SIGPIPE (exit 141)**. Under `set -o pipefail` + `set -e`, that promotes the *successful* subsample into a fatal pipeline failure — aborting the script **after `sub_1.fastq.gz` was written but before `sub_2`**. Alignment → `soy.chr.*` subset → VCF call → FASTQ never ran. Disk fingerprint confirmed it: `sub_1.fastq.gz` present (~49% of R1), `sub_2.fastq.gz` absent, no BAM/VCF/`soy.chr.*`.

2. **`model_builders.sbatch` false-passed on no input.** With the `soy.chr.*` inputs never created, every builder's `-f` guard failed, zero builders ran, `overall` stayed `0`, and the summary block printed **PASS** over an empty `summary.tsv`.

## Fix

- **`stage_soy.sh`**: wrap the two subsample pipelines in `set +o pipefail` / `set -o pipefail` (SIGPIPE from `head` closing the pipe is expected, not an error). Also require **both** mates in the resume guard so a partial `sub_1`-without-`sub_2` state re-subsamples instead of feeding `bwa-mem2` a missing R2.
- **`model_builders.sbatch`**: if `summary.tsv` is empty after all builders (no builder ran), emit a `FAIL-NO-INPUT` row and set `overall=1` — a stress test that exercises nothing must never report green.

## Testing

- Static review of the pipeline/`set -e` interaction; disk state on Delta matches the diagnosed abort point exactly.
- Re-run on Delta pending: `sbatch scripts/delta/stage_soy.sh` (both-mates guard will regenerate the orphaned subsample), then re-run `model_builders.sbatch` with the printed `soy.chr.*` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)