### PR TITLE
chore(conda-recipe): bump to v1.19.1 + sha256

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.19.0" %}
+{% set version = "1.19.1" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 1419fe83570fc393779d0642fce103e234244c968821930914dc36094b9755e0
+  sha256: 87451c24637fdec6faf4376e04ea09fc3a1a1fba78e56efa9fb32faed87543bb
 
 build:
   number: 0


### PR DESCRIPTION
Post-tag conda recipe update for the v1.19.1 release:
- `version` 1.19.0 → 1.19.1
- `sha256` → `87451c24637fdec6faf4376e04ea09fc3a1a1fba78e56efa9fb32faed87543bb` (verified: stable across two fetches of the `v1.19.1` tag archive; tarball's embedded `Cargo.toml` confirms 1.19.1)

Build number stays 0 (new version). Mirrors the v1.19.0 recipe bump (#339). The bioconda-recipes update is the separate downstream step.