### PR TITLE
test(delta): reproducibility harness — drop contig-order check, add thread- & contig-name-invariance

### DIFF
--- a/scripts/delta/run_order_independence.sbatch
+++ b/scripts/delta/run_order_independence.sbatch
@@ -1,28 +1,35 @@
 #!/bin/bash
-# SLURM job: order-independence + determinism validation (report §4 item "#3 SHUFFLE").
+# SLURM job: reproducibility + determinism validation (report §3.10).
 #
-# Confirms that rneat's output is reproducible and invariant to things that MUST
-# NOT change a correct simulation, while being explicit about what legitimately
-# does change. All runs use ONE genome (default yeast: multi-contig + fast) at a
-# FIXED seed; only the variable under test changes between runs. Each run emits a
-# truth VCF (reads off — variants are the determinism signal); we compare the
-# header-less, fully-sorted variant bodies by md5 (set-equality) and use position
-# keys to check shard disjointness.
+# Confirms rneat's output is reproducible and invariant to things that MUST NOT
+# change a correct simulation, while being explicit about what legitimately does
+# change. All runs use ONE genome (default yeast: multi-contig + fast) at a FIXED
+# seed; only the variable under test changes between runs. Each run emits a truth
+# VCF (reads off — variants are the signal); we compare header-less, fully-sorted
+# variant bodies by md5 (set-equality), and for the name check compare the
+# (POS,REF,ALT) multiset (ignoring the legitimately-relabeled CHROM).
 #
 # Checks (each PASS/FAIL printed in a parseable RESULTS block at the end):
-#   A determinism_1thread       same config+seed, run twice, 1 thread  -> identical
-#   B determinism_Nthread       same config+seed, run twice, N threads -> identical
-#   C contig_order_independent  shuffle contig order in the FASTA      -> identical set
-#   D shard_order_independent   same per-shard seeds, merged in two
-#                               different shard orders                 -> identical set
-#   E shard_disjoint            no variant emitted by >1 shard window  -> 0 duplicates
-# Informational (NOT pass/fail — expected to differ by design):
-#   - multithread vs single-thread variant set (RNG stream may differ)
-#   - sharded union vs monolithic (shards use distinct per-shard seeds by design)
+#   A determinism_1thread      same config+seed, run twice, 1 thread   -> identical
+#   B determinism_Nthread      same config+seed, run twice, N threads  -> identical
+#   C thread_invariant         1-thread run vs N-thread run            -> identical set + count
+#   D contig_name_invariant    rename every contig (order+seq fixed)   -> identical (POS,REF,ALT) + count
+#   E shard_order_independent  same per-shard seeds, two merge orders  -> identical set
+#   F shard_disjoint           no variant emitted by >1 shard window   -> 0 duplicates
+# Informational (NOT pass/fail — differs by design):
+#   - sharded union vs monolithic (shards use distinct per-(contig,chunk) seeds)
 #
-# Why this matters: it validates that the HPC region-sharding (genome_array.sbatch
-# + merge_shards.sh) is correct and reproducible, and pins down whether monolithic
-# runs are themselves contig-order-independent. Fast (~few min on yeast).
+# NOTE ON CONTIG ORDER: reproducibility means "same inputs -> same output" (ACM /
+# The Turing Way). A reordered FASTA is a *different input file* (different checksum,
+# a different artifact), so producing a different realization is correct behavior, not
+# a defect — see report §3.10. We therefore do NOT test contig-order invariance; doing
+# so would assert a non-invariance and read as a spurious failure. Check D pins the real
+# boundary instead: rneat's realization depends on contig ORDER + SEQUENCE, not NAME
+# (the RNG derives one stream per contig from its index, not its name).
+#
+# Why this matters: validates that HPC region-sharding (genome_array.sbatch +
+# merge_shards.sh) is correct and reproducible, and that threading never perturbs
+# results. Fast (~few min on yeast).
 #
 # Prereqs: setup.sh (rneat build + bioinf env w/ bcftools, samtools). Submit from repo root.
 # Usage:
@@ -51,7 +58,7 @@ OUTDIR="${OUTDIR:-$SCRATCH/orderindep_$SLURM_JOB_ID}"
 SEED="${SEED:-rneat order independence}"   # one fixed seed for every monolithic run
 COVERAGE="${COVERAGE:-30}"
 READ_LEN="${READ_LEN:-151}"
-MT_THREADS="${MT_THREADS:-8}"              # threads for the multi-thread determinism check
+MT_THREADS="${MT_THREADS:-8}"              # threads for the multi-thread / thread-invariance checks
 NSHARDS="${NSHARDS:-4}"                     # target shard count for the sharding checks
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SCRATCH/cargo-target/rusty-neat}"
 RNEAT_BIN="$CARGO_TARGET_DIR/release/rneat"
@@ -66,7 +73,7 @@ conda_activate bioinf   # bcftools, samtools, seqkit
 mkdir -p "$OUTDIR"
 [[ -f "${REFERENCE}.fai" ]] || samtools faidx "$REFERENCE"
 
-echo "=== order-independence / determinism check: $SLURM_JOB_ID ==="
+echo "=== reproducibility / determinism check: $SLURM_JOB_ID ==="
 echo "ref=$REFERENCE  seed='$SEED'  cov=${COVERAGE}x  mt_threads=$MT_THREADS  nshards=$NSHARDS"
 echo "out=$OUTDIR"
 
@@ -101,6 +108,9 @@ run_rneat() {
 # header-less, fully-sorted body -> stable md5 (set-equality across runs)
 md5of() { bcftools view -H "$1" 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1; }
 nvar()  { bcftools view -H "$1" 2>/dev/null | wc -l; }
+# (POS,REF,ALT) multiset md5 — ignores CHROM, for the contig-name check (rename
+# relabels CHROM but must not move any variant).
+posrefalt() { bcftools view -H "$1" 2>/dev/null | awk '{print $2"\t"$4"\t"$5}' | LC_ALL=C sort | md5sum | cut -d' ' -f1; }
 
 # ── A/B: determinism, 1 thread and N threads ─────────────────────────────
 echo; echo "[A] determinism @ 1 thread (run twice)..."
@@ -109,19 +119,20 @@ run_rneat "$OUTDIR/a2" "$REFERENCE" "$SEED" 1
 echo "[B] determinism @ $MT_THREADS threads (run twice)..."
 run_rneat "$OUTDIR/b1" "$REFERENCE" "$SEED" "$MT_THREADS"
 run_rneat "$OUTDIR/b2" "$REFERENCE" "$SEED" "$MT_THREADS"
+# [C] thread_invariant is A1 vs B1 (single-thread vs multi-thread) — no extra run needed.
 
-# ── C: contig-order independence ─────────────────────────────────────────
-echo "[C] contig-order independence (reverse contig order in FASTA)..."
-SHUF_REF="$OUTDIR/ref_shuffled.fa"
-# reverse the contig order, then re-emit the FASTA in that order
-mapfile -t CONTIGS < <(cut -f1 "${REFERENCE}.fai")
-REV=(); for (( i=${#CONTIGS[@]}-1; i>=0; i-- )); do REV+=("${CONTIGS[$i]}"); done
-samtools faidx "$REFERENCE" "${REV[@]}" > "$SHUF_REF"
-samtools faidx "$SHUF_REF"
-run_rneat "$OUTDIR/c1" "$SHUF_REF" "$SEED" 1
+# ── D: contig-name invariance ────────────────────────────────────────────
+# Rename every contig (prepend "renamed_" to each header name; order + sequence
+# untouched). Output relabels CHROM, but the (POS,REF,ALT) realization must be
+# identical, since the RNG keys on contig index, not name.
+echo "[D] contig-name invariance (rename every contig, order preserved)..."
+NAME_REF="$OUTDIR/ref_renamed.fa"
+sed 's/^>/>renamed_/' "$REFERENCE" > "$NAME_REF"
+samtools faidx "$NAME_REF"
+run_rneat "$OUTDIR/d1" "$NAME_REF" "$SEED" 1
 
-# ── D/E: shard-order independence + disjointness ─────────────────────────
-echo "[D/E] sharding (~$NSHARDS windows, SAME per-shard seeds, two merge orders)..."
+# ── E/F: shard-order independence + disjointness ─────────────────────────
+echo "[E/F] sharding (~$NSHARDS windows, SAME per-shard seeds, two merge orders)..."
 GENOME_BP=$(awk '{s+=$2} END{print s}' "${REFERENCE}.fai")
 SHARD_BP=$(( (GENOME_BP + NSHARDS - 1) / NSHARDS ))
 SHARD_DIR="$OUTDIR/shards"
@@ -146,20 +157,23 @@ DUP=$(for v in "${SHVCF[@]}"; do bcftools view -H "$v" | awk '{print $1":"$2":"$
 # ── verdicts ─────────────────────────────────────────────────────────────
 A1=$(md5of "$OUTDIR/a1/sample.vcf.gz"); A2=$(md5of "$OUTDIR/a2/sample.vcf.gz")
 B1=$(md5of "$OUTDIR/b1/sample.vcf.gz"); B2=$(md5of "$OUTDIR/b2/sample.vcf.gz")
-C1=$(md5of "$OUTDIR/c1/sample.vcf.gz")
 MF=$(md5of "$OUTDIR/merge_fwd.vcf.gz"); MR=$(md5of "$OUTDIR/merge_rev.vcf.gz")
+# contig-name: compare (POS,REF,ALT) multiset + count (CHROM legitimately relabels)
+BASE_PRA=$(posrefalt "$OUTDIR/a1/sample.vcf.gz"); NAME_PRA=$(posrefalt "$OUTDIR/d1/sample.vcf.gz")
+BASE_N=$(nvar "$OUTDIR/a1/sample.vcf.gz");        NAME_N=$(nvar "$OUTDIR/d1/sample.vcf.gz")
 verdict() { [[ "$2" == "$3" ]] && echo "PASS" || echo "FAIL"; }
+name_verdict() { { [[ "$BASE_PRA" == "$NAME_PRA" && "$BASE_N" == "$NAME_N" ]]; } && echo "PASS" || echo "FAIL"; }
 
 echo
 echo "════════════════════════════════════════════════════════════════"
-echo "ORDER-INDEPENDENCE RESULTS — $SLURM_JOB_ID ($(basename "$REFERENCE"))"
+echo "REPRODUCIBILITY RESULTS — $SLURM_JOB_ID ($(basename "$REFERENCE"))"
 echo "════════════════════════════════════════════════════════════════"
-printf '  %-28s %s\n' "determinism_1thread:"      "$(verdict x "$A1" "$A2")  ($A1 vs $A2)"
+printf '  %-28s %s\n' "determinism_1thread:"       "$(verdict x "$A1" "$A2")  ($A1 vs $A2)"
 printf '  %-28s %s\n' "determinism_${MT_THREADS}thread:" "$(verdict x "$B1" "$B2")  ($B1 vs $B2)"
-printf '  %-28s %s\n' "contig_order_independent:"  "$(verdict x "$A1" "$C1")  (base $A1 vs shuffled $C1)"
+printf '  %-28s %s\n' "thread_invariant:"          "$(verdict x "$A1" "$B1")  (1thr $A1 vs ${MT_THREADS}thr $B1)"
+printf '  %-28s %s\n' "contig_name_invariant:"     "$(name_verdict)  (POS,REF,ALT $BASE_PRA vs $NAME_PRA; n $BASE_N vs $NAME_N)"
 printf '  %-28s %s\n' "shard_order_independent:"   "$(verdict x "$MF" "$MR")  (fwd $MF vs rev $MR)"
 printf '  %-28s %s\n' "shard_disjoint:"            "$([[ "$DUP" -eq 0 ]] && echo PASS || echo FAIL)  ($DUP duplicate keys)"
 echo "  ── informational (differences here are expected, not failures) ──"
-printf '  %-28s %s\n' "multithread_vs_1thread:"    "$([[ "$A1" == "$B1" ]] && echo same || echo differ)"
-printf '  %-28s %s\n' "variant_counts:"            "base=$(nvar "$OUTDIR/a1/sample.vcf.gz") shuffled=$(nvar "$OUTDIR/c1/sample.vcf.gz") shard_union=$(nvar "$OUTDIR/merge_fwd.vcf.gz")"
+printf '  %-28s %s\n' "variant_counts:"            "base=$(nvar "$OUTDIR/a1/sample.vcf.gz") renamed=$(nvar "$OUTDIR/d1/sample.vcf.gz") shard_union=$(nvar "$OUTDIR/merge_fwd.vcf.gz")"
 echo "════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
Redesigns `run_order_independence.sbatch` to match the corrected reproducibility framing (report §3.10): reproducibility = same inputs → same output, so a reordered FASTA (a different input artifact) legitimately gives different output and shouldn't be asserted as an invariant.

**Changes:**
- **Remove** `contig_order_independent` — it asserted a non-invariance and surfaced as a spurious "failure."
- **Promote** single-vs-multithread from an informational note to a **pass/fail invariant** (`thread_invariant`: 1-thread run == N-thread run, set + count) — the invariance that actually matters and that the code guarantees (per-contig RNG keyed to `derive_child(contig_idx)`, independent of scheduling).
- **Add** `contig_name_invariant`: rename every contig (order + sequence fixed) and assert the `(POS,REF,ALT)` multiset + count are unchanged (CHROM legitimately relabels). This pins rneat's real reproducibility horizon — output depends on contig **order** + **sequence**, not **name**.
- **Keep** determinism (1-thread rerun), shard-order-independence, shard-disjointness.

Pairs with the §3.10 reproducibility reframe in the report (PR for that is separate). `bash -n` clean; can't be run from the workstation (Delta), so first Delta run is shakeout.