### PR TITLE
chore: sync conda recipe (v1.21.0) develop → main

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.20.1" %}
+{% set version = "1.21.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 228883fd6268650d1b8b9fee77b850867836b749c905e61fa7d98ca72f4368b6
+  sha256: 36f95c15e79578c3cec3e3b0d4724e530bfc0f0166bbd324a1b6f888ab1aae5f
 
 build:
   number: 0


### PR DESCRIPTION
Post-release sync. v1.21.0 is already tagged/released on `main`; this brings the only develop-only
change — the **bioconda recipe bump to 1.21.0** (#406) — onto `main` so the two branches stay in
lockstep (main's recipe was still at 1.20.1).

- Ships: conda-recipe/meta.yaml → version 1.21.0 + v1.21.0 tarball sha256.
- No code, no new release, **no tag** — the v1.21.0 tag already exists.
- Divergence check: `main` carries no content `develop` lacks.