### PR TITLE
docs(readme): add allele-fraction row to the feature chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ line), the current Python 3 NEAT 4.x, and `eidolon`.
 | Sequencing error model                     | ✅                             | ✅                                        | ✅                                                       |
 | Fragment-length + GC-bias models           | ✅                             | ✅                                        | ✅ (incl. one-pass `gen-bam-models`)                     |
 | BED targeting / VCF variant insertion      | ✅                             | ✅                                        | ✅                                                       |
+| Continuous per-variant allele fraction     | ❌ (genotype `{0.5, 1.0}`)     | ❌ (genotype `{0.5, 1.0}`)                | ✅ input-VCF `AF`/`AD` → matched AF spectrum (pooled / somatic) |
 | Parallelism                                | Manual job sharding (`--job`)  | Multiprocessing (`--threads`): genome split into ~8 chunks/thread, then stitched | Multithreading (rayon) |
 | VCF comparison tooling                      | Bundled scripts                | ✅ `compare-vcfs`                          | ✅ `compare-vcfs`                                        |
 | I/O / memory                               | Temp files                     | Temp files                                | Streaming writes, low-memory focus                       |


### PR DESCRIPTION
Adds a **Continuous per-variant allele fraction** row to the NEAT-vs-eidolon comparison table. The `allele_fraction` feature (#398, shipped v1.21.0, validated r=0.98 on SCN Pool-seq) is a genuine differentiator — NEAT 2/4 only do genotype-based `{0.5, 1.0}`; eidolon reproduces a continuous input-driven AF spectrum from `AF`/`AD`. It was in the README prose but not the chart.

Polyploidy *dosage* (epic #265) has no in-tree code and is deliberately **not** listed.