### PR TITLE
chore(conda-recipe): bump to v1.21.1 + sha256

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rneat" %}
-{% set version = "1.21.0" %}
+{% set version = "1.21.1" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/rusty-neat/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 36f95c15e79578c3cec3e3b0d4724e530bfc0f0166bbd324a1b6f888ab1aae5f
+  sha256: a3764606670a6686cc5948eb2d5afc23fbd513c0d380ef6e3db5e073f888aebb
 
 build:
   number: 0


### PR DESCRIPTION
Bumps the in-repo conda recipe to **v1.21.1** with the sha256 of the corrected release tarball (`a3764606…`). Mirrors #406 (the v1.21.0 recipe bump). Picks up the het/hom default-model fix for the current `rneat` bioconda package.