### PR TITLE
docs: fix rename artifacts + CITATION version (Phase A follow-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# eidolon (eidolon) — working practices for agents
+# eidolon — working practices for agents
 
 Hand-written guidance below; the GitNexus block that follows is auto-generated
 (regenerated between its `gitnexus` markers — keep edits **above** the markers).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: >-
-  eidolon (eidolon): a Rust toolkit for simulating NGS read
-  data, including tumor/normal cancer sequencing
+  eidolon (formerly rusty-neat): a Rust toolkit for simulating
+  NGS read data, including tumor/normal cancer sequencing
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
@@ -40,7 +40,7 @@ keywords:
   - vcf
   - rust
 license: BSD-3-Clause
-version: 1.16.0
+version: 2.0.0
 identifiers:
   - type: doi
     value: 10.5281/zenodo.20100558

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# eidolon (eidolon) — working practices for agents
+# eidolon — working practices for agents
 
 Hand-written guidance below; the GitNexus block that follows is auto-generated
 (regenerated between its `gitnexus` markers — keep edits **above** the markers).

--- a/docs/rename_eidolon_scope.md
+++ b/docs/rename_eidolon_scope.md
@@ -1,6 +1,7 @@
 # Rename scope — `rusty-neat` / `rneat` → `eidolon`
 
-Planning doc for the project rename. **Status: scoped, decisions locked, not yet executed.**
+Planning doc for the project rename. **Status: Phase A DONE (PR #425, merged to `develop`;
+ships in the v2.0.0 release PR #426). Phases B–C pending.**
 Target release for the rename: **v2.0.0**, cut *after* v1.21.1 is fully released. Do not
 entangle the rename with any behavior change.
 
@@ -59,7 +60,7 @@ Codebase inventory at scoping time: `rneat` 866× / 129 files, `rusty-neat` 93×
 
 ## Work breakdown
 
-### Phase A — code / docs / CI (one PR → `develop`)
+### Phase A — code / docs / CI (one PR → `develop`) — DONE (PR #425)
 - `Cargo.toml`: bin `rneat` → `eidolon`; lib `common` → `eidolon-core`; `version` → `2.0.0`;
   update `Cargo.lock`. Add the `rneat` deprecation-shim bin target (decision 2).
 - Tests: `assert_cmd::cargo_bin("rneat")` → `"eidolon"` (`cancer_parity.rs`,


### PR DESCRIPTION
Small follow-up to the rename (PR #425) — fixes doubled-parenthetical artifacts and stale metadata the bulk pass left:

- **`eidolon (eidolon)` → clean titles** in `AGENTS.md`, `CLAUDE.md` (→ `eidolon`) and `CITATION.cff` (→ `eidolon (formerly rusty-neat)`). The old headings were `rusty-neat (rneat)`, so both halves got renamed.
- **`CITATION.cff` version `1.16.0` (stale) → `2.0.0`.**
- **`docs/rename_eidolon_scope.md`:** marked Phase A DONE.

Docs only. Merge into `develop` before the v2.0.0 release (#426) so it's included.