### PR TITLE
feat(delta): stage_hg002.sh — human-scale inputs for the model-builder harness

### DIFF
--- a/scripts/delta/stage_hg002.sh
+++ b/scripts/delta/stage_hg002.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# SLURM job: stage REAL GIAB HG002 (human, GRCh38) data for the model-builder harness.
+#
+# Unlike soy, HG002 has a CURATED truth VCF (GIAB v4.2.1) that already matches GRCh38,
+# so we don't call variants ourselves — we align a read subset for the BAM/FASTQ inputs
+# and point gen-mut-model at the truth VCF. This is the human-scale counterpart to
+# stage_soy.sh, and the run that tests the ~12-14 GB peak-RSS extrapolation recorded
+# in docs/model_builder_baseline.md (soy ~1 Gb → ~4 GB; human ~3.1 Gb → ~12-14 GB?).
+#
+# Pipeline: download an Illumina 2x250 read chunk (GIAB FTP, no sra-tools) -> bwa-mem2
+# align to GRCh38.fa -> coordinate-sorted BAM. FASTQ input = the downloaded reads;
+# VCF input = the GIAB truth VCF (fetch_validation_data.sh DATA=hg002).
+# Outputs (in $DATA_DIR): hg002.bam(+.bai), hg002_R1.fastq.gz, hg002_R2.fastq.gz.
+#
+# Prereqs:
+#   * GRCh38.fa staged at $SCRATCH/neat_data/GRCh38.fa (same build already used for sim).
+#   * truth VCF staged:  DATA=hg002 bash scripts/delta/fetch_validation_data.sh
+#   * bwa-mem2 + samtools (bioinf conda env / modules). rneat NOT needed here.
+#
+# HEAVY: ~12 GB read download per chunk; the bwa-mem2 index of GRCh38 needs ~64 GB RAM
+# and ~30 GB disk (built once, reused); human alignment of one chunk is ~1-2 h.
+#
+# Usage:
+#   sbatch scripts/delta/stage_hg002.sh
+#   CHUNKS="L001:001 L001:002" MAX_PAIRS=20000000 sbatch scripts/delta/stage_hg002.sh
+
+#SBATCH --job-name=rneat-stagehg002
+#SBATCH --partition=cpu
+#SBATCH --account=bhrd-delta-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=128G
+#SBATCH --time=12:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH + setup_conda/conda_activate
+
+D="${DATA_DIR:-$SCRATCH/neat_data/hg002}"
+REF="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
+VCF="${HG002_VCF:-$D/HG002_GRCh38_v4.2.1_benchmark.vcf.gz}"
+# Space-separated LANE:CHUNK ids to download+concatenate. One chunk (~20M pairs) is
+# plenty for the builders; add more for a bigger/heavier BAM.
+CHUNKS="${CHUNKS:-L001:001}"
+MAX_PAIRS="${MAX_PAIRS:-0}"                 # 0 = use all downloaded reads; else subsample
+THREADS="${SLURM_CPUS_PER_TASK:-16}"
+BASE="https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/HG002_NA24385_son/NIST_Illumina_2x250bps/reads"
+
+mkdir -p "$D"
+module load samtools/1.22-cce19.0.0
+setup_conda
+conda_activate bioinf                       # bwa-mem2
+
+[[ -f "$REF" ]] || { echo "GRCh38 reference not staged: $REF" >&2; exit 1; }
+echo "=== stage HG002: chunks=[$CHUNKS]  ref=$REF  max_pairs=$MAX_PAIRS  threads=$THREADS ==="
+
+# ── 1. download + concatenate read chunks (GIAB FTP, resumable) ─────────────────
+R1="$D/hg002_R1.fastq.gz"; R2="$D/hg002_R2.fastq.gz"
+if [[ ! -s "$R1" || ! -s "$R2" ]]; then
+    : > "$R1"; : > "$R2"
+    for spec in $CHUNKS; do
+        lane="${spec%%:*}"; id="${spec##*:}"
+        f1="D1_S1_${lane}_R1_${id}.fastq.gz"; f2="D1_S1_${lane}_R2_${id}.fastq.gz"
+        echo "downloading $f1 / $f2 ..."
+        wget -c -O "$D/$f1" "$BASE/$f1"
+        wget -c -O "$D/$f2" "$BASE/$f2"
+        cat "$D/$f1" >> "$R1"; cat "$D/$f2" >> "$R2"
+    done
+fi
+
+# Optional subsample (head keeps R1/R2 in the same order → pairs stay matched).
+if [[ "$MAX_PAIRS" -gt 0 && ! -s "$D/sub_1.fastq.gz" ]]; then
+    echo "subsampling first $MAX_PAIRS pairs..."
+    # head closes the pipe early → zcat gets SIGPIPE (141); expected, not an error.
+    # pipefail would promote it to a failure and set -e would abort → disable it here.
+    set +o pipefail
+    zcat "$R1" | head -n $(( MAX_PAIRS * 4 )) | gzip > "$D/sub_1.fastq.gz"
+    zcat "$R2" | head -n $(( MAX_PAIRS * 4 )) | gzip > "$D/sub_2.fastq.gz"
+    set -o pipefail
+fi
+[[ "$MAX_PAIRS" -gt 0 ]] && { R1="$D/sub_1.fastq.gz"; R2="$D/sub_2.fastq.gz"; }
+
+# ── 2. index reference (bwa-mem2 + faidx); -s guard against a 0-byte stub ────────
+[[ -f "$REF.fai" ]] || samtools faidx "$REF"
+if [[ ! -s "$REF.bwt.2bit.64" ]]; then
+    echo "building bwa-mem2 index for GRCh38 (one-time, ~64 GB RAM, ~30 GB disk)..."
+    bwa-mem2 index "$REF"
+fi
+
+# ── 3. align → coordinate-sorted BAM ─────────────────────────────────────────────
+if [[ ! -s "$D/hg002.bam" ]]; then
+    echo "aligning HG002 reads to GRCh38..."
+    bwa-mem2 mem -t "$THREADS" "$REF" "$R1" "$R2" 2> "$D/bwa.log" \
+        | samtools sort -@ "$THREADS" -o "$D/hg002.bam" -
+    samtools index "$D/hg002.bam"
+fi
+
+# ── 4. sanity: does the truth VCF's contig naming match the reference? ──────────
+# gen-mut-model silently produces nothing if the VCF's contigs aren't in the FASTA
+# (the classic 'chr1' vs '1' trap). Warn loudly rather than let mut_model no-op.
+VCF_OK=1
+if [[ -s "$VCF" ]]; then
+    vcf_ctg=$(zcat "$VCF" | grep -v '^#' | head -1 | cut -f1)
+    if ! cut -f1 "$REF.fai" | grep -qxF "$vcf_ctg"; then
+        echo "WARNING: truth VCF contig '$vcf_ctg' not found in $REF.fai — gen-mut-model" >&2
+        echo "         would see zero variants. Check GRCh38 contig naming (chr-prefix?)." >&2
+        VCF_OK=0
+    fi
+else
+    echo "WARNING: truth VCF not found at $VCF — run: DATA=hg002 bash scripts/delta/fetch_validation_data.sh" >&2
+    VCF_OK=0
+fi
+
+nreads=$(( $(zcat "$R1" | wc -l) / 4 ))
+echo
+echo "════════════════════════════════════════════════════════════════"
+echo "HG002 staged: $nreads read pairs aligned to GRCh38"
+echo "Run the model-builders (human-scale stress; expect gc_bias/bam_models RSS in the GB range):"
+echo "  REFERENCE=$REF INPUT_BAM=$D/hg002.bam \\"
+echo "  INPUT_FASTQ=$R1 \\"
+[[ "$VCF_OK" -eq 1 ]] && echo "  INPUT_VCF=$VCF \\" || echo "  # (INPUT_VCF omitted — see contig-naming warning above; mut_model will be skipped)"
+echo "    sbatch scripts/delta/model_builders.sbatch"
+echo "════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
Adds `stage_hg002.sh` so we can run `model_builders.sbatch` on real **human-scale** data — the run that tests the resource extrapolation in `docs/model_builder_baseline.md` (soy ~1 Gb → ~4 GB observed peak RSS; **human ~3.1 Gb → predicted ~12–14 GB**).

## How it works (human counterpart to `stage_soy.sh`)
- **Reads:** downloads a GIAB NIST 2×250 Illumina chunk directly from the GIAB FTP (`.../NIST_Illumina_2x250bps/reads/`), no sra-tools. Default one L001 chunk pair (~20M pairs); `CHUNKS="L001:001 L001:002"` for more, `MAX_PAIRS=N` to subsample.
- **BAM:** `bwa-mem2` align to the already-staged `GRCh38.fa` → sorted/indexed BAM.
- **VCF:** uses the **GIAB v4.2.1 curated truth VCF** directly (matches GRCh38 by construction) — no `bcftools` step needed, unlike soy. Fetched via `DATA=hg002 bash scripts/delta/fetch_validation_data.sh`.
- Reuses stage_soy's `pipefail`/SIGPIPE-safe subsample + both-mates resume guard.
- **Contig-naming guard:** if the truth VCF's contigs aren't in `GRCh38.fa.fai` (the `chr1` vs `1` trap), it warns loudly and omits `INPUT_VCF` rather than let `gen-mut-model` silently no-op.

## Heads-up (real costs)
- **~12 GB** read download per chunk.
- **bwa-mem2 index of GRCh38 needs ~64 GB RAM and ~30 GB disk** (built once, reused) — mind the bhrd scratch **project** quota (`PRUNE`/cleanup if it bites, per prior runs).
- Human alignment of one chunk ≈ 1–2 h.

## Testing
`bash -n` clean. Not run on Delta yet — that's the next step once the reference/VCF are confirmed staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)