### PR TITLE
chore(conda-recipe): bump to v1.21.0 + sha256

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.20.1" %}
+{% set version = "1.21.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 228883fd6268650d1b8b9fee77b850867836b749c905e61fa7d98ca72f4368b6
+  sha256: 36f95c15e79578c3cec3e3b0d4724e530bfc0f0166bbd324a1b6f888ab1aae5f
 
 build:
   number: 0


### PR DESCRIPTION
Bumps the bioconda recipe to **v1.21.0** now that it's tagged/released on `main`.

- `version` 1.20.1 → 1.21.0
- `sha256` of the v1.21.0 release tarball: `36f95c15e79578c3cec3e3b0d4724e530bfc0f0166bbd324a1b6f888ab1aae5f`
  (from `curl -sL .../v1.21.0.tar.gz | sha256sum`)

Last step to finish the v1.21.0 release. Mirrors the prior recipe-bump PRs (#380, #396).