### PR TITLE
fix(rng): NeatRng::random() could return values outside [0,1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+Unreleased
+==========
+
+### Bug fixes
+- **RNG: `NeatRng::random()` could return values outside `[0,1)`.** `new_from_seed` only
+  nudged out-of-range seed state by `+1` (`if x < 0 { x += 1 }`), but `mash()` can return
+  `>= 1`, so certain seeds — notably RNGs from `derive_child(idx)` (one per contig/chunk in
+  whole-genome gen-reads) — left the state far outside `[0,1)` (observed: a child whose first
+  `random()` was `-8311.87`). Downstream this crashed `Normal::inverse_cdf` in fragment-length
+  sampling on the SV-weighted path (`x must be in [0, 1]`) at whole-genome scale, and could
+  have mis-fed other RNG consumers. Fixed by normalizing seed state with `rem_euclid(1.0)`,
+  which is byte-identical to the old wrap for the well-behaved `[-1,1)` range — so existing
+  seeds/outputs are unchanged (model-parity + full suite green); only previously-broken seeds
+  change. Regression test added.
+
+
 7/7/2026
 ========
 ## rneat v1.20.0 — realism update

--- a/common/src/rng/mod.rs
+++ b/common/src/rng/mod.rs
@@ -58,18 +58,17 @@ impl NeatRng {
             let vector_seed = seed.chars().collect::<Vec<char>>();
             seed_vec.push(vector_seed.clone());
             // update the parameters
-            s0 -= masher.mash(&vector_seed);
-            if s0 < 0f64 {
-                s0 += 1f64;
-            }
-            s1 -= masher.mash(&vector_seed);
-            if s1 < 0f64 {
-                s1 += 1f64;
-            }
-            s2 -= masher.mash(&vector_seed);
-            if s2 < 0f64 {
-                s2 += 1f64;
-            }
+            // Normalize the state into [0,1) with rem_euclid. The old `if sX < 0 { += 1 }`
+            // only nudged by one, so when `mash()` returns >= 1 (its `n/NORM` can exceed 1),
+            // the state escaped [0,1) — sometimes by thousands. `random()` then produced
+            // out-of-range/garbage draws (its `t.floor() as u32` truncation compounds it),
+            // which crashed `Normal::inverse_cdf` downstream (fragment-length sampling in the
+            // SV-weighted path). rem_euclid maps ANY finite value into [0,1); for the
+            // well-behaved range [-1,1) it is byte-identical to the old wrap, so seeds that
+            // already worked are unaffected — only the previously-broken ones change.
+            s0 = (s0 - masher.mash(&vector_seed)).rem_euclid(1.0);
+            s1 = (s1 - masher.mash(&vector_seed)).rem_euclid(1.0);
+            s2 = (s2 - masher.mash(&vector_seed)).rem_euclid(1.0);
         }
 
         Ok(NeatRng { s0, s1, s2, c })
@@ -150,6 +149,26 @@ impl NeatRng {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Regression: `random()` must ALWAYS return a finite value in [0,1), including for
+    // derived children (whole-genome gen-reads derives one RNG per contig/chunk). Before the
+    // rem_euclid fix in new_from_seed, some derived seeds left the state far outside [0,1)
+    // (e.g. derive_child(6097) → random() == -8311.87), which crashed Normal::inverse_cdf in
+    // fragment-length sampling on the SV-weighted path at whole-genome scale.
+    #[test]
+    fn random_always_in_unit_interval_across_derived_children() {
+        let base = NeatRng::new_from_seed(&vec!["scn sv render check".to_string()]).unwrap();
+        for idx in 0..30_000u64 {
+            let mut child = base.derive_child(idx);
+            for _ in 0..40 {
+                let x = child.random().unwrap();
+                assert!(
+                    x.is_finite() && (0.0..1.0).contains(&x),
+                    "derive_child({idx}).random() = {x} is out of [0,1)"
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_gen_bool() {


### PR DESCRIPTION
**Core RNG correctness bug** (affects the released binary), found while simulating SVs on the whole SCN genome.

**Symptom:** `gen-reads` panicked `x must be in [0, 1]` in `Normal::inverse_cdf`, via `FragmentLengthModel::generate_fragment` in the SV-weighted fragment path, only at whole-genome scale.

**Root cause:** `NeatRng::new_from_seed` normalized seed state with a single `if x < 0 { x += 1 }`, but `mash()` returns `n/NORM` which can be `>= 1`. So seeds whose `mash` pushed the state far outside `[0,1)` — notably `derive_child(idx)` RNGs (one per contig/chunk) — never recovered, and `random()` (whose `t.floor() as u32` truncation compounds it) then returned garbage. Reproduced deterministically: `derive_child(6097).random() == -8311.87`. A whole-genome run derives enough children to hit a bad one; that value reaches the fragment Normal and panics.

**Fix:** normalize seed state with `rem_euclid(1.0)`. For the well-behaved `[-1,1)` range it's **byte-identical** to the old wrap, so existing seeds/outputs are unchanged — **`model_parity` and the full suite stay green** (350 + 258 + integration, 0 failures). Only previously-broken seeds change.

**Test:** regression test derives 30k children × 40 draws and asserts every `random()` is finite and in `[0,1)` (fails pre-fix at idx 6097).

Unblocks the SCN SV-render simulation (`simulate_scn_sv.sh`, #392).

🤖 Generated with [Claude Code](https://claude.com/claude-code)