### PR TITLE
feat(delta): stage_hcc1395.sh — real cancer (SEQC2) for a compound tumor model

### DIFF
--- a/scripts/delta/stage_hcc1395.sh
+++ b/scripts/delta/stage_hcc1395.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# SLURM job: stage REAL cancer data — SEQC2 HCC1395 (tumor) / HCC1395BL (normal),
+# a triple-negative breast cancer cell line + matched normal from the same donor —
+# for a COMPOUND tumor model: germline layer from the normal + somatic layer from
+# the tumor's real high-confidence truth VCF, composed by `rneat gen-cancer-reads`.
+#
+# WHY / WHAT THE COMPOUND MODEL IS
+#   gen-cancer-reads separates the germline process (normal_model + germline_vcf)
+#   from the somatic process (tumor_model). This stages both from real data:
+#     * somatic  → SEQC2 high-confidence somatic SNV+INDEL truth VCF (real TNBC
+#                  signature; feeds gen-mut-model → tumor_model)
+#     * germline → CALLED from the normal BAM here (this donor's germline; feeds
+#                  gen-mut-model → normal_model + used as the shared germline_vcf)
+#     * sequencing (seq-error/frag/gc/bam-models) → the real tumor/normal BAMs
+#
+# SEQC2 hosts pre-aligned + deduped NovaSeq BAMs (GRCh38), so NO alignment/index is
+# needed. To respect scratch quota, we region-scope (default chr1): samtools pulls
+# just that region from the remote BAM via range requests (MODE=remote), or set
+# MODE=download to fetch the whole ~60-80 GB BAM first.
+#
+# Prereqs: GRCh38.fa staged at $SCRATCH/neat_data/GRCh38.fa (same build used for
+#          HG002); samtools + bcftools (bioinf conda env / modules). rneat NOT needed.
+#
+# Usage:
+#   sbatch scripts/delta/stage_hcc1395.sh
+#   REGION="chr1 chr2" sbatch scripts/delta/stage_hcc1395.sh
+#   REGION=all MODE=download sbatch scripts/delta/stage_hcc1395.sh   # whole genome, full BAMs
+#
+# HEAVY: region chr1 ≈ ~5 GB pulled per BAM; germline calling on chr1 (~50x) is
+# multi-hour. REGION=all downloads ~140 GB and calls genome-wide.
+
+#SBATCH --job-name=rneat-stagehcc1395
+#SBATCH --partition=cpu
+#SBATCH --account=bhrd-delta-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=12:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"   # $SCRATCH + setup_conda/conda_activate
+
+D="${DATA_DIR:-$SCRATCH/neat_data/hcc1395}"
+REF="${REFERENCE:-$SCRATCH/neat_data/GRCh38.fa}"
+REGION="${REGION:-chr1}"                 # space-separated contigs, or "all" for whole genome
+MODE="${MODE:-remote}"                    # remote = range-request subset; download = full BAM first
+THREADS="${SLURM_CPUS_PER_TASK:-16}"
+BAM_BASE="https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/data/WGS"
+VCF_BASE="https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/seqc/Somatic_Mutation_WG/release/latest"
+TUMOR_BAM="${TUMOR_BAM:-WGS_NS_T_1.bwa.dedup.bam}"    # NovaSeq replicate 1
+NORMAL_BAM="${NORMAL_BAM:-WGS_NS_N_1.bwa.dedup.bam}"
+
+mkdir -p "$D"
+module load samtools/1.22-cce19.0.0
+module load htslib/1.22-gcc13.3.1
+setup_conda
+conda_activate bioinf                     # bcftools (+ samtools with libcurl if module lacks it)
+
+[[ -f "$REF" ]] || { echo "GRCh38 reference not staged: $REF" >&2; exit 1; }
+[[ -f "$REF.fai" ]] || samtools faidx "$REF"
+echo "=== stage HCC1395: region=[$REGION] mode=$MODE ref=$REF threads=$THREADS ==="
+
+# ── 1. somatic truth VCF (SNV + INDEL, high-conf in high-conf regions; GRCh38) ──
+if [[ ! -s "$D/somatic.vcf.gz" ]]; then
+    for f in high-confidence_sSNV_in_HC_regions_v1.2.vcf.gz \
+             high-confidence_sINDEL_in_HC_regions_v1.2.vcf.gz; do
+        [[ -s "$D/$f" ]] || wget -c -O "$D/$f" "$VCF_BASE/$f"
+        bcftools index -f -t "$D/$f"
+    done
+    # combine SNV + INDEL into one somatic model input, sorted + bgzipped.
+    bcftools concat -a "$D/high-confidence_sSNV_in_HC_regions_v1.2.vcf.gz" \
+                       "$D/high-confidence_sINDEL_in_HC_regions_v1.2.vcf.gz" -Ou \
+        | bcftools sort -Oz -o "$D/somatic.vcf.gz"
+    bcftools index -t "$D/somatic.vcf.gz"
+fi
+
+# region arg forms: samtools/bcftools want space-separated contigs; "all" = no filter.
+region_args=(); vcf_region=""
+if [[ "$REGION" != "all" ]]; then
+    region_args=($REGION)
+    vcf_region=$(printf '%s,' $REGION); vcf_region="${vcf_region%,}"   # bcftools -r csv
+fi
+
+# ── 2. subset the tumor + normal BAMs to REGION (no alignment — pre-aligned) ─────
+fetch_bam() {   # <remote_name> <local_prefix>
+    local name="$1" out="$D/$2.bam"
+    [[ -s "$out" ]] && return 0
+    if [[ "$MODE" == "download" || "$REGION" == "all" ]]; then
+        [[ -s "$D/$name" ]] || wget -c -O "$D/$name" "$BAM_BASE/$name"
+        samtools view -@ "$THREADS" -b "$D/$name" "${region_args[@]}" -o "$out"
+    else
+        # Range-request subset straight from the remote BAM (needs htslib+libcurl).
+        # samtools auto-discovers the remote .bai alongside the .bam.
+        samtools view -@ "$THREADS" -b "$BAM_BASE/$name" "${region_args[@]}" -o "$out" \
+            || { echo "remote subset failed (samtools may lack libcurl) — retry with MODE=download" >&2; exit 1; }
+    fi
+    samtools index "$out"
+    [[ -s "$out" ]] && [[ "$(samtools view -c "$out")" -gt 0 ]] \
+        || { echo "empty BAM after subset: $out (bad REGION contig name? check chr-prefix)" >&2; exit 1; }
+}
+fetch_bam "$TUMOR_BAM"  tumor
+fetch_bam "$NORMAL_BAM" normal
+
+# ── 3. call germline from the NORMAL bam (this donor's germline; per-contig || ) ─
+if [[ ! -s "$D/germline.vcf.gz" ]]; then
+    echo "calling germline from normal BAM over [$REGION]..."
+    if [[ "$REGION" == "all" ]]; then
+        contigs=$(cut -f1 "$REF.fai")
+    else
+        contigs="$REGION"
+    fi
+    parts="$D/germ_parts"; mkdir -p "$parts"
+    printf '%s\n' $contigs | xargs -P "$THREADS" -I CTG bash -c '
+        ctg="$1"; out="'"$parts"'/$ctg.vcf.gz"
+        [[ -s "$out" ]] && exit 0
+        bcftools mpileup -r "$ctg" -f "'"$REF"'" "'"$D"'/normal.bam" 2>/dev/null \
+            | bcftools call -mv -Oz -o "$out" 2>/dev/null
+    ' _ CTG
+    printf '%s\n' $contigs | sed "s#^#$parts/#; s#\$#.vcf.gz#" > "$D/germ_parts.list"
+    bcftools concat -Oz -f "$D/germ_parts.list" -o "$D/germline.vcf.gz"
+    bcftools index -t "$D/germline.vcf.gz"
+    rm -rf "$parts" "$D/germ_parts.list"
+fi
+
+# ── 4. FASTQ for seq-error (tumor reads) + contig-naming sanity ─────────────────
+[[ -s "$D/tumor.fastq.gz" ]] || samtools fastq -n "$D/tumor.bam" 2>/dev/null | gzip > "$D/tumor.fastq.gz"
+som_ctg=$(bcftools view -H "$D/somatic.vcf.gz" 2>/dev/null | head -1 | cut -f1)
+cut -f1 "$REF.fai" | grep -qxF "$som_ctg" \
+    || echo "WARNING: somatic VCF contig '$som_ctg' not in $REF.fai — check GRCh38 contig naming" >&2
+
+n_som=$(bcftools view -H "$D/somatic.vcf.gz" ${vcf_region:+-r "$vcf_region"} 2>/dev/null | wc -l)
+n_germ=$(bcftools view -H "$D/germline.vcf.gz" 2>/dev/null | wc -l)
+echo
+echo "════════════════════════════════════════════════════════════════"
+echo "HCC1395 staged (region [$REGION]): $n_som somatic, $n_germ germline variants"
+echo "Build the COMPOUND model, then simulate:"
+echo "  # somatic tumor_model (real TNBC signature):"
+echo "  rneat gen-mut-model  -c <(printf 'reference: %s\\nvcf_file: %s\\noutput_file: %s\\noverwrite_output: true\\nbed_file: .\\n' \\"
+echo "      $REF $D/somatic.vcf.gz $D/tumor_model.json.gz)"
+echo "  # germline normal_model (this donor):"
+echo "  rneat gen-mut-model  -c <(printf 'reference: %s\\nvcf_file: %s\\noutput_file: %s\\noverwrite_output: true\\nbed_file: .\\n' \\"
+echo "      $REF $D/germline.vcf.gz $D/normal_model.json.gz)"
+echo "  # sequencing models from the real tumor BAM/FASTQ:"
+echo "  REFERENCE=$REF INPUT_BAM=$D/tumor.bam INPUT_FASTQ=$D/tumor.fastq.gz INPUT_VCF=$D/somatic.vcf.gz \\"
+echo "    sbatch scripts/delta/model_builders.sbatch"
+echo "  # compound tumor/normal simulation (gen-cancer-reads):"
+echo "  #   reference: $REF ; normal_model: normal_model.json.gz ; tumor_model: tumor_model.json.gz"
+echo "  #   germline_vcf: $D/germline.vcf.gz ; tumor_mutation_rate: model ; paired_ended + fragment_model"
+echo "════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
Stages the SEQC2 **HCC1395** (triple-negative breast cancer) / **HCC1395BL** (matched normal, same donor) reference — the only ungated real-cancer training data — for a **compound tumor model**.

## The compound model
`gen-cancer-reads` separates germline from somatic. This stages both from real data:
- **somatic layer** → SEQC2 high-confidence somatic SNV+INDEL truth VCF (real TNBC mutational signature) → `gen-mut-model` → `tumor_model`
- **germline layer** → **called from the normal BAM** here (this donor's germline) → `gen-mut-model` → `normal_model`, and reused as the shared `germline_vcf`
- **sequencing layer** → `seq-error`/`frag`/`gc`/`bam-models` from the real tumor/normal BAMs

Then `gen-cancer-reads` (now able to take a built `fragment_model`, #366) composes them into a synthetic HCC1395-like tumor/normal.

## Staging mechanics
- SEQC2 hosts **pre-aligned + deduped NovaSeq GRCh38 BAMs** (`WGS_NS_{T,N}_1.bwa.dedup.bam`), so **no alignment or bwa index** — a big simplification vs stage_soy/hg002.
- **Region-scoped (default `chr1`)** to respect the bhrd scratch quota. `MODE=remote` (default) pulls only the region from the remote BAM via `samtools` range requests (~5 GB, not the 60–80 GB whole BAM); `MODE=download` fetches the full BAM first; `REGION=all` does the whole genome.
- Somatic VCF = SNV+INDEL HighConf concat/sorted; germline = per-contig-parallel `bcftools` call on the normal BAM (reuses the soy `FULL_GENOME` fan-out pattern). Contig-naming guard + empty-BAM guard included.
- Prints the exact `gen-mut-model` / `model_builders` / `gen-cancer-reads` next-step commands.

## Notes / caveats
- Cell line ≠ fresh patient tumor (culture-acquired variants, aneuploidy) — but it's a genuine cancer genome from an individual and the community-standard public somatic reference.
- `MODE=remote` needs a samtools built with libcurl (Delta's 1.22 module should have it); guarded with a clear "retry with MODE=download" message if not.
- `bash -n` clean; region-arg parsing verified. Not run on Delta yet — Phase 1 of the HCC1395 track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)