### PR TITLE
fix(delta): stage_scn.sh unbound `mate` in fetch_read (set -u abort)

### DIFF
--- a/scripts/delta/stage_scn.sh
+++ b/scripts/delta/stage_scn.sh
@@ -87,7 +87,11 @@ ena_url() {
 # fall back to the computed URL + wget's exit code (unverified). Guards against a truncated
 # transfer AND against silently accepting one.
 fetch_read() {
-    local mate="$1" dst="$D/${SRR}_${mate}.fastq.gz" url md5 bytes rc tries=0 got
+    local mate="$1" url md5 bytes rc tries=0 got
+    # dst on its own line: in a single `local`, every RHS is expanded BEFORE any name is
+    # assigned, so ${mate} here would read the still-unset outer `mate` → "mate: unbound
+    # variable" under `set -u` (same gotcha as ena_url above).
+    local dst="$D/${SRR}_${mate}.fastq.gz"
     url="$(  awk -F'\t' 'NR==1{print $2}' <<<"$ENA_META" | cut -d';' -f"$mate")"
     md5="$(  awk -F'\t' 'NR==1{print $3}' <<<"$ENA_META" | cut -d';' -f"$mate")"
     bytes="$(awk -F'\t' 'NR==1{print $4}' <<<"$ENA_META" | cut -d';' -f"$mate")"


### PR DESCRIPTION
Hotfix for a `set -u` abort introduced in #384: `fetch_read` fails immediately on the first read fetch with `line 90: mate: unbound variable`, killing the staging job (hit on the PA3/MM-BD3A contrast run — the first run to actually exercise `fetch_read`; the MM26 run predated it).

**Cause:** `local mate="$1" dst="$D/${SRR}_${mate}.fastq.gz" ...` on one line. Bash expands every RHS of a `local` **before** assigning any name, so `${mate}` in `dst` read the still-unset outer `mate`. Exactly the gotcha already fixed + commented in `ena_url`, reintroduced here.

**Fix:** move `dst` to its own `local` line after `mate` is assigned.

**Why it slipped through:** `bash -n` and the isolated awk-parse unit test don't run the `local` line at runtime. Now tested under `set -u`: the old form errors with the exact message, the split form resolves the path correctly. No other same-line self-references in the file.

Delta harness only. The PA3 assembly (stage 1) already downloaded before the abort, so a re-run resumes straight into the reads fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)