### PR TITLE
chore(conda-recipe): bump to v2.0.0 + sha256 (+ ACCESS-report rename note)

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "eidolon" %}
-{% set version = "1.21.1" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/eidolon/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/eidolon/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: a3764606670a6686cc5948eb2d5afc23fbd513c0d380ef6e3db5e073f888aebb
+  sha256: 288c80e1b9eafbd9579ad614d046a48e7a95e083539a499548078118e62b064a
 
 build:
   number: 0

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -7,8 +7,8 @@ Allocation: `bhrd-delta-cpu` (NCSA Delta). Core-hours used to date: ~2,500 of ~3
 
 ## 1. Project summary
 
-`eidolon` is a Rust port and extension of NEAT, a next-generation-sequencing read
-simulator. It generates FASTQ, a golden BAM, and a truth VCF whose statistical
+`eidolon` (formerly `rusty-neat` / `rneat`; renamed at v2.0.0) is a Rust port and
+extension of NEAT, a next-generation-sequencing read simulator. It generates FASTQ, a golden BAM, and a truth VCF whose statistical
 properties match real data, and it adds a native tumor/normal cancer workflow
 (`gen-cancer-reads`) with structural variants and an origin-tagged somatic truth
 set. This project used Delta to (1) verify eidolon produces high-quality data on a


### PR DESCRIPTION
- **conda recipe → v2.0.0** with the sha256 of the v2.0.0 release tarball (`288c80e1…`), fetched from the renamed `github.com/ncsa/eidolon` repo. Mirrors the prior #406/#423 recipe bumps.
- **ACCESS report:** adds a "formerly `rusty-neat` / `rneat`" note on first mention for reviewer continuity (deferred from the rename PR).

Docs/packaging only. This is the in-repo recipe; the bioconda-recipes feedstock PR for the new `eidolon` package is the separate Phase C step.