### PR TITLE
chore(release): v1.21.1 — realistic default het/hom ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-Unreleased (develop)
-====================
-## Fix — realistic default het/hom ratio
+7/20/2026
+=========
+## rneat v1.21.1 — realistic default het/hom ratio
 
 The bundled default mutation model shipped `homozygous_frequency = 0.01` — a faithful
 port of the NEAT lineage's own default (NEAT2 0.010, NEAT4 0.001) — which forces each

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "1.21.0"
+version = "1.21.1"
 dependencies = [
  "bincode",
  "bstr",
@@ -1095,7 +1095,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rneat"
-version = "1.21.0"
+version = "1.21.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '1.21.0'
+version = '1.21.1'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."


### PR DESCRIPTION
Release prep for **v1.21.1** (patch, bug-fix on top of v1.21.0).

## What ships
- **Default mutation model `homozygous_frequency` 0.01 → 0.333** (#419, already merged to develop). Corrects the ~99 het/hom ratio in default-model `gen-reads` output to a realistic ~2.0. Sampling logic was already correct; only the embedded default value was wrong (a faithful port of NEAT2 0.010 / NEAT4 0.001).
- Regression guard `test_default_homozygous_frequency_is_realistic`.
- ACCESS report §3.1 + CHANGELOG updated.

## Release mechanics
- Workspace version `1.21.0 → 1.21.1` (+ Cargo.lock).
- CHANGELOG `Unreleased (develop)` → dated `v1.21.1`.

## Why patch
Pure correctness fix that changes default output — matches the **v1.20.1** precedent (RNG out-of-range fix), not the v1.20.0 minor (which added a new mechanism). No API/flag/algorithm additions.

## Verification
chr22 germline run: het/hom **2.00**, P(hom) 0.333 (42,997 sites). Full suite + model-parity green.

After merge: develop→main PR + tag `v1.21.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)