### PR TITLE
chore(release): v1.21.0 — per-variant allele fraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+7/18/2026
+=========
+## rneat v1.21.0 — per-variant allele fraction
+
+Adds an optional per-variant allele fraction so an input VCF can drive a continuous
+allele-frequency spectrum in the simulated reads, instead of only the `{0.5, 1.0}` the
+genotype-based fraction could produce. Backward-compatible: variants without an allele
+fraction are unchanged (model-parity + full suite green).
+
+### Read generation — allele-frequency realism (#398)
+- gen-reads now honors an optional per-variant `allele_fraction` parsed from the input VCF —
+  `INFO/AF` if present, else `FORMAT/AD` as `alt / (ref + alt)`. When set, the alt allele is
+  emitted on that fraction of overlapping reads, and the golden VCF's measured `GT:AD:DP:AF`
+  tracks it. This lets rneat replay pooled or somatic allele-frequency spectra from a real
+  sample — the reproductive-replay case the model builders could not express before. Allele
+  depth is used over genotype for pooled data, where `GT` is not diploid-meaningful.
+- **Backward-compatible.** Variants with no allele fraction keep the genotype-based behavior
+  (homozygous → all alt, heterozygous → ~0.5) with the identical RNG draw, so default runs are
+  byte-identical to prior output.
+- **Validated on real data.** On soybean-cyst-nematode Pool-seq, simulated-vs-real per-site
+  allele frequency reached Pearson r = 0.98 at 150x coverage, unbiased, with the residual
+  error tracking the binomial coverage-noise floor.
+
+### Notes
+- `Variant` no longer derives `Eq` / `Hash` — the new `Option<f64>` field is only `PartialEq`,
+  and `Variant` was never used as a map key or set member (a separate `VariantKey` is hashed).
+
+
 7/13/2026
 =========
 ## rneat v1.20.1 — bug-fix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.20.1"
+version = "1.21.0"
 dependencies = [
  "bincode",
  "bstr",
@@ -1095,7 +1095,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.20.1"
+version = "1.21.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.20.1'
+version = '1.21.0'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."


### PR DESCRIPTION
Corrects the version collision on `develop`: the allele_fraction feature (#398, PR #399)
merged without a version bump, so `develop` was sitting on the already-released **1.20.1**.

- Workspace version **1.20.1 → 1.21.0** (minor — new backward-compatible feature).
- CHANGELOG entry for v1.21.0 (per-variant `allele_fraction`, validated on SCN Pool-seq at r = 0.98).
- Lockfile refreshed. **No code changes.**

After this merges, `develop` reports 1.21.0 correctly. Shipping (develop→main PR + tag `v1.21.0`
+ conda recipe bump) is the follow-up when you're ready to cut the release.