### PR TITLE
feat(delta): SCN SV simulation + CNV calling + status doc

### DIFF
--- a/docs/scn_status.md
+++ b/docs/scn_status.md
@@ -2,10 +2,11 @@
 
 Consolidated status for the soybean-cyst-nematode (SCN, *Heterodera glycines*) real-data
 work under the realism epic (#311). Data from **João Gomes Viana** (Matt Hudson lab).
-Keep this current as the SCN work progresses. Last updated: **2026-07-11**.
+Keep this current as the SCN work progresses. Last updated: **2026-07-12**.
 
-Goal: use real SCN Pool-seq data to (Phase 1) build genuine per-strain rneat models, and
-(Phase 2) reproduce the population allele-frequency spectrum in simulated reads.
+Goal: use real SCN Pool-seq data to (Phase 1) build genuine per-strain rneat models incl.
+**structural variants**, and (Phase 2) reproduce the population allele-frequency spectrum in
+simulated reads.
 
 ## Data & accessions (BioProject PRJNA1055977)
 
@@ -57,6 +58,38 @@ against a *different* reference, so raw variant counts aren't a clean cross-stra
 A true virulence-linked variant comparison needs both pools on a **common** reference (a
 separate, orthogonal task, not yet done).
 
+## Phase 1b — Structural variants — **DONE ✅ (the "complex organism" payoff)**
+
+The short-variant staging yields only SNPs + small indels, so the model's `sv_model` was empty
+and rneat's flagship SV machinery was untested on SCN. `scripts/delta/call_scn_sv.sh` fixes that:
+Delly (`sr` on 2.x) on the staged BAM → merge with the short VCF → rebuild the model.
+
+MM26A (Delly v2.3.1, PASS SVs): **9,410 SVs** — DEL 5,169 (55%), INV 1,541 (16%), BND 1,449 (15%),
+DUP 1,081 (11%), INS 170 (2%). The rebuilt `mut_model` (job 20101361) has a **populated
+`sv_model`**: per-base SV rate 4.28×10⁻⁵; type mix Del .34 / Inv .25 / Bnd .23 / Dup .17; length
+log-normals DEL ~6.6 kb, DUP ~16 kb, INV ~60 kb (BND lengthless).
+
+- **Biology matches predictions:** DEL-dominant, **DUP present** (SCN's copy-number/duplication
+  character), and **INS/TEs suppressed** (2%) — the empirical demonstration that short reads
+  can't span the repeats where TEs live (→ the long-read motivation).
+- **Model type mix ≠ raw counts** (DEL .34 vs .56) is *expected*: `SvModel::fit_from_observations`
+  drops SVs < `MIN_SV_LENGTH_BP` = 50 (`common/src/structs/sv_model.rs:32`), filtering short DELs
+  and all 170 small INS. Not a bug.
+- **`cnv_copy_number_distribution` is empty** because `delly sr` gives DEL/DUP/INV/BND, not
+  explicit copy-number — that's what `delly cnv` (below) adds.
+
+Follow-ups (this PR):
+- **`scripts/delta/simulate_scn_sv.sh`** — simulate reads *from* the SV-inclusive model with
+  `sv_rate_scale=1.0` and verify SVs actually **render** in the golden VCF (closes the loop).
+- **`scripts/delta/call_scn_cnv.sh`** — `delly cnv` read-depth copy-number (the biologically
+  central SCN signal). Needs a mappability map (auto-built with `dicey`; `dicey` CLI is
+  version-sensitive — pass `MAP=<prebuilt>` to skip). Merge its calls to populate
+  `cnv_copy_number_distribution`.
+
+Delly 2.x note: `call` → `sr` (short-read SV); `cnv` (read-depth CNV); **`lr` = native long-read
+SV discovery** — directly usable on the PRJNA852516 PacBio/ONT data (no rneat long-read
+generation needed to *call* SVs on real long reads).
+
 ## Phase 2 — reproduce the pool allele-frequency spectrum — **designed**
 
 Full design: **`docs/scn_phase2_af_design.md`** (PR #386). Summary:
@@ -84,7 +117,12 @@ Full design: **`docs/scn_phase2_af_design.md`** (PR #386). Summary:
 | #384 | robust, ENA-verified read download (retry + size/md5) |
 | #385 | `set -u` hotfix (unbound `mate` in `fetch_read`) |
 | #382 | cancer-pipeline re-run staleness fix (adjacent, found during this track) |
-| #386 | Phase 2 design doc *(open)* |
+| #386 | Phase 2 (allele-frequency) design doc |
+| #388 | `call_scn_sv.sh` — Delly structural-variant calling → SV model |
+| #389 | long-read epic scope doc |
+| #390 / #391 | Delly static-binary override + Boost fix; Delly 2.x `call`→`sr` |
+| #387 | this status doc |
+| *(this PR)* | `simulate_scn_sv.sh` (SV render check) + `call_scn_cnv.sh` (CNV) |
 
 ## Operational notes (Delta)
 
@@ -98,7 +136,11 @@ Full design: **`docs/scn_phase2_af_design.md`** (PR #386). Summary:
 
 ## Next steps
 
-1. **Phase 2 Step 0** — AF extraction + `scn_af_compare.py` + ploidy=2 gap baseline (no code).
-2. Trace the input-VCF → read-stream path; implement the `allele_fraction` enabling change
-   (issue under #311); re-run + validate; A/B MM26 vs PA3/BD3.
-3. *(Orthogonal, optional)* common-reference variant comparison for a clean virulence signal.
+1. **Run the SV follow-ups (in progress):** `simulate_scn_sv.sh` (confirm SVs render from the
+   trained model) + `call_scn_cnv.sh` (populate the CNV distribution).
+2. **PA3 / MM-BD3 SV contrast** — run the SV + CNV pipeline on the avirulent line and compare SV
+   spectra virulent-vs-avirulent (reference-bias caveat applies).
+3. **Long reads:** `delly lr` on the PRJNA852516 PacBio/ONT data to recover the TEs short reads
+   under-call (no rneat long-read *generation* needed). See `docs/longread_epic_scope.md`.
+4. **Phase 2 Step 0** — AF extraction + `scn_af_compare.py` + ploidy=2 gap baseline (no code),
+   then the `allele_fraction` enabling change (issue under #311).

--- a/scripts/delta/call_scn_cnv.sh
+++ b/scripts/delta/call_scn_cnv.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# SLURM job: call COPY-NUMBER VARIANTS on the staged SCN data with `delly cnv`, to populate the
+# biologically-central CNV signal that `delly sr` (call_scn_sv.sh) does NOT produce — its output
+# is DEL/DUP/INV/BND, so the built sv_model's `cnv_copy_number_distribution` comes out empty.
+# CNV / gene copy-number is at the heart of SCN virulence (host Rhg1/Rhg4 resolve via copy-number;
+# the SCN genome has extensive parasitism-gene duplications — see call_scn_sv.sh refs), so a
+# read-depth CNV pass is the highest-value biology add for the SV model.
+#
+# ⚠️ `delly cnv` REQUIRES a mappability map (`-m`). There's no prebuilt map for a non-model genome
+# like SCN, so we generate one with `dicey` (dellytools), following Delly's documented procedure:
+# chop the genome into reads → realign → measure per-base mappability. This is the heavy/fiddly
+# part and dicey's CLI is VERSION-SENSITIVE (we learned the hard way that Delly 2.x renamed
+# `call`→`sr`) — if the chop/mappability2 calls below fail, check `dicey --help` for your version,
+# or pass a prebuilt map with MAP=<path> to skip generation entirely.
+#
+# Prereqs: strain staged by stage_scn.sh (REF + BAM); delly (static v2.3.1, DELLY=<path>) + dicey
+# (conda install -n bioinf -c bioconda dicey) + bwa-mem2 + bcftools; samtools/htslib modules.
+#
+# Usage:
+#   DELLY=$SCRATCH/bin/delly sbatch scripts/delta/call_scn_cnv.sh                 # MM26/MM26A
+#   DELLY=… ACC=GCA_040805705.1 SRR=SRR27329600 sbatch scripts/delta/call_scn_cnv.sh   # PA3/BD3
+#   DELLY=… MAP=/path/to/prebuilt.map.fa.gz sbatch scripts/delta/call_scn_cnv.sh   # skip dicey
+
+#SBATCH --job-name=rneat-scncnv
+#SBATCH --partition=cpu
+#SBATCH --account=bhrd-delta-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=48G
+#SBATCH --time=12:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"
+
+D="${DATA_DIR:-$SCRATCH/neat_data/scn}"
+ACC="${ACC:-GCA_040805935.1}"
+SRR="${SRR:-SRR27329602}"
+REF="${REFERENCE:-$D/${ACC}.fa}"
+BAM="${BAM:-$D/${SRR}.bam}"
+MAP="${MAP:-$D/${ACC}.map.fa.gz}"           # mappability map; auto-generated with dicey if absent
+DELLY="${DELLY:-delly}"
+THREADS="${SLURM_CPUS_PER_TASK:-16}"
+
+module load samtools/1.22-cce19.0.0
+module load htslib/1.22-gcc13.3.1
+setup_conda
+conda_activate bioinf
+
+"$DELLY" --version >/dev/null 2>&1 || { echo "delly '$DELLY' not runnable — pass DELLY=<static binary>." >&2; exit 1; }
+"$DELLY" --help 2>&1 | grep -qE '^[[:space:]]*cnv[[:space:]]' || { echo "this delly has no 'cnv' subcommand." >&2; exit 1; }
+[[ -s "$REF" ]] || { echo "reference not staged: $REF (run stage_scn.sh)" >&2; exit 1; }
+[[ -s "$BAM" ]] || { echo "BAM not staged: $BAM (run stage_scn.sh)" >&2; exit 1; }
+[[ -f "$REF.fai" ]] || samtools faidx "$REF"
+[[ -f "$BAM.bai" ]] || samtools index "$BAM"
+
+echo "=== SCN CNV calling: ref=$ACC  bam=$(basename "$BAM") ==="
+
+# ── 1. mappability map (dicey) — VERSION-SENSITIVE; skip if MAP already exists ────
+if [[ ! -s "$MAP" ]]; then
+    command -v dicey >/dev/null 2>&1 || {
+        echo "dicey not found (conda install -n bioinf -c bioconda dicey), or pass MAP=<prebuilt>." >&2
+        exit 1; }
+    echo "generating mappability map with dicey (Delly's documented procedure)..."
+    MW="$D/cnv_map_${ACC}"; mkdir -p "$MW"
+    ( cd "$MW"
+      # chop the genome into simulated reads, realign to itself, measure mappability.
+      dicey chop "$REF"
+      [[ -s "$REF.bwt.2bit.64" ]] || bwa-mem2 index "$REF"
+      bwa-mem2 mem -t "$THREADS" "$REF" read1.fq.gz read2.fq.gz 2>bwa.log \
+          | samtools sort -@ "$THREADS" -o srt.bam -
+      samtools index srt.bam
+      dicey mappability2 srt.bam            # → map.fa.gz (+ any .fai/.gzi)
+      # normalize to a bgzipped, faidx'd map at $MAP
+      gunzip -f map.fa.gz
+      bgzip -f map.fa
+      mv -f map.fa.gz "$MAP"
+      samtools faidx "$MAP"
+    )
+    rm -rf "$MW"
+fi
+[[ -s "$MAP" ]] || { echo "mappability map missing after generation: $MAP" >&2; exit 1; }
+
+# ── 2. delly cnv (read-depth copy-number) ────────────────────────────────────────
+CNV_BCF="$D/${SRR}.cnv.bcf"
+CNV_VCF="$D/${SRR}.cnv.vcf.gz"
+if [[ ! -s "$CNV_VCF" ]]; then
+    echo "delly cnv..."
+    OMP_NUM_THREADS="$THREADS" "$DELLY" cnv -g "$REF" -m "$MAP" -o "$CNV_BCF" "$BAM"
+    bcftools view -f PASS -O z -o "$CNV_VCF" "$CNV_BCF"
+    bcftools index -t "$CNV_VCF"
+fi
+
+ncnv=$(bcftools view -H "$CNV_VCF" | wc -l)
+echo "── copy-number spread (PASS; CN from FORMAT/RDCN where available) ──"
+bcftools view -H "$CNV_VCF" | grep -oE 'SVTYPE=[A-Z]+' | sort | uniq -c | sort -rn || true
+echo "  total PASS CNV segments: $ncnv"
+
+echo
+echo "════════════════════════════════════════════════════════════════"
+echo "SCN CNVs: $ncnv PASS segments → $CNV_VCF"
+echo "To fold CNV into the model, concat it into the all-variants VCF (sample-normalized, like"
+echo "call_scn_sv.sh does) and rebuild — the sv_model's cnv_copy_number_distribution then populates:"
+echo "  # reheader $CNV_VCF + $D/${SRR}.all.vcf.gz to a common sample, bcftools concat -a | sort,"
+echo "  # then: REFERENCE=$REF INPUT_BAM=$BAM INPUT_FASTQ=$D/${SRR}.fastq.gz INPUT_VCF=<merged> \\"
+echo "  #       sbatch scripts/delta/model_builders.sbatch"
+echo "════════════════════════════════════════════════════════════════"

--- a/scripts/delta/simulate_scn_sv.sh
+++ b/scripts/delta/simulate_scn_sv.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# SLURM job: simulate reads FROM the SV-inclusive SCN model and verify structural variants
+# actually RENDER in the golden VCF. This closes the loop end-to-end:
+#   real SCN SVs (Delly) → gen-mut-model sv_model → gen-reads renders SVs into the truth set.
+# It is the ultimate proof that rneat's SV machinery works on a real complex organism, not just
+# that the model file has an sv_model field.
+#
+# gen-reads only emits SVs when `sv_rate_scale > 0` (default 0 = opt-in) AND the mutation model
+# carries a populated sv_model; sv_rate_scale=1.0 reproduces the model's trained per-base SV rate.
+#
+# Prereqs: call_scn_sv.sh + model_builders already run with the SV-inclusive VCF (INPUT_VCF=
+# …all.vcf.gz), producing a mut_model.json.gz whose sv_model is populated. Pass MODELS=<that
+# model_builders output>/models. Reference staged by stage_scn.sh. rneat built (setup.sh).
+#
+# Usage:
+#   MODELS=$SCRATCH/modelbuild_<JOB>/models sbatch scripts/delta/simulate_scn_sv.sh
+#   MODELS=… COV=5 sbatch scripts/delta/simulate_scn_sv.sh          # lighter/heavier coverage
+
+#SBATCH --job-name=rneat-scnsvsim
+#SBATCH --partition=cpu
+#SBATCH --account=bhrd-delta-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=6:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+REPO_ROOT="${RNEAT_REPO:-${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}}"
+source "$REPO_ROOT/scripts/delta/lib_report.sh"
+
+D="${DATA_DIR:-$SCRATCH/neat_data/scn}"
+ACC="${ACC:-GCA_040805935.1}"
+REF="${REFERENCE:-$D/${ACC}.fa}"
+MODELS="${MODELS:?set MODELS=<model_builders output>/models (the SV-inclusive build)}"
+COV="${COV:-8}"
+SV_SCALE="${SV_RATE_SCALE:-1.0}"      # 1.0 = the model's trained SV rate
+OUTDIR="${OUTDIR:-$SCRATCH/scn_svsim_${SLURM_JOB_ID:-manual}}"
+THREADS="${SLURM_CPUS_PER_TASK:-8}"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
+RNEAT_BIN="${RNEAT_BIN:-$CARGO_TARGET_DIR/release/rneat}"
+
+source "$HOME/.cargo/env" 2>/dev/null || true
+module load samtools/1.22-cce19.0.0
+module load htslib/1.22-gcc13.3.1
+
+MUT="$MODELS/mut_model.json.gz"
+[[ -s "$REF" ]] || { echo "reference not staged: $REF (run stage_scn.sh)" >&2; exit 1; }
+[[ -s "$MUT" ]] || { echo "mut_model not found: $MUT (run model_builders with the SV-inclusive VCF)" >&2; exit 1; }
+[[ -x "$RNEAT_BIN" ]] || { echo "rneat binary not found: $RNEAT_BIN (run setup.sh)" >&2; exit 1; }
+
+# Preflight: the model must actually carry an sv_model, else this test is meaningless.
+python3 - "$MUT" <<'PY' || { echo "ABORT: mut_model has no sv_model — build from the SV-inclusive VCF first." >&2; exit 1; }
+import gzip, json, sys
+d = json.load(gzip.open(sys.argv[1]))
+sv = d.get("sv_model")
+assert sv is not None, "sv_model is None"
+print(f"sv_model present: per_base_rate={sv.get('per_base_rate')} types={list(sv.get('type_probabilities',{}))}")
+PY
+
+mkdir -p "$OUTDIR"
+cat > "$OUTDIR/sim.yml" <<YML
+reference: $REF
+read_len: 151
+coverage: $COV
+ploidy: 2
+paired_ended: true
+sv_rate_scale: $SV_SCALE
+produce_fastq: true
+produce_vcf: true
+produce_bam: false
+overwrite_output: true
+output_dir: $OUTDIR
+output_filename: scn_svsim
+rng_seed: scn sv render check
+num_threads: $THREADS
+mutation_model: $MUT
+YML
+# The other built models are optional here (we're testing SV rendering, not error/frag fidelity),
+# but include them if present so the reads are realistic too.
+[[ -s "$MODELS/seq_error.json.gz" ]]  && echo "sequence_error_model: $MODELS/seq_error.json.gz" >> "$OUTDIR/sim.yml"
+[[ -s "$MODELS/frag_length.json.gz" ]] && echo "fragment_model: $MODELS/frag_length.json.gz"     >> "$OUTDIR/sim.yml"
+[[ -s "$MODELS/gc_bias.json.gz" ]]    && echo "gc_bias_model: $MODELS/gc_bias.json.gz"           >> "$OUTDIR/sim.yml"
+
+echo "=== gen-reads (sv_rate_scale=$SV_SCALE, cov=$COV) from $MUT ==="
+"$RNEAT_BIN" --log-level info gen-reads -c "$OUTDIR/sim.yml"
+
+GOLDEN="$OUTDIR/scn_svsim.vcf.gz"
+[[ -s "$GOLDEN" ]] || { echo "no golden VCF at $GOLDEN — did produce_vcf run?" >&2; exit 1; }
+
+echo
+echo "── SVs RENDERED in the simulated golden VCF (by SVTYPE) ──"
+zcat "$GOLDEN" | grep -v '^#' | grep -oE 'SVTYPE=[A-Za-z]+' | sort | uniq -c | sort -rn
+nsv=$(zcat "$GOLDEN" | grep -v '^#' | grep -c 'SVTYPE=' || true)
+ntot=$(zcat "$GOLDEN" | grep -vc '^#' || true)
+echo
+echo "════════════════════════════════════════════════════════════════"
+echo "Simulated golden VCF: $ntot variants, of which $nsv are SVs (symbolic ALT / SVTYPE)."
+if [[ "$nsv" -gt 0 ]]; then
+    echo "✅ rneat RENDERED structural variants from the SCN-trained sv_model — loop closed."
+else
+    echo "⚠️ NO SVs rendered — check sv_rate_scale>0 and that sv_model.per_base_rate>0."
+fi
+echo "Golden VCF: $GOLDEN"
+echo "════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
Follow-ups to the SV milestone (real SCN SVs → `gen-mut-model` `sv_model` populated). Addresses options 1 (simulate) and 3 (CNV).

**`simulate_scn_sv.sh`** — simulate reads *from* the SV-inclusive model (`sv_rate_scale=1.0`, which reproduces the trained SV rate) and verify SVs actually **render** in the golden VCF. Preflights that `sv_model` is populated; reports the simulated SVTYPE spread. This closes the loop end-to-end: real SCN SVs → `sv_model` → gen-reads output.

**`call_scn_cnv.sh`** — `delly cnv` read-depth copy-number, the biologically-central SCN signal that `delly sr` doesn't produce (so `cnv_copy_number_distribution` came out empty). `delly cnv` needs a mappability map; there's none prebuilt for a non-model genome, so it auto-builds one with `dicey` (Delly's documented chop→realign→mappability procedure). **`dicey`'s CLI is version-sensitive** (flagged in the header — we learned that lesson from `call`→`sr`); pass `MAP=<prebuilt>` to skip generation.

**`docs/scn_status.md`** — records the SV milestone (9,410 SVs; populated `sv_model` with per-base rate 4.28e-5 + type mix + length log-normals; the `MIN_SV_LENGTH_BP=50` reason the model mix ≠ raw counts; Delly 2.x `sr`/`cnv`/`lr` notes), the two new scripts, and refreshed tooling + next steps.

Delta harness + docs only. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)