### PR TITLE
chore(conda-recipe): bump to v1.20.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.19.1" %}
+{% set version = "1.20.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 87451c24637fdec6faf4376e04ea09fc3a1a1fba78e56efa9fb32faed87543bb
+  sha256: 5287c3c05a3020a705e681995381e7eb0c24ae51a3ea77ac595121c45b91b07e
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `conda-recipe/meta.yaml` to the released **v1.20.0** tag + its tarball sha256 (`5287c3c0…`).

Follows the recipe-bump convention (targets develop, as #375 did for 1.19.1). Since main and develop are content-equal after the #379 release merge, **main also needs this** — I'll open a develop→main sync once this merges so the released recipe matches on both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)