### PR TITLE
fix(delta): skip NEAT arm on genomes too large for it (benchmark timeout)

### DIFF
--- a/scripts/delta/benchmark.sbatch
+++ b/scripts/delta/benchmark.sbatch
@@ -63,7 +63,7 @@ GENOMES=(
     "ecoli:$DATA_DIR/ecoli.fa"        # single-contig, tiny
     "yeast:$DATA_DIR/yeast.fa"        # MULTI-contig (~16) — also the Phase B genome
     "chr22:$DATA_DIR/chr22.fa"        # single-contig, ~50 Mb
-    "human:$DATA_DIR/GRCh38.fa"       # multi-contig, large — staged only for a big run
+    "human:$DATA_DIR/GRCh38.fa"       # multi-contig, large — rneat-only (NEAT arm auto-skipped: too big, see run_neat)
 )
 HEADTOHEAD_THREADS="${HEADTOHEAD_THREADS:-1}"
 
@@ -192,6 +192,17 @@ YAML
 run_neat() {
     local label="$1" fasta="$2" nthreads="$3"
     [[ -n "${NEAT_BIN:-}" ]] || { echo "  NEAT binary not found — skipping NEAT for $label"; return; }
+    # NEAT 4 (Python) wall scales with genome size: ~12 min/rep on chr22 (50 Mb), so a
+    # full human genome (~3.1 Gb) is ~12 h/rep — a 3-rep sweep can never finish and
+    # times out the whole job (job 19891600 died here). Cap the NEAT arm by genome
+    # size; rneat still runs on the large genome for its own numbers, and that rneat-
+    # only result (rneat does human in ~1 h; NEAT can't) is itself the comparison.
+    local neat_cap_mb="${NEAT_MAX_GENOME_MB:-200}"
+    local sz_mb; sz_mb=$(awk -v b="$(stat -c%s "$fasta")" 'BEGIN{printf "%.0f", b/1048576}')
+    if (( sz_mb > neat_cap_mb )); then
+        echo "  [neat] SKIP $label (${sz_mb} MB > NEAT_MAX_GENOME_MB=${neat_cap_mb} MB): NEAT 4 is intractable at this size"
+        return
+    fi
     local cfg="$OUTDIR/neat_${label}_t${nthreads}.yml"
     cat > "$cfg" <<YAML
 reference: $fasta


### PR DESCRIPTION
## What timed out

Job 19891600 (`rneat-benchmark`, the `perf` step of `regression_suite.sh`) hit its 6 h wall. The `.out` tail showed why: Phase A runs **both** tools on every genome in `GENOMES`, which includes `human:GRCh38.fa` (~3.1 Gb). Per-rep walls:

| genome | rneat | NEAT 4 |
|---|---|---|
| yeast (12 Mb) | 18 s | 212 s |
| chr22 (50 Mb) | 57 s | 745 s |
| human (3.1 Gb) | ~65 min, 9.9 GB | **∞** (died on rep 1/3) |

NEAT 4 scales with genome size (~12 min on chr22 ⇒ ~12 h/rep on human), so a 3-rep human sweep can never finish. `rneat` human completed fine.

## Fix

Gate the NEAT arm by genome size in `run_neat` (`NEAT_MAX_GENOME_MB`, default 200 MB) and log the skip (no silent cap). yeast/chr22/ecoli keep the head-to-head; human runs rneat-only. That rneat-only result — **rneat does a human genome in ~1 h where NEAT 4 is intractable** — is itself the comparison worth reporting.

With this, the full benchmark fits the 6 h wall (~4 h: rneat human 3 reps dominates).

## Notes

- Does **not** affect PR #361 (perf rebaseline): rneat's ecoli/chr22 rows completed before the timeout and are what the rebaseline used.
- `bash -n` clean; gate logic verified (12/50 MB → NEAT runs, 3100 MB → skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)