### PR TITLE
chore(conda-recipe): bump to v1.20.1

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.20.0" %}
+{% set version = "1.20.1" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 5287c3c05a3020a705e681995381e7eb0c24ae51a3ea77ac595121c45b91b07e
+  sha256: 228883fd6268650d1b8b9fee77b850867836b749c905e61fa7d98ca72f4368b6
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `conda-recipe/meta.yaml` to the released **v1.20.1** tag + its tarball sha256 (`228883fd…`). Targets develop, per the recipe-bump convention (#380 did the same for 1.20.0).