### PR TITLE
docs(readme): bump stale eidolon version refs to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ line), the current Python 3 NEAT 4.x, and `eidolon`.
 
 |                                            | **NEAT 2.x** (genReads)        | **NEAT 4.x**                              | **`eidolon`**                                              |
 | ------------------------------------------ | ------------------------------ | ----------------------------------------- | -------------------------------------------------------- |
-| Latest version                             | 2.1                            | 4.5.3                                      | 1.17.0                                                   |
+| Latest version                             | 2.1                            | 4.5.3                                      | 2.0.0                                                    |
 | Language                                   | Python 2                       | Python 3                                  | Rust                                                     |
 | FASTQ reads (single / paired)              | ✅                             | ✅                                        | ✅                                                       |
 | Golden BAM + VCF truth set                 | ✅                             | ✅                                        | ✅                                                       |
@@ -94,7 +94,7 @@ required. If you prefer to build from source or grab a release binary, read on.
 
 You will need to install the rust toolchain to compile `eidolon`, including `cargo`. Check the cargo documentation for instructions (https://doc.rust-lang.org/cargo/getting-started/installation.html). Alternatively, you can try one of the binaries on the release page. Select the one that matches your system and let us know if you run into errors. During compilation, you may run into errors, such as cmake not found. Some of the packages `eidolon` uses have these dependencies. For Debian/Ubuntu this should be a simple `sudo apt install cmake` and for RHEL/Rocky type distros this should be `sudo dnf install cmake`. There may be some other requirements. Drop a comment if you need specific help.
 
-Download the executable in the release (current version 1.5.0).
+Download the executable in the release (current version 2.0.0).
 
 ```bash
 $ eidolon --help


### PR DESCRIPTION
The README's install command is already `conda install -c bioconda eidolon` (staged by the rename — it goes accurate the moment bioconda #67420 publishes). This just fixes two **stale eidolon version numbers** spotted while readying it:
- comparison table 'Latest version': `1.17.0` → `2.0.0`
- release-download line: `1.5.0` → `2.0.0`

(The `2.1` in the table is NEAT 2.x's version — left as-is.) Docs only.