### PR TITLE
chore(release): v1.19.1 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 Unreleased
 ==========
-## Unreleased (targeting rneat v1.19.1)
+_Nothing yet._
 
-_Version bump + date land with the develop→main release PR._
+
+7/6/2026
+========
+## rneat v1.19.1
+
+Bug-fix + logging release on top of v1.19.0. The output-affecting changes are the VCF
+dropped-FORMAT fix and the `fragment_model` input paths; the logging change is
+output-preserving (verbosity/perf only), so fidelity is unchanged from v1.19.0.
+
+### Read generation
+- `gen-reads` accepts a `fragment_model` as a paired-end fragment source — no longer
+  requires explicit `fragment_mean`/`fragment_st_dev` when a model is supplied; the model
+  takes precedence at runtime, mean/st_dev are ignored if both are set (#355).
+- `gen-cancer-reads` accepts a `fragment_model` for paired-end runs, at parity with
+  gen-reads (#366).
+
+### Model building / VCF input
+- `gen-mut-model` (and every VCF input path) now accepts spec-compliant records that drop
+  trailing per-sample FORMAT fields (all but GT). Previously these errored with "FORMAT
+  list and sample list different lengths", silently failing the model build on standard
+  GIAB / bcftools-mpileup VCFs. Samples with *more* fields than FORMAT are still rejected (#364).
 
 ### Logging / performance
 - **Default `.neat.log` level is now `info`** (was effectively `trace`). The `--log-level`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "bincode",
  "bstr",
@@ -1095,7 +1095,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.19.0'
+version = '1.19.1'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."


### PR DESCRIPTION
Release-prep for **v1.19.1**: bumps the workspace version 1.19.0 → 1.19.1 (+ `Cargo.lock`) and dates the CHANGELOG.

Develop's version currently equals the released `v1.19.0` tag, so this bump is required before a develop→main merge (otherwise main's code collides with the tag).

**Ships (4 crate-code changes over v1.19.0):**
- `gen-mut-model` / VCF input: accept spec-compliant dropped trailing FORMAT fields — no longer errors on standard GIAB / mpileup VCFs (#364, the notable bugfix)
- `gen-reads` accepts a `fragment_model` as a paired-end fragment source (#355)
- `gen-cancer-reads` accepts a `fragment_model` (#366)
- logging default → `info` (output-preserving; perf/verbosity only) (#340)

Fidelity is unchanged from v1.19.0. Builds clean at 1.19.1.

**After this merges to develop:** cut the `develop → main` release PR, then tag `v1.19.1` on main. (Conda recipe → 1.19.1 + sha256 is a post-tag step — needs the release tarball hash.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)