### PR TITLE
fix(delta): harden SCN/soy harness scripts (#395 correctness + guards)

### DIFF
--- a/scripts/delta/call_scn_cnv.sh
+++ b/scripts/delta/call_scn_cnv.sh
@@ -75,6 +75,9 @@ if [[ ! -s "$MAP" ]]; then
           | samtools sort -@ "$THREADS" -o srt.bam -
       samtools index srt.bam
       dicey mappability2 srt.bam            # → map.fa.gz (+ any .fai/.gzi)
+      # dicey's CLI is version-sensitive; fail loudly if the expected output is absent
+      # rather than letting the next step operate on a missing/renamed file.
+      [[ -s map.fa.gz ]] || { echo "ERROR: dicey mappability2 did not produce map.fa.gz (CLI version mismatch?)" >&2; exit 1; }
       # normalize to a bgzipped, faidx'd map at $MAP
       gunzip -f map.fa.gz
       bgzip -f map.fa

--- a/scripts/delta/call_scn_sv.sh
+++ b/scripts/delta/call_scn_sv.sh
@@ -102,7 +102,7 @@ if [[ ! -s "$SV_VCF" ]]; then
 fi
 
 echo "── SVTYPE spread (PASS) ──"
-bcftools view -H "$SV_VCF" | grep -oE 'SVTYPE=[A-Z]+' | sort | uniq -c | sort -rn
+bcftools view -H "$SV_VCF" | grep -oE 'SVTYPE=[A-Z]+' | sort | uniq -c | sort -rn || true
 nsv=$(bcftools view -H "$SV_VCF" | wc -l)
 echo "  total PASS SVs: $nsv"
 

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -84,7 +84,9 @@ VARSCAN_ENV="${VARSCAN_ENV:-varscan}"
 RUN_STRELKA="${RUN_STRELKA:-0}"
 STRELKA_ENV="${STRELKA_ENV:-strelka}"
 
-THREADS=$SLURM_CPUS_PER_TASK
+# Default the SLURM vars so a direct (non-sbatch) run doesn't abort under `set -u`.
+: "${SLURM_JOB_ID:=manual}"
+THREADS="${SLURM_CPUS_PER_TASK:-4}"
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
 RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
 PREFIX="$OUTDIR/sample"

--- a/scripts/delta/simulate_scn_sv.sh
+++ b/scripts/delta/simulate_scn_sv.sh
@@ -93,7 +93,7 @@ GOLDEN="$OUTDIR/scn_svsim.vcf.gz"
 
 echo
 echo "── SVs RENDERED in the simulated golden VCF (by SVTYPE) ──"
-zcat "$GOLDEN" | grep -v '^#' | grep -oE 'SVTYPE=[A-Za-z]+' | sort | uniq -c | sort -rn
+zcat "$GOLDEN" | grep -v '^#' | grep -oE 'SVTYPE=[A-Za-z]+' | sort | uniq -c | sort -rn || true
 nsv=$(zcat "$GOLDEN" | grep -v '^#' | grep -c 'SVTYPE=' || true)
 ntot=$(zcat "$GOLDEN" | grep -vc '^#' || true)
 echo

--- a/scripts/delta/stage_scn.sh
+++ b/scripts/delta/stage_scn.sh
@@ -160,8 +160,11 @@ if [[ "$MAX_PAIRS" -gt 0 ]]; then
         # head closes the pipe → zcat gets SIGPIPE (141); expected, so drop pipefail for
         # just these two so `set -e` doesn't abort a step that actually succeeded.
         set +o pipefail
-        zcat "$R1" | head -n $(( MAX_PAIRS * 4 )) | gzip > "$D/sub_1.fastq.gz"
-        zcat "$R2" | head -n $(( MAX_PAIRS * 4 )) | gzip > "$D/sub_2.fastq.gz"
+        # Write to .tmp then promote, so an interrupted run leaves a partial .tmp
+        # (regenerated next run) rather than a truncated sub_*.fastq.gz the -s guard
+        # above would wrongly accept.
+        zcat "$R1" | head -n $(( MAX_PAIRS * 4 )) | gzip > "$D/sub_1.fastq.gz.tmp" && mv -f "$D/sub_1.fastq.gz.tmp" "$D/sub_1.fastq.gz"
+        zcat "$R2" | head -n $(( MAX_PAIRS * 4 )) | gzip > "$D/sub_2.fastq.gz.tmp" && mv -f "$D/sub_2.fastq.gz.tmp" "$D/sub_2.fastq.gz"
         set -o pipefail
     fi
     R1="$D/sub_1.fastq.gz"; R2="$D/sub_2.fastq.gz"
@@ -191,11 +194,22 @@ if [[ ! -s "$VCF" ]]; then
     ncontig=$(wc -l < "$REF.fai")
     echo "calling genome-wide VCF ($ncontig contigs, ${THREADS}-way)..."
     cut -f1 "$REF.fai" | xargs -P "$THREADS" -I CTG bash -c '
+        set -o pipefail
         ctg="$1"; out="'"$parts"'/$ctg.vcf.gz"
         [[ -s "$out" ]] && exit 0
-        bcftools mpileup -a FORMAT/AD -r "$ctg" -f "'"$REF"'" "'"$BAM"'" 2>/dev/null \
-            | bcftools call -mv -Oz -o "$out" 2>/dev/null
-    ' _ CTG
+        if ! bcftools mpileup -a FORMAT/AD -r "$ctg" -f "'"$REF"'" "'"$BAM"'" 2>"$out.log" \
+             | bcftools call -mv -Oz -o "$out.tmp" 2>>"$out.log"; then
+            echo "ERROR: per-contig VCF call failed for $ctg (see $out.log)" >&2
+            rm -f "$out.tmp"; exit 1
+        fi
+        mv -f "$out.tmp" "$out"
+    ' _ CTG || { echo "ERROR: a per-contig VCF call failed; aborting before concat (logs in $parts/*.log)" >&2; exit 1; }
+    # Guard against a silently-dropped contig: every fai contig must have produced a
+    # part before concat. A variant-free contig still yields a valid header-only file,
+    # so we fail only on a MISSING part (the symptom of a crashed/OOM'd call).
+    for c in $(cut -f1 "$REF.fai"); do
+        [[ -s "$parts/$c.vcf.gz" ]] || { echo "ERROR: missing per-contig VCF part for '$c'" >&2; exit 1; }
+    done
     cut -f1 "$REF.fai" | sed "s#^#$parts/#; s#\$#.vcf.gz#" > "$D/${SRR}_parts.list"
     bcftools concat -Oz -f "$D/${SRR}_parts.list" -o "$VCF"
     bcftools index -t "$VCF"

--- a/scripts/delta/stage_soy.sh
+++ b/scripts/delta/stage_soy.sh
@@ -119,11 +119,22 @@ if [[ -n "$FULL_GENOME" ]]; then
         parts="$D/vcf_parts"; mkdir -p "$parts"
         echo "calling genome-wide VCF ($ncontig contigs, ${THREADS}-way)..."
         cut -f1 "$REF.fai" | xargs -P "$THREADS" -I CTG bash -c '
+            set -o pipefail
             ctg="$1"; out="'"$parts"'/$ctg.vcf.gz"
             [[ -s "$out" ]] && exit 0
-            bcftools mpileup -r "$ctg" -f "'"$REF"'" "'"$D"'/soy.full.bam" 2>/dev/null \
-                | bcftools call -mv -Oz -o "$out" 2>/dev/null
-        ' _ CTG
+            if ! bcftools mpileup -r "$ctg" -f "'"$REF"'" "'"$D"'/soy.full.bam" 2>"$out.log" \
+                 | bcftools call -mv -Oz -o "$out.tmp" 2>>"$out.log"; then
+                echo "ERROR: per-contig VCF call failed for $ctg (see $out.log)" >&2
+                rm -f "$out.tmp"; exit 1
+            fi
+            mv -f "$out.tmp" "$out"
+        ' _ CTG || { echo "ERROR: a per-contig VCF call failed; aborting before concat (logs in $parts/*.log)" >&2; exit 1; }
+        # A silently-dropped contig would vanish from the genome-wide VCF; require every
+        # fai contig to have produced a part (variant-free → valid header-only file; only
+        # a MISSING part is a failure).
+        for c in $(cut -f1 "$REF.fai"); do
+            [[ -s "$parts/$c.vcf.gz" ]] || { echo "ERROR: missing per-contig VCF part for '$c'" >&2; exit 1; }
+        done
         # concat parts in genome (fai) order; same reference header → no -a needed
         cut -f1 "$REF.fai" | sed "s#^#$parts/#; s#\$#.vcf.gz#" > "$D/vcf_parts.list"
         bcftools concat -Oz -f "$D/vcf_parts.list" -o "$D/soy.full.vcf.gz"


### PR DESCRIPTION
Addresses the **correctness** findings and **lower-priority guards** from #395 (v1.20.1 review). Harness scripts only — no binary change; all six pass `bash -n`.

## Correctness
1. **Silent contig drop** (`stage_scn.sh`, `stage_soy.sh`) — the per-contig `bash -c` ran without `pipefail` and discarded stderr, so a failed/OOM'd contig wrote a header-only VCF the `[[ -s ]]` guard accepted → that contig vanished from the genome-wide VCF. Now: `pipefail` inside the `bash -c`, stderr → per-contig `.log`, write to `.tmp` and promote only on success, plus a post-fan-out check that **every fai contig produced a part** before concat (a variant-free contig still yields a valid header-only file, so only a *missing* part fails).
2. **Unreachable zero-SV diagnostic** (`simulate_scn_sv.sh:96`, `call_scn_sv.sh:105`) — the `grep -oE | uniq -c` pipelines lacked `|| true`, so a zero-SV run aborted before the diagnostic. Added `|| true` (matching `call_scn_cnv.sh:100`).

## Guards (lower-priority items)
- `call_scn_cnv.sh`: assert `map.fa.gz` exists before consuming it (dicey CLI is version-sensitive).
- `stage_scn.sh` subsample: `.tmp` + `mv` so an interrupted run leaves a partial temp, not a truncated file the `-s` guard would accept.
- `cancer_pipeline.sbatch`: default `SLURM_JOB_ID` / `SLURM_CPUS_PER_TASK` so a direct run doesn't abort under `set -u`.

## Deferred
Item 4 (de-duplicate `stage_scn.sh` vs `stage_soy.sh` by hoisting shared helpers into `lib_report.sh`, incl. moving `stage_soy.sh` off the unverified `wget -c`) is a larger refactor — left as a follow-up so this stays a focused, reviewable correctness PR. #395 can stay open for it.