### PR TITLE
sync: develop → main (.zenodo.json + README v2.0.0 version refs)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,29 @@
+{
+  "title": "eidolon (formerly rusty-neat): a Rust toolkit for simulating NGS read data, including tumor/normal cancer sequencing",
+  "description": "eidolon is a Rust port and extension of NEAT that generates simulated next-generation sequencing data in FASTQ and VCF formats with the statistical properties of real datasets, along with a golden BAM/VCF truth set of inserted variants and ideal alignments. It adds structural-variant simulation (CNV, BND, INV, INS, and others) and an end-to-end tumor/normal cancer workflow (gen-cancer-reads) that merges two read passes at a configurable purity and emits an origin-tagged truth VCF for benchmarking somatic and structural-variant callers, with an emphasis on low memory use and short CPU time.",
+  "upload_type": "software",
+  "license": "BSD-3-Clause",
+  "creators": [
+    {
+      "name": "Allen, Joshua",
+      "affiliation": "National Center for Supercomputing Applications, University of Illinois Urbana-Champaign",
+      "orcid": "0009-0008-0002-5239"
+    },
+    {
+      "name": "Kowalik, Mikolaj"
+    },
+    {
+      "name": "NEAT Contributors"
+    }
+  ],
+  "keywords": [
+    "bioinformatics",
+    "ngs-simulation",
+    "cancer-genomics",
+    "structural-variants",
+    "variant-calling",
+    "fastq",
+    "vcf",
+    "rust"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ line), the current Python 3 NEAT 4.x, and `eidolon`.
 
 |                                            | **NEAT 2.x** (genReads)        | **NEAT 4.x**                              | **`eidolon`**                                              |
 | ------------------------------------------ | ------------------------------ | ----------------------------------------- | -------------------------------------------------------- |
-| Latest version                             | 2.1                            | 4.5.3                                      | 1.17.0                                                   |
+| Latest version                             | 2.1                            | 4.5.3                                      | 2.0.0                                                    |
 | Language                                   | Python 2                       | Python 3                                  | Rust                                                     |
 | FASTQ reads (single / paired)              | ✅                             | ✅                                        | ✅                                                       |
 | Golden BAM + VCF truth set                 | ✅                             | ✅                                        | ✅                                                       |
@@ -94,7 +94,7 @@ required. If you prefer to build from source or grab a release binary, read on.
 
 You will need to install the rust toolchain to compile `eidolon`, including `cargo`. Check the cargo documentation for instructions (https://doc.rust-lang.org/cargo/getting-started/installation.html). Alternatively, you can try one of the binaries on the release page. Select the one that matches your system and let us know if you run into errors. During compilation, you may run into errors, such as cmake not found. Some of the packages `eidolon` uses have these dependencies. For Debian/Ubuntu this should be a simple `sudo apt install cmake` and for RHEL/Rocky type distros this should be `sudo dnf install cmake`. There may be some other requirements. Drop a comment if you need specific help.
 
-Download the executable in the release (current version 1.5.0).
+Download the executable in the release (current version 2.0.0).
 
 ```bash
 $ eidolon --help

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ line), the current Python 3 NEAT 4.x, and `eidolon`.
 | Sequencing error model                     | ✅                             | ✅                                        | ✅                                                       |
 | Fragment-length + GC-bias models           | ✅                             | ✅                                        | ✅ (incl. one-pass `gen-bam-models`)                     |
 | BED targeting / VCF variant insertion      | ✅                             | ✅                                        | ✅                                                       |
+| Continuous per-variant allele fraction     | ❌ (genotype `{0.5, 1.0}`)     | ❌ (genotype `{0.5, 1.0}`)                | ✅ input-VCF `AF`/`AD` → matched AF spectrum (pooled / somatic) |
 | Parallelism                                | Manual job sharding (`--job`)  | Multiprocessing (`--threads`): genome split into ~8 chunks/thread, then stitched | Multithreading (rayon) |
 | VCF comparison tooling                      | Bundled scripts                | ✅ `compare-vcfs`                          | ✅ `compare-vcfs`                                        |
 | I/O / memory                               | Temp files                     | Temp files                                | Streaming writes, low-memory focus                       |


### PR DESCRIPTION
Routine `develop → main` reconcile. Contents:
- `.zenodo.json` (#430) — future GitHub→Zenodo releases self-populate correct metadata
- README (#431) — stale eidolon version refs `1.17.0` / `1.5.0` → `2.0.0`

Docs/metadata only, no code changes. Keeps `main` and `develop` reconciled.