### PR TITLE
feat(gen-cancer-reads): generative subclonal somatic VAF (#405)

### DIFF
--- a/docs/cancer_howto.md
+++ b/docs/cancer_howto.md
@@ -217,6 +217,30 @@ rows are dropped, both warned with a count. Extra columns (`cellular_prevalence_
 VCF's `NEAT_CCF` carries exactly those planted CCFs → run the deconvolution tool on
 the *simulated* reads → confirm it recovers the architecture you fed in.
 
+### Reproductive replay (from a real somatic VCF)
+
+The subclonal options above are *generative* — they invent somatic variants matching
+a target architecture. To instead **replay a specific real tumor's somatic calls**,
+point at a somatic VCF:
+
+```yaml
+purity: 0.6
+tumor_mutation_rate: 0.0      # pure replay — no de-novo somatic on top
+somatic_vcf: tumor_somatic.vcf.gz
+```
+
+Each variant is honored at its **observed VAF** (`INFO/AF`, else derived from
+`FORMAT/AD`), divided by `purity` so the merged reads reproduce that VAF after
+tumor/normal mixing (a raw Mutect2/Strelka VCF works directly). Replayed variants are
+tagged `NEAT_ORIGIN=somatic` / `NEAT_PROVENANCE=somatic_input` in the truth — distinct
+from germline even though both come from files. Notes:
+
+- Composes with generation: leave `tumor_mutation_rate > 0` (and optional `subclones`)
+  to layer de-novo somatic variants on top of the replayed set.
+- A variant with no AF falls back to its genotype dosage (het ≈ 0.5, hom = 1.0).
+- Observed VAF above `purity` is physically impossible for a somatic variant; it's
+  clamped to a tumor-cell fraction of 1.0 with a warning.
+
 ### One germline, many tumor scenarios
 
 Fix the germline once and sweep purity/depth by pointing each run at the same

--- a/docs/cancer_howto.md
+++ b/docs/cancer_howto.md
@@ -165,12 +165,21 @@ subclones:
   - {ccf: 0.15, weight: 0.1}  # minor subclone
 ```
 
-CCF **composes** with purity: a somatic variant at CCF `f` is observed in the merged
-output at `VAF = purity · f` (purity = normal contamination, CCF = subclonal fraction —
-orthogonal axes). Germline (shared) variants are unaffected. This produces the
-multi-modal somatic VAF spectrum that subclonal-deconvolution tools (PyClone, SciClone,
-…) consume. `ccf ∈ (0, 1]`; `weight` defaults to `1.0` (equal share). Omit the block for
-the single-fraction default (output is byte-identical to pre-subclone runs).
+CCF is a **cellular-fraction factor** that composes with the variant's dosage and with
+purity — it does not replace them:
+
+```text
+observed VAF = purity · dosage · CCF
+```
+
+`dosage` is the alt-copy fraction from the genotype (0.5 for a heterozygous SNV, 1.0 for
+homozygous; `alt_copies/ploidy` in general). So a heterozygous somatic variant at CCF `f`
+is observed at `~purity·f/2` — the value a subclonal-deconvolution tool (PyClone,
+SciClone, …) inverts back to `f`. These are orthogonal axes (purity = normal
+contamination, dosage = per-copy multiplicity, CCF = subclonal fraction). Germline
+(shared) variants are unaffected. `ccf ∈ (0, 1]`; `weight` defaults to `1.0` (equal
+share). Omit the block for the dosage-only default (output is byte-identical to
+pre-subclone runs).
 
 ### One germline, many tumor scenarios
 
@@ -220,7 +229,7 @@ tools/cancer_sv_benchmark.sh \
 | `tumor_mutation_rate` | per-base somatic rate. Default `1e-5`. `model` = use the model's fitted rate. |
 | `normal_mutation_rate` | per-base germline rate. Default = the model's fitted rate. |
 | `sv_rate_scale` | de novo SV multiplier; `0` = off, `1.0` = the model's `sv_model` rate. |
-| `subclones` | optional list of `{ccf, weight}` subclones; spreads somatic variants across CCFs → observed VAF = `purity · ccf`. Omit for a single fraction. |
+| `subclones` | optional list of `{ccf, weight}` subclones; spreads somatic variants across CCFs → observed VAF = `purity · dosage · ccf`. Omit for the dosage-only default. |
 | `germline_vcf` | fixed shared germline instead of de-novo generation. |
 | `rng_seed` | seeds both passes (suffixed `-normal`/`-tumor`); printed to the log. |
 | `keep_per_pass` | keep per-pass FASTQs (`false` = merged only). |

--- a/docs/cancer_howto.md
+++ b/docs/cancer_howto.md
@@ -181,15 +181,22 @@ contamination, dosage = per-copy multiplicity, CCF = subclonal fraction). Germli
 share). Omit the block for the dosage-only default (output is byte-identical to
 pre-subclone runs).
 
-Each somatic record in the golden/merged-truth VCF carries the **intended** CCF as
-`INFO/NEAT_CCF` — ground truth for validation. Measured `AF` should track
-`dosage × NEAT_CCF`, so you can score how well a subclonal-deconvolution caller
-recovers the planted architecture. Germline/shared records never carry it.
+Each somatic record in the golden/merged-truth VCF carries two ground-truth INFO tags:
+
+- **`NEAT_CCF`** — the intended cellular fraction (subclone CCF).
+- **`NEAT_VAF`** — the intended **observed** VAF after tumor/normal mixing
+  (`purity × dosage × CCF`; for a reproductive `somatic_vcf` replay, the original
+  input VAF). This is the number a somatic caller measures on the merged reads.
+
+Mind the difference from `FORMAT/AF`: that field is measured **per-pass (tumor-only)**,
+so it reads `dosage × CCF` (≈ `NEAT_VAF ÷ purity`) and carries sampling noise.
+For scoring a caller's VAF against ground truth, compare to `NEAT_VAF`; use `FORMAT/AF`
+only if you want the tumor-cell fraction. Germline/shared records carry neither tag.
 
 ```bash
-# planted CCF vs measured AF for somatic sites
+# planted observed VAF vs caller VAF: score against NEAT_VAF, not FORMAT/AF
 bcftools view -H -i 'INFO/NEAT_ORIGIN="somatic"' merged_truth.vcf.gz \
-  | awk -F'\t' '{match($8,/NEAT_CCF=[0-9.]+/); print substr($8,RSTART+9), $NF}'
+  | awk -F'\t' '{match($8,/NEAT_VAF=[0-9.]+/); print $2, substr($8,RSTART+9)}'
 ```
 
 ### Building the architecture from real data

--- a/docs/cancer_howto.md
+++ b/docs/cancer_howto.md
@@ -150,6 +150,28 @@ tumor_model: tools/cosmic_per_tissue_BRCA.json.gz
 sv_rate_scale: 1.0       # 1.0 = the model's nominal rate; higher stress-tests SV callers
 ```
 
+### Subclonal architecture (somatic VAF spectrum)
+
+By default the somatic burden sits at ~one effective VAF, set by `purity` alone.
+Real tumors are mixtures of subclones at distinct **cancer-cell fractions (CCF)**.
+Add a `subclones:` list to spread de-novo somatic variants across those fractions —
+each variant is assigned a subclone (share ∝ `weight`) and takes its `ccf`:
+
+```yaml
+purity: 0.8
+subclones:
+  - {ccf: 1.0, weight: 0.6}   # clonal / truncal — present in every tumor cell
+  - {ccf: 0.4, weight: 0.3}   # major subclone
+  - {ccf: 0.15, weight: 0.1}  # minor subclone
+```
+
+CCF **composes** with purity: a somatic variant at CCF `f` is observed in the merged
+output at `VAF = purity · f` (purity = normal contamination, CCF = subclonal fraction —
+orthogonal axes). Germline (shared) variants are unaffected. This produces the
+multi-modal somatic VAF spectrum that subclonal-deconvolution tools (PyClone, SciClone,
+…) consume. `ccf ∈ (0, 1]`; `weight` defaults to `1.0` (equal share). Omit the block for
+the single-fraction default (output is byte-identical to pre-subclone runs).
+
 ### One germline, many tumor scenarios
 
 Fix the germline once and sweep purity/depth by pointing each run at the same
@@ -198,6 +220,7 @@ tools/cancer_sv_benchmark.sh \
 | `tumor_mutation_rate` | per-base somatic rate. Default `1e-5`. `model` = use the model's fitted rate. |
 | `normal_mutation_rate` | per-base germline rate. Default = the model's fitted rate. |
 | `sv_rate_scale` | de novo SV multiplier; `0` = off, `1.0` = the model's `sv_model` rate. |
+| `subclones` | optional list of `{ccf, weight}` subclones; spreads somatic variants across CCFs → observed VAF = `purity · ccf`. Omit for a single fraction. |
 | `germline_vcf` | fixed shared germline instead of de-novo generation. |
 | `rng_seed` | seeds both passes (suffixed `-normal`/`-tumor`); printed to the log. |
 | `keep_per_pass` | keep per-pass FASTQs (`false` = merged only). |

--- a/docs/cancer_howto.md
+++ b/docs/cancer_howto.md
@@ -192,6 +192,31 @@ bcftools view -H -i 'INFO/NEAT_ORIGIN="somatic"' merged_truth.vcf.gz \
   | awk -F'\t' '{match($8,/NEAT_CCF=[0-9.]+/); print substr($8,RSTART+9), $NF}'
 ```
 
+### Building the architecture from real data
+
+Instead of hand-authoring `subclones:`, point at a subclonal-deconvolution tool's
+cluster table with `subclones_file:` (tab-separated, header required; mutually
+exclusive with the inline list). eidolon folds the two shapes real tools emit into
+`{ccf, weight}`:
+
+| Tool | Shape | Columns used |
+|---|---|---|
+| PyClone / PyClone-VI | per-mutation | `cluster_id`, `cellular_prevalence` → grouped by cluster, weight = mutation count |
+| PCAWG-11 / CSR / DPClust | cluster table | `cluster`, `ccf`, size (`n_ssms` / `size` / `weight`) → used directly |
+
+```yaml
+subclones_file: pyclone_clusters.tsv
+```
+
+Other tools convert with a one-liner — emit a header plus the two/three columns
+above. CCF > 1.0 (noisy clonal clusters) is clamped to 1.0 and non-positive-CCF
+rows are dropped, both warned with a count. Extra columns (`cellular_prevalence_std`,
+`cluster_assignment_prob`, …) are ignored.
+
+**Round-trip validation.** Ingest a real tumor's clusters → simulate → the golden
+VCF's `NEAT_CCF` carries exactly those planted CCFs → run the deconvolution tool on
+the *simulated* reads → confirm it recovers the architecture you fed in.
+
 ### One germline, many tumor scenarios
 
 Fix the germline once and sweep purity/depth by pointing each run at the same

--- a/docs/cancer_howto.md
+++ b/docs/cancer_howto.md
@@ -181,6 +181,17 @@ contamination, dosage = per-copy multiplicity, CCF = subclonal fraction). Germli
 share). Omit the block for the dosage-only default (output is byte-identical to
 pre-subclone runs).
 
+Each somatic record in the golden/merged-truth VCF carries the **intended** CCF as
+`INFO/NEAT_CCF` — ground truth for validation. Measured `AF` should track
+`dosage × NEAT_CCF`, so you can score how well a subclonal-deconvolution caller
+recovers the planted architecture. Germline/shared records never carry it.
+
+```bash
+# planted CCF vs measured AF for somatic sites
+bcftools view -H -i 'INFO/NEAT_ORIGIN="somatic"' merged_truth.vcf.gz \
+  | awk -F'\t' '{match($8,/NEAT_CCF=[0-9.]+/); print substr($8,RSTART+9), $NF}'
+```
+
 ### One germline, many tumor scenarios
 
 Fix the germline once and sweep purity/depth by pointing each run at the same

--- a/eidolon-core/src/file_tools/vcf_tools.rs
+++ b/eidolon-core/src/file_tools/vcf_tools.rs
@@ -15,7 +15,7 @@ use crate::file_tools::file_io::{
 };
 use crate::structs::mutated_map::{AdCounter, MutatedMap};
 use crate::structs::nucleotides::sequence_array_to_string;
-use crate::structs::variants::{AlternateType, Variant, VariantError};
+use crate::structs::variants::{AlternateType, Provenance, Variant, VariantError};
 
 #[derive(Debug, Error)]
 pub enum VcfToolsError {
@@ -108,6 +108,13 @@ pub fn write_vcf(
     )?;
     writeln!(
         &mut buffer,
+        "##INFO=<ID=NEAT_CCF,Number=1,Type=Float,\
+        Description=\"Intended cellular fraction of this de-novo variant \
+        (cancer-cell fraction of its assigned subclone; #405). The realized alt \
+        fraction is NEAT_CCF x allele dosage; absent when no subclonal model is set.\">"
+    )?;
+    writeln!(
+        &mut buffer,
         "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
     )?;
     writeln!(
@@ -175,7 +182,17 @@ pub fn write_vcf(
                     Some(existing) => format!("{existing};NEAT_PROVENANCE={prov}"),
                 }
             } else {
-                format!("NEAT_PROVENANCE={prov}")
+                // Literal records: NEAT_PROVENANCE is the base INFO. A de-novo literal
+                // may carry extra simulator-emitted tags (e.g. NEAT_CCF, the intended
+                // cellular fraction) in `info`; pass those through. Input-VCF literals
+                // deliberately drop their source INFO — only provenance is emitted — so
+                // existing golden output for input_vcf: runs is unchanged.
+                match (variant.provenance, variant.info.as_deref()) {
+                    (Provenance::Denovo, Some(extra)) if !extra.is_empty() && extra != "." => {
+                        format!("{extra};NEAT_PROVENANCE={prov}")
+                    }
+                    _ => format!("NEAT_PROVENANCE={prov}"),
+                }
             };
             // SAMPLE: for literal variants, AD/DP/AF come from the per-contig
             // counter populated by the gen-reads fragment loop; positions with

--- a/eidolon-core/src/file_tools/vcf_tools.rs
+++ b/eidolon-core/src/file_tools/vcf_tools.rs
@@ -115,6 +115,14 @@ pub fn write_vcf(
     )?;
     writeln!(
         &mut buffer,
+        "##INFO=<ID=NEAT_VAF,Number=1,Type=Float,\
+        Description=\"Intended observed variant allele fraction of this somatic \
+        variant in the tumor/normal-mixed output (purity x dosage x CCF; #405). \
+        Directly comparable to a caller's VAF on the merged reads — unlike FORMAT/AF, \
+        which is measured per-pass (tumor-only). Absent outside cancer somatic runs.\">"
+    )?;
+    writeln!(
+        &mut buffer,
         "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
     )?;
     writeln!(
@@ -182,13 +190,15 @@ pub fn write_vcf(
                     Some(existing) => format!("{existing};NEAT_PROVENANCE={prov}"),
                 }
             } else {
-                // Literal records: NEAT_PROVENANCE is the base INFO. A de-novo literal
-                // may carry extra simulator-emitted tags (e.g. NEAT_CCF, the intended
-                // cellular fraction) in `info`; pass those through. Input-VCF literals
-                // deliberately drop their source INFO — only provenance is emitted — so
-                // existing golden output for input_vcf: runs is unchanged.
+                // Literal records: NEAT_PROVENANCE is the base INFO. Simulator-emitted
+                // tags (NEAT_CCF, NEAT_VAF) live in `info` on de-novo and reproductive
+                // somatic (SomaticVcf) variants — pass those through. Germline input-VCF
+                // literals deliberately drop their source INFO (only provenance emitted),
+                // so existing golden output for input_vcf: runs is unchanged.
                 match (variant.provenance, variant.info.as_deref()) {
-                    (Provenance::Denovo, Some(extra)) if !extra.is_empty() && extra != "." => {
+                    (Provenance::Denovo | Provenance::SomaticVcf, Some(extra))
+                        if !extra.is_empty() && extra != "." =>
+                    {
                         format!("{extra};NEAT_PROVENANCE={prov}")
                     }
                     _ => format!("NEAT_PROVENANCE={prov}"),

--- a/eidolon-core/src/structs/variants.rs
+++ b/eidolon-core/src/structs/variants.rs
@@ -524,6 +524,39 @@ impl Variant {
     pub fn get_loc(&self) -> Result<usize, VariantError> {
         Ok(self.location)
     }
+
+    /// Allele **dosage** as a fraction: alt-copy count over total called copies,
+    /// derived from the N-wide `genotype_str` (`0/1` → 0.5, `1/1` → 1.0,
+    /// `0/0/0/1` → 0.25). Any non-zero allele index counts as alt; missing (`.`)
+    /// alleles are excluded from the total. This is the biological "what fraction
+    /// of this cell's homologous copies carry the variant" and, for a diploid,
+    /// reproduces the read sampler's het-0.5 / hom-1.0 default.
+    ///
+    /// It is the composable **base** for `allele_fraction`: a subclonal CCF (#405)
+    /// or other cellular-fraction factor multiplies onto it, and polyploid dosage
+    /// (#266/#267) flows in automatically once `genotype_str` carries a real
+    /// per-copy spread. Falls back to the coarse `Genotype` label (Hom → 1.0,
+    /// Het → 0.5) if `genotype_str` has no parseable alleles.
+    pub fn dosage_fraction(&self) -> f64 {
+        let (mut alt, mut total) = (0usize, 0usize);
+        for allele in self.genotype_str.split(['/', '|']) {
+            match allele.trim() {
+                "" | "." => {}
+                "0" => total += 1,
+                _ => {
+                    alt += 1;
+                    total += 1;
+                }
+            }
+        }
+        if total == 0 {
+            return match self.genotype {
+                Genotype::Homozygous => 1.0,
+                Genotype::Heterozygous => 0.5,
+            };
+        }
+        alt as f64 / total as f64
+    }
 }
 
 /// Shared core of `Variant::from_file` and `Variant::from_file_lean`: parse
@@ -823,6 +856,41 @@ mod tests {
         // can rely on Denovo as the default provenance for unannotated
         // outputs.
         assert_eq!(variant.provenance, Provenance::Denovo);
+    }
+
+    #[test]
+    fn dosage_fraction_from_genotype_string() {
+        let snp = |gt: &mut Vec<usize>| {
+            Variant::new(SNP, 10, &vec![Nucleotide::A], &vec![Nucleotide::T], gt).unwrap()
+        };
+        // Diploid: het → 0.5, hom → 1.0 (reproduces the read-sampler default).
+        assert_eq!(snp(&mut vec![0, 1]).dosage_fraction(), 0.5);
+        assert_eq!(snp(&mut vec![1, 1]).dosage_fraction(), 1.0);
+        // Polyploid dosage classes fall straight out of the N-wide GT string.
+        assert_eq!(snp(&mut vec![0, 0, 0, 1]).dosage_fraction(), 0.25);
+        assert_eq!(snp(&mut vec![0, 1, 1, 1]).dosage_fraction(), 0.75);
+    }
+
+    #[test]
+    fn dosage_fraction_handles_missing_and_phased_alleles() {
+        let v = Variant {
+            variant_type: SNP,
+            location: 1,
+            reference: vec![Nucleotide::A],
+            alternate: AlternateType::Literal(vec![Nucleotide::T]),
+            // Phased with a missing allele: alt=1 over called=2 → 0.5.
+            genotype_str: "0|1|.".to_string(),
+            genotype: Genotype::Heterozygous,
+            allele_fraction: None,
+            id: None,
+            quality_score: None,
+            filter: None,
+            info: None,
+            format: Vec::new(),
+            sample: Vec::new(),
+            provenance: Provenance::Denovo,
+        };
+        assert_eq!(v.dosage_fraction(), 0.5);
     }
 
     #[test]

--- a/eidolon-core/src/structs/variants.rs
+++ b/eidolon-core/src/structs/variants.rs
@@ -41,6 +41,10 @@ pub enum Provenance {
     Denovo,
     /// Variant was carried through from the user's `input_vcf:` file.
     InputVcf,
+    /// Variant was supplied via a reproductive somatic VCF (#405). Distinct from
+    /// `InputVcf` (germline) so a tumor/normal merge resolves it to `somatic`, not
+    /// `shared`, even though — like `InputVcf` — it came from a file.
+    SomaticVcf,
 }
 
 impl Provenance {
@@ -49,6 +53,7 @@ impl Provenance {
         match self {
             Provenance::Denovo => "denovo",
             Provenance::InputVcf => "input",
+            Provenance::SomaticVcf => "somatic_input",
         }
     }
 }

--- a/eidolon/src/gen_cancer_reads/utils/config.rs
+++ b/eidolon/src/gen_cancer_reads/utils/config.rs
@@ -50,10 +50,10 @@ pub struct CancerConfig {
     pub keep_per_pass: bool,
     pub overwrite_output: bool,
     /// Optional subclonal architecture (#405). When set, the tumor pass distributes
-    /// its de-novo somatic variants across these subclones, stamping each with its
-    /// subclone's cancer-cell fraction (CCF) as a per-variant allele_fraction. The
-    /// observed VAF in the merged output is `purity × CCF`. `None` → the pre-#405
-    /// single-fraction behavior (every somatic variant near one effective VAF).
+    /// its de-novo somatic variants across these subclones; each subclone's
+    /// cancer-cell fraction (CCF) composes with the variant's dosage, so the
+    /// observed VAF in the merged output is `purity × dosage × CCF`. `None` → the
+    /// pre-#405 behavior (somatic VAF driven by dosage and purity alone).
     pub subclones: Option<SubcloneModel>,
 }
 

--- a/eidolon/src/gen_cancer_reads/utils/config.rs
+++ b/eidolon/src/gen_cancer_reads/utils/config.rs
@@ -6,8 +6,9 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use log::warn;
 use serde_yml::Value;
 
 use crate::gen_cancer_reads::errors::GenCancerReadsError;
@@ -95,6 +96,14 @@ impl CancerConfig {
     fn from_scrape(scrape: HashMap<String, Value>) -> Result<CancerConfig, GenCancerReadsError> {
         let mut cfg = CancerConfig::default();
 
+        // A subclonal architecture may be given inline (`subclones:`) OR loaded from a
+        // deconvolution-tool cluster table (`subclones_file:`), but not both.
+        if scrape.contains_key("subclones") && scrape.contains_key("subclones_file") {
+            return Err(GenCancerReadsError::ConfigError(
+                "specify either `subclones` (inline) or `subclones_file` (path), not both".into(),
+            ));
+        }
+
         let req_path = |v: &Value, key: &str| -> Result<PathBuf, GenCancerReadsError> {
             let s = v.as_str().ok_or_else(|| {
                 GenCancerReadsError::ConfigError(format!("{key} must be a path string"))
@@ -152,6 +161,10 @@ impl CancerConfig {
                 }
                 "germline_vcf" => cfg.germline_vcf = Some(req_path(value, "germline_vcf")?),
                 "subclones" => cfg.subclones = Some(parse_subclones(value)?),
+                "subclones_file" => {
+                    cfg.subclones =
+                        Some(parse_subclones_file(&req_path(value, "subclones_file")?)?);
+                }
                 "sv_rate_scale" => cfg.sv_rate_scale = as_f64(value, "sv_rate_scale")?,
                 "keep_per_pass" => cfg.keep_per_pass = as_bool(value, "keep_per_pass")?,
                 "overwrite_output" => cfg.overwrite_output = as_bool(value, "overwrite_output")?,
@@ -326,6 +339,141 @@ fn parse_subclones(v: &Value) -> Result<SubcloneModel, GenCancerReadsError> {
     }
     SubcloneModel::new(subclones)
         .map_err(|e| GenCancerReadsError::ConfigError(format!("invalid subclones: {e}")))
+}
+
+/// Column-name synonyms accepted in a `subclones_file` cluster table (matched
+/// case-insensitively). Kept tool-agnostic: PyClone/PyClone-VI use
+/// `cellular_prevalence`; PCAWG-11 / DPClust cluster tables use `ccf` + `n_ssms`.
+const CLUSTER_COLS: &[&str] = &["cluster_id", "cluster", "clusterid"];
+const CCF_COLS: &[&str] = &["cellular_prevalence", "ccf", "cancer_cell_fraction", "cp"];
+const WEIGHT_COLS: &[&str] = &[
+    "n_ssms",
+    "size",
+    "weight",
+    "n_mutations",
+    "n_snvs",
+    "n_variants",
+];
+
+/// Build a [`SubcloneModel`] from a deconvolution-tool cluster table (#405, B1).
+///
+/// Accepts a tab-separated file with a header and folds the two shapes real tools
+/// emit into `{ccf, weight}` clusters:
+///
+/// - **Cluster table** (PCAWG-11 / CSR / DPClust): one row per cluster, a `ccf`
+///   column and a size column (`n_ssms` / `size` / `weight`) → used directly.
+/// - **Per-mutation table** (PyClone / PyClone-VI): one row per mutation with
+///   `cluster_id` + `cellular_prevalence` and no size column → grouped by cluster,
+///   `ccf` = mean prevalence, `weight` = mutation count.
+///
+/// Robustness for real files: CCF > 1.0 is clamped to 1.0 (noisy clonal clusters);
+/// rows with non-finite or ≤ 0 CCF are skipped; both are warned once with a count.
+/// Extra columns (std, assignment probability, …) are ignored.
+fn parse_subclones_file(path: &Path) -> Result<SubcloneModel, GenCancerReadsError> {
+    let text = fs::read_to_string(path)
+        .map_err(|e| GenCancerReadsError::ConfigError(format!("subclones_file {path:?}: {e}")))?;
+    let mut lines = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'));
+
+    let header = lines.next().ok_or_else(|| {
+        GenCancerReadsError::ConfigError(format!("subclones_file {path:?} is empty"))
+    })?;
+    let cols: Vec<String> = header
+        .split('\t')
+        .map(|c| c.trim().to_lowercase())
+        .collect();
+    let find = |names: &[&str]| cols.iter().position(|c| names.contains(&c.as_str()));
+
+    let cluster_idx = find(CLUSTER_COLS).ok_or_else(|| {
+        GenCancerReadsError::ConfigError(format!(
+            "subclones_file {path:?}: no cluster column (one of {CLUSTER_COLS:?})"
+        ))
+    })?;
+    let ccf_idx = find(CCF_COLS).ok_or_else(|| {
+        GenCancerReadsError::ConfigError(format!(
+            "subclones_file {path:?}: no CCF column (one of {CCF_COLS:?})"
+        ))
+    })?;
+    let weight_idx = find(WEIGHT_COLS);
+
+    // Aggregate by cluster id, preserving first-seen order for determinism.
+    struct Acc {
+        ccf_sum: f64,
+        rows: usize,
+        weight_sum: f64,
+    }
+    let mut order: Vec<String> = Vec::new();
+    let mut accs: HashMap<String, Acc> = HashMap::new();
+    let (mut clamped, mut skipped) = (0usize, 0usize);
+
+    for (n, line) in lines.enumerate() {
+        let fields: Vec<&str> = line.split('\t').collect();
+        let get = |i: usize| fields.get(i).map(|s| s.trim());
+        let parse_f = |name: &str, s: Option<&str>| -> Result<f64, GenCancerReadsError> {
+            s.and_then(|s| s.parse::<f64>().ok()).ok_or_else(|| {
+                GenCancerReadsError::ConfigError(format!(
+                    "subclones_file {path:?}: row {} has an unparseable {name}",
+                    n + 2 // +1 header, +1 to 1-index
+                ))
+            })
+        };
+        let cluster = match get(cluster_idx) {
+            Some(c) if !c.is_empty() => c.to_string(),
+            _ => continue,
+        };
+        let mut ccf = parse_f("ccf", get(ccf_idx))?;
+        if !ccf.is_finite() || ccf <= 0.0 {
+            skipped += 1;
+            continue;
+        }
+        if ccf > 1.0 {
+            ccf = 1.0;
+            clamped += 1;
+        }
+        let weight = match weight_idx {
+            Some(i) => parse_f("weight", get(i))?,
+            None => 1.0,
+        };
+        let acc = accs.entry(cluster.clone()).or_insert_with(|| {
+            order.push(cluster.clone());
+            Acc {
+                ccf_sum: 0.0,
+                rows: 0,
+                weight_sum: 0.0,
+            }
+        });
+        acc.ccf_sum += ccf;
+        acc.rows += 1;
+        acc.weight_sum += weight;
+    }
+
+    if clamped > 0 {
+        warn!("subclones_file {path:?}: clamped {clamped} CCF value(s) > 1.0 to 1.0");
+    }
+    if skipped > 0 {
+        warn!("subclones_file {path:?}: skipped {skipped} row(s) with non-positive/invalid CCF");
+    }
+
+    let subclones: Vec<Subclone> = order
+        .iter()
+        .map(|k| {
+            let a = &accs[k];
+            Subclone {
+                ccf: a.ccf_sum / a.rows as f64,
+                // No size column → this is a per-mutation table; weight = row count.
+                weight: if weight_idx.is_some() {
+                    a.weight_sum
+                } else {
+                    a.rows as f64
+                },
+            }
+        })
+        .collect();
+
+    SubcloneModel::new(subclones)
+        .map_err(|e| GenCancerReadsError::ConfigError(format!("subclones_file {path:?}: {e}")))
 }
 
 #[cfg(test)]
@@ -550,6 +698,144 @@ mod tests {
     fn subclones_reject_empty_list() {
         let mut s = base_scrape();
         s.insert("subclones".into(), Value::Sequence(vec![]));
+        assert!(matches!(
+            CancerConfig::from_scrape(s),
+            Err(GenCancerReadsError::ConfigError(_))
+        ));
+    }
+
+    // ── subclones_file (B1: ingest a deconvolution cluster table) ────────────
+
+    fn write_tmp(name: &str, body: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!("eidolon_sctest_{name}.tsv"));
+        fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn subclones_file_pyclone_per_mutation_groups_by_cluster() {
+        // PyClone-VI shape: one row per mutation, no size column → weight = count,
+        // ccf = mean cellular_prevalence. Extra columns are ignored.
+        let tsv = write_tmp(
+            "pyclone",
+            "mutation_id\tsample_id\tcluster_id\tcellular_prevalence\tcluster_assignment_prob\n\
+             m1\tS\t0\t1.0\t0.99\n\
+             m2\tS\t0\t1.0\t0.98\n\
+             m3\tS\t0\t1.0\t0.97\n\
+             m4\tS\t1\t0.4\t0.95\n\
+             m5\tS\t1\t0.4\t0.90\n",
+        );
+        let m = parse_subclones_file(&tsv).unwrap();
+        assert_eq!(m.subclones().len(), 2);
+        assert_eq!(
+            m.subclones()[0],
+            Subclone {
+                ccf: 1.0,
+                weight: 3.0
+            }
+        );
+        assert_eq!(
+            m.subclones()[1],
+            Subclone {
+                ccf: 0.4,
+                weight: 2.0
+            }
+        );
+    }
+
+    #[test]
+    fn subclones_file_pcawg_cluster_table_uses_size_as_weight() {
+        // PCAWG-11 / DPClust shape: one row per cluster with an n_ssms size column.
+        let tsv = write_tmp(
+            "pcawg",
+            "cluster\tn_ssms\tccf\n\
+             1\t1200\t1.0\n\
+             2\t300\t0.55\n\
+             3\t80\t0.2\n",
+        );
+        let m = parse_subclones_file(&tsv).unwrap();
+        assert_eq!(m.subclones().len(), 3);
+        assert_eq!(
+            m.subclones()[0],
+            Subclone {
+                ccf: 1.0,
+                weight: 1200.0
+            }
+        );
+        assert_eq!(
+            m.subclones()[2],
+            Subclone {
+                ccf: 0.2,
+                weight: 80.0
+            }
+        );
+    }
+
+    #[test]
+    fn subclones_file_clamps_ccf_above_one_and_skips_nonpositive() {
+        let tsv = write_tmp(
+            "clamp",
+            "cluster_id\tcellular_prevalence\n\
+             0\t1.03\n\
+             0\t0.97\n\
+             1\t0.0\n\
+             2\t0.5\n",
+        );
+        let m = parse_subclones_file(&tsv).unwrap();
+        // cluster 0: 1.03 clamped to 1.0, mean(1.0, 0.97) = 0.985; cluster 1 skipped
+        // (ccf 0.0); cluster 2 kept.
+        assert_eq!(m.subclones().len(), 2);
+        assert!((m.subclones()[0].ccf - 0.985).abs() < 1e-9);
+        assert_eq!(m.subclones()[0].weight, 2.0);
+        assert_eq!(
+            m.subclones()[1],
+            Subclone {
+                ccf: 0.5,
+                weight: 1.0
+            }
+        );
+    }
+
+    #[test]
+    fn subclones_file_missing_ccf_column_errors() {
+        let tsv = write_tmp("nocol", "cluster_id\tfoo\n0\t1.0\n");
+        assert!(matches!(
+            parse_subclones_file(&tsv),
+            Err(GenCancerReadsError::ConfigError(_))
+        ));
+    }
+
+    #[test]
+    fn subclones_file_lands_on_tumor_pass() {
+        let tsv = write_tmp("wire", "cluster\tn_ssms\tccf\n1\t10\t1.0\n2\t5\t0.3\n");
+        let mut s = base_scrape();
+        s.insert(
+            "subclones_file".into(),
+            Value::String(tsv.to_string_lossy().into()),
+        );
+        let cfg = CancerConfig::from_scrape(s).unwrap();
+        assert_eq!(cfg.subclones.as_ref().unwrap().subclones().len(), 2);
+        assert!(cfg.normal_pass().unwrap().subclone_model.is_none());
+        assert!(
+            cfg.tumor_pass(PathBuf::from("/tmp/g.vcf.gz"))
+                .unwrap()
+                .subclone_model
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn subclones_inline_and_file_are_mutually_exclusive() {
+        let tsv = write_tmp("mutex", "cluster\tccf\n1\t1.0\n");
+        let mut s = base_scrape();
+        s.insert(
+            "subclones".into(),
+            serde_yml::from_str("- {ccf: 1.0}").unwrap(),
+        );
+        s.insert(
+            "subclones_file".into(),
+            Value::String(tsv.to_string_lossy().into()),
+        );
         assert!(matches!(
             CancerConfig::from_scrape(s),
             Err(GenCancerReadsError::ConfigError(_))

--- a/eidolon/src/gen_cancer_reads/utils/config.rs
+++ b/eidolon/src/gen_cancer_reads/utils/config.rs
@@ -56,6 +56,12 @@ pub struct CancerConfig {
     /// observed VAF in the merged output is `purity × dosage × CCF`. `None` → the
     /// pre-#405 behavior (somatic VAF driven by dosage and purity alone).
     pub subclones: Option<SubcloneModel>,
+    /// Reproductive somatic input (#405): a VCF of somatic variants to replay in the
+    /// tumor pass, honored at their observed VAF (`INFO/AF` or `FORMAT/AD`). Each
+    /// variant's fraction is divided by `purity` so it reproduces after tumor/normal
+    /// mixing, and it is tagged `somatic` in the merged truth. Composes with de-novo
+    /// somatic generation (set `tumor_mutation_rate: 0` for pure replay).
+    pub somatic_vcf: Option<PathBuf>,
 }
 
 impl Default for CancerConfig {
@@ -81,6 +87,7 @@ impl Default for CancerConfig {
             keep_per_pass: true,
             overwrite_output: false,
             subclones: None,
+            somatic_vcf: None,
         }
     }
 }
@@ -160,6 +167,7 @@ impl CancerConfig {
                     };
                 }
                 "germline_vcf" => cfg.germline_vcf = Some(req_path(value, "germline_vcf")?),
+                "somatic_vcf" => cfg.somatic_vcf = Some(req_path(value, "somatic_vcf")?),
                 "subclones" => cfg.subclones = Some(parse_subclones(value)?),
                 "subclones_file" => {
                     cfg.subclones =
@@ -273,6 +281,10 @@ impl CancerConfig {
             // #405: only the tumor pass carries the subclonal architecture — the
             // normal pass has no somatic variants to stamp.
             subclone_model: self.subclones.clone(),
+            // #405 reproductive: replay the somatic VCF only in the tumor pass. Its
+            // observed VAFs are divided by purity so they reproduce after mixing.
+            somatic_vcf: self.somatic_vcf.clone(),
+            somatic_af_scale: 1.0 / self.purity,
             output_filename: format!("{}_tumor", self.output_prefix),
             rng_seed: Some(format!("{}-tumor", self.rng_seed_root)),
             ..self.shared_run_config()
@@ -822,6 +834,22 @@ mod tests {
                 .subclone_model
                 .is_some()
         );
+    }
+
+    #[test]
+    fn somatic_vcf_lands_on_tumor_pass_with_purity_scale() {
+        let mut s = base_scrape();
+        s.insert("purity".into(), Value::from(0.8));
+        s.insert("somatic_vcf".into(), Value::String("/tmp/som.vcf".into()));
+        let cfg = CancerConfig::from_scrape(s).unwrap();
+        assert_eq!(cfg.somatic_vcf, Some(PathBuf::from("/tmp/som.vcf")));
+
+        // Only the tumor pass replays it, at 1/purity.
+        let normal = cfg.normal_pass().unwrap();
+        let tumor = cfg.tumor_pass(PathBuf::from("/tmp/g.vcf.gz")).unwrap();
+        assert!(normal.somatic_vcf.is_none());
+        assert_eq!(tumor.somatic_vcf, Some(PathBuf::from("/tmp/som.vcf")));
+        assert!((tumor.somatic_af_scale - 1.25).abs() < 1e-9); // 1/0.8
     }
 
     #[test]

--- a/eidolon/src/gen_cancer_reads/utils/config.rs
+++ b/eidolon/src/gen_cancer_reads/utils/config.rs
@@ -285,6 +285,10 @@ impl CancerConfig {
             // observed VAFs are divided by purity so they reproduce after mixing.
             somatic_vcf: self.somatic_vcf.clone(),
             somatic_af_scale: 1.0 / self.purity,
+            // #405: record each somatic variant's intended observed VAF
+            // (INFO/NEAT_VAF = purity × allele_fraction) for direct comparison
+            // against a caller's VAF on the merged reads.
+            merged_vaf_purity: Some(self.purity),
             output_filename: format!("{}_tumor", self.output_prefix),
             rng_seed: Some(format!("{}-tumor", self.rng_seed_root)),
             ..self.shared_run_config()

--- a/eidolon/src/gen_cancer_reads/utils/config.rs
+++ b/eidolon/src/gen_cancer_reads/utils/config.rs
@@ -12,6 +12,7 @@ use serde_yml::Value;
 
 use crate::gen_cancer_reads::errors::GenCancerReadsError;
 use crate::gen_reads::utils::config::RunConfiguration;
+use crate::gen_reads::utils::subclone::{Subclone, SubcloneModel};
 
 /// Default tumor-pass somatic SNP/indel rate (typical solid tumor; see #235).
 /// The de-novo mutations added in the tumor pass are somatic, so this — not the
@@ -48,6 +49,12 @@ pub struct CancerConfig {
     pub sv_rate_scale: f64,
     pub keep_per_pass: bool,
     pub overwrite_output: bool,
+    /// Optional subclonal architecture (#405). When set, the tumor pass distributes
+    /// its de-novo somatic variants across these subclones, stamping each with its
+    /// subclone's cancer-cell fraction (CCF) as a per-variant allele_fraction. The
+    /// observed VAF in the merged output is `purity × CCF`. `None` → the pre-#405
+    /// single-fraction behavior (every somatic variant near one effective VAF).
+    pub subclones: Option<SubcloneModel>,
 }
 
 impl Default for CancerConfig {
@@ -72,6 +79,7 @@ impl Default for CancerConfig {
             sv_rate_scale: 0.0,
             keep_per_pass: true,
             overwrite_output: false,
+            subclones: None,
         }
     }
 }
@@ -143,6 +151,7 @@ impl CancerConfig {
                     };
                 }
                 "germline_vcf" => cfg.germline_vcf = Some(req_path(value, "germline_vcf")?),
+                "subclones" => cfg.subclones = Some(parse_subclones(value)?),
                 "sv_rate_scale" => cfg.sv_rate_scale = as_f64(value, "sv_rate_scale")?,
                 "keep_per_pass" => cfg.keep_per_pass = as_bool(value, "keep_per_pass")?,
                 "overwrite_output" => cfg.overwrite_output = as_bool(value, "overwrite_output")?,
@@ -248,6 +257,9 @@ impl CancerConfig {
             mutation_model: self.tumor_model.clone(),
             input_vcf: Some(germline_vcf),
             sv_rate_scale: self.sv_rate_scale,
+            // #405: only the tumor pass carries the subclonal architecture — the
+            // normal pass has no somatic variants to stamp.
+            subclone_model: self.subclones.clone(),
             output_filename: format!("{}_tumor", self.output_prefix),
             rng_seed: Some(format!("{}-tumor", self.rng_seed_root)),
             ..self.shared_run_config()
@@ -278,6 +290,42 @@ fn as_f64(v: &Value, key: &str) -> Result<f64, GenCancerReadsError> {
 fn as_bool(v: &Value, key: &str) -> Result<bool, GenCancerReadsError> {
     v.as_bool()
         .ok_or_else(|| GenCancerReadsError::ConfigError(format!("{key} must be a boolean")))
+}
+
+/// Parse the optional `subclones:` YAML list into a validated [`SubcloneModel`] (#405).
+///
+/// Expected shape — a non-empty sequence of `{ccf, weight}` mappings:
+/// ```yaml
+/// subclones:
+///   - {ccf: 1.0, weight: 0.6}   # clonal / truncal
+///   - {ccf: 0.4, weight: 0.3}   # major subclone
+///   - {ccf: 0.15, weight: 0.1}  # minor subclone
+/// ```
+/// `weight` is optional and defaults to `1.0` (equal share). CCF/weight validity is
+/// enforced by `SubcloneModel::new`.
+fn parse_subclones(v: &Value) -> Result<SubcloneModel, GenCancerReadsError> {
+    let seq = v.as_sequence().ok_or_else(|| {
+        GenCancerReadsError::ConfigError("subclones must be a list of {ccf, weight} entries".into())
+    })?;
+    let mut subclones = Vec::with_capacity(seq.len());
+    for (i, entry) in seq.iter().enumerate() {
+        let map = entry.as_mapping().ok_or_else(|| {
+            GenCancerReadsError::ConfigError(format!(
+                "subclones[{i}] must be a mapping with a ccf (and optional weight)"
+            ))
+        })?;
+        let ccf_val = map.get(Value::String("ccf".into())).ok_or_else(|| {
+            GenCancerReadsError::ConfigError(format!("subclones[{i}] is missing required 'ccf'"))
+        })?;
+        let ccf = as_f64(ccf_val, &format!("subclones[{i}].ccf"))?;
+        let weight = match map.get(Value::String("weight".into())) {
+            Some(w) => as_f64(w, &format!("subclones[{i}].weight"))?,
+            None => 1.0,
+        };
+        subclones.push(Subclone { ccf, weight });
+    }
+    SubcloneModel::new(subclones)
+        .map_err(|e| GenCancerReadsError::ConfigError(format!("invalid subclones: {e}")))
 }
 
 #[cfg(test)]
@@ -413,5 +461,98 @@ mod tests {
         assert!(normal.output_filename.ends_with("_normal"));
         assert!(tumor.output_filename.ends_with("_tumor"));
         assert_eq!(tumor.input_vcf, Some(PathBuf::from("/tmp/g.vcf.gz")));
+    }
+
+    #[test]
+    fn no_subclones_by_default() {
+        let cfg = CancerConfig::from_scrape(base_scrape()).unwrap();
+        assert!(cfg.subclones.is_none());
+        // And it must not leak into either pass.
+        assert!(cfg.normal_pass().unwrap().subclone_model.is_none());
+        assert!(
+            cfg.tumor_pass(PathBuf::from("/tmp/g.vcf.gz"))
+                .unwrap()
+                .subclone_model
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn subclones_parse_and_land_on_tumor_pass_only() {
+        let mut s = base_scrape();
+        let sub: Value =
+            serde_yml::from_str("- {ccf: 1.0, weight: 3.0}\n- {ccf: 0.2, weight: 1.0}").unwrap();
+        s.insert("subclones".into(), sub);
+        let cfg = CancerConfig::from_scrape(s).unwrap();
+
+        let model = cfg.subclones.as_ref().expect("subclones parsed");
+        assert_eq!(model.subclones().len(), 2);
+        assert_eq!(
+            model.subclones()[0],
+            Subclone {
+                ccf: 1.0,
+                weight: 3.0
+            }
+        );
+        assert_eq!(
+            model.subclones()[1],
+            Subclone {
+                ccf: 0.2,
+                weight: 1.0
+            }
+        );
+
+        // The normal pass has no somatic variants → no model; the tumor pass carries it.
+        assert!(cfg.normal_pass().unwrap().subclone_model.is_none());
+        assert_eq!(
+            cfg.tumor_pass(PathBuf::from("/tmp/g.vcf.gz"))
+                .unwrap()
+                .subclone_model,
+            Some(model.clone())
+        );
+    }
+
+    #[test]
+    fn subclones_weight_defaults_to_one() {
+        let mut s = base_scrape();
+        let sub: Value = serde_yml::from_str("- {ccf: 0.5}\n- {ccf: 0.3}").unwrap();
+        s.insert("subclones".into(), sub);
+        let cfg = CancerConfig::from_scrape(s).unwrap();
+        let model = cfg.subclones.unwrap();
+        assert_eq!(
+            model.subclones()[0],
+            Subclone {
+                ccf: 0.5,
+                weight: 1.0
+            }
+        );
+        assert_eq!(
+            model.subclones()[1],
+            Subclone {
+                ccf: 0.3,
+                weight: 1.0
+            }
+        );
+    }
+
+    #[test]
+    fn subclones_reject_bad_ccf() {
+        let mut s = base_scrape();
+        let sub: Value = serde_yml::from_str("- {ccf: 1.5, weight: 1.0}").unwrap();
+        s.insert("subclones".into(), sub);
+        assert!(matches!(
+            CancerConfig::from_scrape(s),
+            Err(GenCancerReadsError::ConfigError(_))
+        ));
+    }
+
+    #[test]
+    fn subclones_reject_empty_list() {
+        let mut s = base_scrape();
+        s.insert("subclones".into(), Value::Sequence(vec![]));
+        assert!(matches!(
+            CancerConfig::from_scrape(s),
+            Err(GenCancerReadsError::ConfigError(_))
+        ));
     }
 }

--- a/eidolon/src/gen_cancer_reads/utils/vcf_merge.rs
+++ b/eidolon/src/gen_cancer_reads/utils/vcf_merge.rs
@@ -3,12 +3,13 @@
 //!
 //! Both inputs are eidolon-golden VCFs with identical record representation (the
 //! tumor pass carries normal's germline verbatim via `input_vcf`, tagged
-//! `INFO/NEAT_PROVENANCE=input`; somatic de-novo records are `=denovo`). So an
-//! exact `(contig,pos,ref,alt)` key is sufficient — no positional/normalized
-//! matching needed. Origin rules:
-//!   - tumor `denovo`            -> `somatic`
-//!   - tumor `input` (or other)  -> `shared`   (germline carried into the tumor)
-//!   - normal key absent in tumor -> `germline` (germline-only; lost in tumor)
+//! `INFO/NEAT_PROVENANCE=input`; somatic de-novo records are `=denovo`, and
+//! reproductive somatic-VCF records (#405) are `=somatic_input`). So an exact
+//! `(contig,pos,ref,alt)` key is sufficient — no positional/normalized matching
+//! needed. Origin rules:
+//!   - tumor `denovo` / `somatic_input` -> `somatic`  (tumor-only)
+//!   - tumor `input` (or other)         -> `shared`   (germline carried into tumor)
+//!   - normal key absent in tumor       -> `germline` (germline-only; lost in tumor)
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -64,12 +65,15 @@ fn key_of(cols: &[&str]) -> Option<Key> {
 }
 
 /// Origin for a tumor-pass record, from its INFO/NEAT_PROVENANCE.
+///
+/// De-novo-sampled variants and reproductive somatic-VCF variants (#405) are both
+/// tumor-only → `somatic`; anything else in the tumor pass is germline carried
+/// through `input_vcf` → `shared`.
 pub fn tumor_origin(info: &str) -> &'static str {
-    if info.split(';').any(|f| f == "NEAT_PROVENANCE=denovo") {
-        "somatic"
-    } else {
-        "shared"
-    }
+    let is_somatic = info
+        .split(';')
+        .any(|f| f == "NEAT_PROVENANCE=denovo" || f == "NEAT_PROVENANCE=somatic_input");
+    if is_somatic { "somatic" } else { "shared" }
 }
 
 /// Append `NEAT_ORIGIN=<origin>` to an INFO column.
@@ -221,6 +225,13 @@ mod tests {
     fn tumor_origin_classifies_provenance() {
         assert_eq!(tumor_origin("NEAT_PROVENANCE=denovo"), "somatic");
         assert_eq!(tumor_origin("SVTYPE=DEL;NEAT_PROVENANCE=denovo"), "somatic");
+        // #405 reproductive somatic-VCF variants classify as somatic, not shared,
+        // even though (like germline input) they came from a file.
+        assert_eq!(tumor_origin("NEAT_PROVENANCE=somatic_input"), "somatic");
+        assert_eq!(
+            tumor_origin("AF=0.3;NEAT_PROVENANCE=somatic_input"),
+            "somatic"
+        );
         assert_eq!(tumor_origin("NEAT_PROVENANCE=input"), "shared");
         assert_eq!(tumor_origin("."), "shared");
     }

--- a/eidolon/src/gen_reads/utils.rs
+++ b/eidolon/src/gen_reads/utils.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod generate_fragments;
 pub mod generate_variants;
 pub mod runner;
+pub mod subclone;

--- a/eidolon/src/gen_reads/utils/config.rs
+++ b/eidolon/src/gen_reads/utils/config.rs
@@ -129,10 +129,10 @@ pub struct RunConfiguration {
     // disabled, output is byte-identical to pre-adapter behavior.
     pub adapters: AdapterConfig,
     // Optional subclonal architecture for de-novo variants (#405). When `Some`,
-    // each de-novo variant generated in this run is assigned a subclone's
-    // cancer-cell fraction as its per-variant `allele_fraction`, yielding a
-    // realistic somatic VAF spectrum. Set only on the cancer *tumor* pass; `None`
-    // everywhere else keeps output byte-identical to pre-#405 behavior.
+    // each de-novo variant is assigned a subclone whose cancer-cell fraction (CCF)
+    // *composes* with the variant's dosage into `allele_fraction = dosage × CCF`,
+    // yielding a realistic somatic VAF spectrum. Set only on the cancer *tumor*
+    // pass; `None` everywhere else keeps output byte-identical to pre-#405 behavior.
     pub subclone_model: Option<subclone::SubcloneModel>,
 }
 

--- a/eidolon/src/gen_reads/utils/config.rs
+++ b/eidolon/src/gen_reads/utils/config.rs
@@ -144,6 +144,11 @@ pub struct RunConfiguration {
     // tumor/normal mixing (merged VAF = purity × af = the input VAF). Clamped to 1.0.
     // Default 1.0 (no scaling).
     pub somatic_af_scale: f64,
+    // Purity used to record a somatic variant's intended *observed* merged VAF as
+    // `INFO/NEAT_VAF = purity × allele_fraction` (#405). The cancer tumor pass sets
+    // `Some(purity)`; `None` elsewhere suppresses the tag. Only emitted where a
+    // subclone model or somatic_vcf is active, so plain runs stay byte-identical.
+    pub merged_vaf_purity: Option<f64>,
 }
 
 impl Default for RunConfiguration {
@@ -189,6 +194,7 @@ impl Default for RunConfiguration {
             subclone_model: None,
             somatic_vcf: None,
             somatic_af_scale: 1.0,
+            merged_vaf_purity: None,
         }
     }
 }
@@ -859,6 +865,7 @@ mod tests {
             subclone_model: None,
             somatic_vcf: None,
             somatic_af_scale: 1.0,
+            merged_vaf_purity: None,
         };
 
         println!("{:?}", test_configuration);

--- a/eidolon/src/gen_reads/utils/config.rs
+++ b/eidolon/src/gen_reads/utils/config.rs
@@ -134,6 +134,16 @@ pub struct RunConfiguration {
     // yielding a realistic somatic VAF spectrum. Set only on the cancer *tumor*
     // pass; `None` everywhere else keeps output byte-identical to pre-#405 behavior.
     pub subclone_model: Option<subclone::SubcloneModel>,
+    // Reproductive somatic input (#405): a VCF of somatic variants to replay in the
+    // tumor pass. Loaded as `Provenance::SomaticVcf` (→ merged truth origin
+    // `somatic`, not `shared`) with their `allele_fraction` honored. Set only on the
+    // cancer tumor pass; `None` elsewhere.
+    pub somatic_vcf: Option<PathBuf>,
+    // Multiplier applied to `somatic_vcf` variants' `allele_fraction` on load. The
+    // cancer tumor pass sets `1/purity` so a supplied *observed* VAF reproduces after
+    // tumor/normal mixing (merged VAF = purity × af = the input VAF). Clamped to 1.0.
+    // Default 1.0 (no scaling).
+    pub somatic_af_scale: f64,
 }
 
 impl Default for RunConfiguration {
@@ -177,6 +187,8 @@ impl Default for RunConfiguration {
             sv_max_length_fraction: 0.25,
             adapters: AdapterConfig::default(),
             subclone_model: None,
+            somatic_vcf: None,
+            somatic_af_scale: 1.0,
         }
     }
 }
@@ -845,6 +857,8 @@ mod tests {
             sv_max_length_fraction: 0.25,
             adapters: AdapterConfig::default(),
             subclone_model: None,
+            somatic_vcf: None,
+            somatic_af_scale: 1.0,
         };
 
         println!("{:?}", test_configuration);

--- a/eidolon/src/gen_reads/utils/config.rs
+++ b/eidolon/src/gen_reads/utils/config.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 
 use crate::eidolon_core::file_tools::folder_tools::check_create_dir;
 use crate::gen_reads::errors::GenerateReadsError;
+use crate::gen_reads::utils::subclone;
 use log::{error, info, warn};
 use serde_yml::Value;
 use std::collections::HashMap;
@@ -127,6 +128,12 @@ pub struct RunConfiguration {
     // Optional 3' sequencing-adapter readthrough (#125). Default disabled; when
     // disabled, output is byte-identical to pre-adapter behavior.
     pub adapters: AdapterConfig,
+    // Optional subclonal architecture for de-novo variants (#405). When `Some`,
+    // each de-novo variant generated in this run is assigned a subclone's
+    // cancer-cell fraction as its per-variant `allele_fraction`, yielding a
+    // realistic somatic VAF spectrum. Set only on the cancer *tumor* pass; `None`
+    // everywhere else keeps output byte-identical to pre-#405 behavior.
+    pub subclone_model: Option<subclone::SubcloneModel>,
 }
 
 impl Default for RunConfiguration {
@@ -169,6 +176,7 @@ impl Default for RunConfiguration {
             sv_rate_scale: 0.0,
             sv_max_length_fraction: 0.25,
             adapters: AdapterConfig::default(),
+            subclone_model: None,
         }
     }
 }
@@ -836,6 +844,7 @@ mod tests {
             sv_rate_scale: 0.0,
             sv_max_length_fraction: 0.25,
             adapters: AdapterConfig::default(),
+            subclone_model: None,
         };
 
         println!("{:?}", test_configuration);

--- a/eidolon/src/gen_reads/utils/runner.rs
+++ b/eidolon/src/gen_reads/utils/runner.rs
@@ -1,7 +1,7 @@
 use eidolon_core::file_tools::block_gz::BlockGzWriter;
 use eidolon_core::file_tools::file_io::create_output_file;
 use eidolon_core::rng::NeatRng;
-use eidolon_core::structs::variants::{Genotype, SvType, VariantType};
+use eidolon_core::structs::variants::{Genotype, Provenance, SvType, VariantType};
 use log::{debug, error, info, warn};
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
@@ -149,6 +149,48 @@ pub fn run_neat(
             Some(filter_input_vcf(raw))
         }
         None => None,
+    };
+
+    // #405 reproductive somatic: replay a supplied somatic VCF in this pass. Tag its
+    // variants `SomaticVcf` (so the tumor/normal merge resolves origin `somatic`, not
+    // `shared`) and scale their allele_fraction by `somatic_af_scale` — the cancer
+    // tumor pass sets 1/purity, so a supplied *observed* VAF reproduces after mixing.
+    let input_variants = if let Some(path) = &config.somatic_vcf {
+        info!("Loading reproductive somatic VCF: {}", path.display());
+        let mut som = filter_input_vcf(read_vcf(path.to_path_buf())?);
+        let mut clamped = 0usize;
+        for variants in som.values_mut() {
+            for v in variants.iter_mut() {
+                v.provenance = Provenance::SomaticVcf;
+                if let Some(af) = v.allele_fraction {
+                    let scaled = af * config.somatic_af_scale;
+                    v.allele_fraction = Some(if scaled > 1.0 {
+                        clamped += 1;
+                        1.0
+                    } else {
+                        scaled
+                    });
+                }
+            }
+        }
+        if clamped > 0 {
+            warn!(
+                "somatic_vcf: clamped {clamped} scaled allele fraction(s) > 1.0 \
+                 (observed VAF exceeded purity)"
+            );
+        }
+        // Merge the somatic variants into the germline input map (or stand alone).
+        Some(match input_variants {
+            Some(mut germline) => {
+                for (contig, mut vs) in som {
+                    germline.entry(contig).or_default().append(&mut vs);
+                }
+                germline
+            }
+            None => som,
+        })
+    } else {
+        input_variants
     };
 
     info!("Reading fasta file: {}", &config.reference.display());

--- a/eidolon/src/gen_reads/utils/runner.rs
+++ b/eidolon/src/gen_reads/utils/runner.rs
@@ -1092,10 +1092,20 @@ fn generate_mutated_map(
                 // dosage (#266/#267) flow in for free once genotype_str carries a real
                 // per-copy spread. `None` elsewhere leaves output byte-identical.
                 if let Some(model) = &config.subclone_model {
+                    let ccf = model.sample_ccf(&mut rng)?;
                     let base = variant
                         .allele_fraction
                         .unwrap_or_else(|| variant.dosage_fraction());
-                    variant.allele_fraction = Some(base * model.sample_ccf(&mut rng)?);
+                    variant.allele_fraction = Some(base * ccf);
+                    // Record the intended cellular fraction (INFO/NEAT_CCF) so the
+                    // golden VCF carries ground truth for validation — observed AD/AF
+                    // should track dosage × NEAT_CCF. De-novo literals have no prior
+                    // INFO, but merge defensively in case that changes.
+                    let tag = format!("NEAT_CCF={ccf:.4}");
+                    variant.info = Some(match variant.info.take() {
+                        Some(e) if !e.is_empty() && e != "." => format!("{e};{tag}"),
+                        _ => tag,
+                    });
                 }
                 if variant.variant_type == VariantType::Deletion
                     && variant.reference.len() - 1 > max_del_len

--- a/eidolon/src/gen_reads/utils/runner.rs
+++ b/eidolon/src/gen_reads/utils/runner.rs
@@ -1083,12 +1083,19 @@ fn generate_mutated_map(
         if let Some(vec) = result {
             for mut variant in vec {
                 // #405: in the cancer tumor pass, distribute de-novo somatic variants
-                // across subclones — each takes its subclone's CCF as the per-variant
-                // allele_fraction. Composes with purity (the tumor/normal coverage
-                // split) at merge time → observed VAF = purity × CCF. `None` elsewhere
-                // leaves allele_fraction untouched, so output is byte-identical.
+                // across subclones. A subclone's CCF is a *cellular-fraction factor*
+                // that composes with the variant's allele dosage — it does not replace
+                // it. So observed alt fraction = dosage × CCF (× purity via the
+                // tumor/normal coverage split at merge time): a heterozygous somatic
+                // SNV at CCF f lands at f/2, which is what subclonal-deconvolution
+                // tools invert. Multiplying (not overwriting) also lets polyploid
+                // dosage (#266/#267) flow in for free once genotype_str carries a real
+                // per-copy spread. `None` elsewhere leaves output byte-identical.
                 if let Some(model) = &config.subclone_model {
-                    variant.allele_fraction = Some(model.sample_ccf(&mut rng)?);
+                    let base = variant
+                        .allele_fraction
+                        .unwrap_or_else(|| variant.dosage_fraction());
+                    variant.allele_fraction = Some(base * model.sample_ccf(&mut rng)?);
                 }
                 if variant.variant_type == VariantType::Deletion
                     && variant.reference.len() - 1 > max_del_len

--- a/eidolon/src/gen_reads/utils/runner.rs
+++ b/eidolon/src/gen_reads/utils/runner.rs
@@ -162,14 +162,23 @@ pub fn run_neat(
         for variants in som.values_mut() {
             for v in variants.iter_mut() {
                 v.provenance = Provenance::SomaticVcf;
+                // Drop the source VCF's INFO (like germline input_vcf) so it doesn't
+                // leak into the golden; re-populate only with our own ground-truth tag.
+                v.info = None;
                 if let Some(af) = v.allele_fraction {
-                    let scaled = af * config.somatic_af_scale;
-                    v.allele_fraction = Some(if scaled > 1.0 {
+                    let raw = af * config.somatic_af_scale;
+                    let scaled = if raw > 1.0 {
                         clamped += 1;
                         1.0
                     } else {
-                        scaled
-                    });
+                        raw
+                    };
+                    v.allele_fraction = Some(scaled);
+                    // NEAT_VAF = intended observed VAF after mixing = purity × scaled =
+                    // the input observed VAF (or purity, if it was clamped).
+                    if let Some(p) = config.merged_vaf_purity {
+                        append_info_tag(&mut v.info, format!("NEAT_VAF={:.4}", p * scaled));
+                    }
                 }
             }
         }
@@ -1138,16 +1147,16 @@ fn generate_mutated_map(
                     let base = variant
                         .allele_fraction
                         .unwrap_or_else(|| variant.dosage_fraction());
-                    variant.allele_fraction = Some(base * ccf);
-                    // Record the intended cellular fraction (INFO/NEAT_CCF) so the
-                    // golden VCF carries ground truth for validation — observed AD/AF
-                    // should track dosage × NEAT_CCF. De-novo literals have no prior
-                    // INFO, but merge defensively in case that changes.
-                    let tag = format!("NEAT_CCF={ccf:.4}");
-                    variant.info = Some(match variant.info.take() {
-                        Some(e) if !e.is_empty() && e != "." => format!("{e};{tag}"),
-                        _ => tag,
-                    });
+                    let af = base * ccf;
+                    variant.allele_fraction = Some(af);
+                    // Ground truth in the golden VCF: NEAT_CCF = intended cellular
+                    // fraction (observed AD/AF tracks dosage × CCF within the tumor
+                    // pass); NEAT_VAF = intended observed fraction after tumor/normal
+                    // mixing (purity × af), directly comparable to a caller's VAF.
+                    append_info_tag(&mut variant.info, format!("NEAT_CCF={ccf:.4}"));
+                    if let Some(p) = config.merged_vaf_purity {
+                        append_info_tag(&mut variant.info, format!("NEAT_VAF={:.4}", p * af));
+                    }
                 }
                 if variant.variant_type == VariantType::Deletion
                     && variant.reference.len() - 1 > max_del_len
@@ -2499,6 +2508,16 @@ fn collect_chunk_result(
 /// Symbolic / structural variants (`<DEL>`, `<DUP>`, `<CNV>`, ...) are also
 /// kept — gen_reads uses them downstream to modulate coverage and to round-
 /// trip into the output VCF; they never go through per-base mutation.
+/// Append a `KEY=value` tag to a variant's optional INFO string, merging with any
+/// existing content (`;`-joined). Used to attach simulator ground-truth tags
+/// (NEAT_CCF, NEAT_VAF) to somatic variants for the golden VCF (#405).
+fn append_info_tag(info: &mut Option<String>, tag: String) {
+    *info = Some(match info.take() {
+        Some(e) if !e.is_empty() && e != "." => format!("{e};{tag}"),
+        _ => tag,
+    });
+}
+
 fn filter_input_vcf(raw: HashMap<String, Vec<Variant>>) -> HashMap<String, Vec<Variant>> {
     let mut out: HashMap<String, Vec<Variant>> = HashMap::new();
     for (contig, variants) in raw {

--- a/eidolon/src/gen_reads/utils/runner.rs
+++ b/eidolon/src/gen_reads/utils/runner.rs
@@ -1081,7 +1081,15 @@ fn generate_mutated_map(
             &mut rng,
         )?;
         if let Some(vec) = result {
-            for variant in vec {
+            for mut variant in vec {
+                // #405: in the cancer tumor pass, distribute de-novo somatic variants
+                // across subclones — each takes its subclone's CCF as the per-variant
+                // allele_fraction. Composes with purity (the tumor/normal coverage
+                // split) at merge time → observed VAF = purity × CCF. `None` elsewhere
+                // leaves allele_fraction untouched, so output is byte-identical.
+                if let Some(model) = &config.subclone_model {
+                    variant.allele_fraction = Some(model.sample_ccf(&mut rng)?);
+                }
                 if variant.variant_type == VariantType::Deletion
                     && variant.reference.len() - 1 > max_del_len
                 {

--- a/eidolon/src/gen_reads/utils/subclone.rs
+++ b/eidolon/src/gen_reads/utils/subclone.rs
@@ -8,12 +8,22 @@
 //! somatic variant is assigned to a subclone (weighted draw) and takes the
 //! subclone's CCF as its per-variant [`allele_fraction`](eidolon_core::structs::variants::Variant::allele_fraction).
 //!
-//! The CCF **composes** with tumor purity for free. Purity is realized as the
-//! tumor/normal coverage split at read-mixing time, so a somatic variant stamped at
-//! CCF `f` in the tumor pass lands in the merged BAM at
-//! `observed VAF = purity × f` — exactly the orthogonal decomposition #405 calls for
-//! (purity = normal contamination; CCF = subclonal cellular fraction). No new
-//! read-mixing math is needed; the model only stamps `allele_fraction`.
+//! A subclone's CCF is a **cellular-fraction factor** that *composes* — it does not
+//! replace the variant's allele dosage or tumor purity. For a variant at dosage `d`
+//! (alt copies / ploidy) assigned to a subclone at CCF `f`, the caller stamps
+//! `allele_fraction = d × f`, and purity — realized as the tumor/normal coverage
+//! split at read-mixing time — contributes the final factor:
+//!
+//! ```text
+//! observed VAF = purity × dosage × CCF
+//! ```
+//!
+//! So a heterozygous somatic SNV (d = 0.5) at CCF `f` lands at `f/2` — the value a
+//! subclonal-deconvolution tool inverts back to `f`. These are orthogonal axes
+//! (purity = normal contamination; dosage = per-copy multiplicity; CCF = subclonal
+//! cellular fraction). This model owns only the CCF factor; dosage composition lives
+//! at the call site (`Variant::dosage_fraction`), so polyploid dosage (#266/#267)
+//! flows in for free. No new read-mixing math is needed.
 //!
 //! This is the generative half of #405. The reproductive half (honor per-variant CCF
 //! from an input somatic VCF) rides the existing `INFO/AF` → `allele_fraction` parse

--- a/eidolon/src/gen_reads/utils/subclone.rs
+++ b/eidolon/src/gen_reads/utils/subclone.rs
@@ -1,0 +1,203 @@
+//! Subclonal architecture for de-novo somatic variants (#405, part of realism epic #311).
+//!
+//! A tumor is a mixture of cell populations ("subclones"), each present at a
+//! distinct **cancer-cell fraction (CCF)** — the fraction of tumor cells carrying
+//! that subclone's mutations. `gen-cancer-reads` today models a tumor with a single
+//! global `purity` scalar, so every somatic variant collapses to essentially one
+//! effective VAF. A [`SubcloneModel`] restores that missing axis: each de-novo
+//! somatic variant is assigned to a subclone (weighted draw) and takes the
+//! subclone's CCF as its per-variant [`allele_fraction`](eidolon_core::structs::variants::Variant::allele_fraction).
+//!
+//! The CCF **composes** with tumor purity for free. Purity is realized as the
+//! tumor/normal coverage split at read-mixing time, so a somatic variant stamped at
+//! CCF `f` in the tumor pass lands in the merged BAM at
+//! `observed VAF = purity × f` — exactly the orthogonal decomposition #405 calls for
+//! (purity = normal contamination; CCF = subclonal cellular fraction). No new
+//! read-mixing math is needed; the model only stamps `allele_fraction`.
+//!
+//! This is the generative half of #405. The reproductive half (honor per-variant CCF
+//! from an input somatic VCF) rides the existing `INFO/AF` → `allele_fraction` parse
+//! path and is tracked separately. The generic AF-sampling superset is #404.
+
+use eidolon_core::rng::NeatRng;
+
+/// One tumor subclone: a cancer-cell fraction and its relative share of the
+/// somatic variant burden.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Subclone {
+    /// Cancer-cell fraction in `(0.0, 1.0]`. `1.0` is a clonal (truncal) population
+    /// present in every tumor cell.
+    pub ccf: f64,
+    /// Relative weight — the (unnormalized) share of de-novo somatic variants
+    /// assigned to this subclone. Weights are normalized across the model, so only
+    /// their ratios matter.
+    pub weight: f64,
+}
+
+/// A tumor's subclonal architecture: a non-empty set of [`Subclone`]s over which
+/// de-novo somatic variants are distributed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubcloneModel {
+    subclones: Vec<Subclone>,
+}
+
+/// Reasons a [`SubcloneModel`] cannot be constructed.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SubcloneModelError {
+    /// No subclones were supplied.
+    Empty,
+    /// A CCF fell outside `(0.0, 1.0]`.
+    CcfOutOfRange(f64),
+    /// A weight was non-positive (or NaN).
+    NonPositiveWeight(f64),
+}
+
+impl std::fmt::Display for SubcloneModelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SubcloneModelError::Empty => write!(f, "subclones must not be empty"),
+            SubcloneModelError::CcfOutOfRange(v) => {
+                write!(f, "subclone ccf {v} out of range (0.0, 1.0]")
+            }
+            SubcloneModelError::NonPositiveWeight(v) => {
+                write!(f, "subclone weight {v} must be positive")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SubcloneModelError {}
+
+impl SubcloneModel {
+    /// Build a validated model. Rejects an empty set, any CCF outside `(0.0, 1.0]`,
+    /// and any non-positive/NaN weight.
+    pub fn new(subclones: Vec<Subclone>) -> Result<Self, SubcloneModelError> {
+        if subclones.is_empty() {
+            return Err(SubcloneModelError::Empty);
+        }
+        for s in &subclones {
+            if !(s.ccf > 0.0 && s.ccf <= 1.0) {
+                return Err(SubcloneModelError::CcfOutOfRange(s.ccf));
+            }
+            // Reject non-finite (NaN/inf) and non-positive weights: a weight must be a
+            // real, positive share. `<= 0.0` alone would let NaN slip through.
+            if !s.weight.is_finite() || s.weight <= 0.0 {
+                return Err(SubcloneModelError::NonPositiveWeight(s.weight));
+            }
+        }
+        Ok(SubcloneModel { subclones })
+    }
+
+    /// The subclones, in construction order.
+    pub fn subclones(&self) -> &[Subclone] {
+        &self.subclones
+    }
+
+    /// Draw a CCF for one de-novo somatic variant, weighted by subclone share.
+    ///
+    /// Consumes exactly **one** `rng.random()` draw regardless of subclone count, so
+    /// the RNG-stream perturbation is a single, predictable step per stamped variant.
+    /// The final subclone catches any floating-point residue, so a valid model always
+    /// returns a CCF.
+    pub fn sample_ccf(&self, rng: &mut NeatRng) -> Result<f64, eidolon_core::rng::NeatRngError> {
+        let total: f64 = self.subclones.iter().map(|s| s.weight).sum();
+        let mut r = rng.random()? * total;
+        for s in &self.subclones {
+            r -= s.weight;
+            if r < 0.0 {
+                return Ok(s.ccf);
+            }
+        }
+        // Unreachable for a validated (non-empty, positive-weight) model except via
+        // floating-point rounding at the very top of the range; fall back to the last.
+        Ok(self.subclones.last().expect("validated non-empty").ccf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty() {
+        assert_eq!(SubcloneModel::new(vec![]), Err(SubcloneModelError::Empty));
+    }
+
+    #[test]
+    fn rejects_bad_ccf() {
+        let bad = vec![Subclone {
+            ccf: 1.5,
+            weight: 1.0,
+        }];
+        assert_eq!(
+            SubcloneModel::new(bad),
+            Err(SubcloneModelError::CcfOutOfRange(1.5))
+        );
+        let zero = vec![Subclone {
+            ccf: 0.0,
+            weight: 1.0,
+        }];
+        assert_eq!(
+            SubcloneModel::new(zero),
+            Err(SubcloneModelError::CcfOutOfRange(0.0))
+        );
+    }
+
+    #[test]
+    fn rejects_bad_weight() {
+        let bad = vec![Subclone {
+            ccf: 0.5,
+            weight: 0.0,
+        }];
+        assert_eq!(
+            SubcloneModel::new(bad),
+            Err(SubcloneModelError::NonPositiveWeight(0.0))
+        );
+    }
+
+    #[test]
+    fn sample_ccf_respects_weights() {
+        // Clonal 1.0 (weight 3), minor 0.2 (weight 1) → ~75% / ~25% split.
+        let model = SubcloneModel::new(vec![
+            Subclone {
+                ccf: 1.0,
+                weight: 3.0,
+            },
+            Subclone {
+                ccf: 0.2,
+                weight: 1.0,
+            },
+        ])
+        .unwrap();
+        let mut rng = NeatRng::new_from_seed(&vec!["ccf-test".to_string()]).unwrap();
+
+        let n = 20_000;
+        let mut clonal = 0;
+        for _ in 0..n {
+            let ccf = model.sample_ccf(&mut rng).unwrap();
+            assert!(ccf == 1.0 || ccf == 0.2, "unexpected ccf {ccf}");
+            if ccf == 1.0 {
+                clonal += 1;
+            }
+        }
+        let frac = clonal as f64 / n as f64;
+        // Expected 0.75; allow generous sampling slack.
+        assert!(
+            (frac - 0.75).abs() < 0.03,
+            "clonal fraction {frac} should be near 0.75"
+        );
+    }
+
+    #[test]
+    fn sample_ccf_single_subclone_is_deterministic() {
+        let model = SubcloneModel::new(vec![Subclone {
+            ccf: 0.4,
+            weight: 1.0,
+        }])
+        .unwrap();
+        let mut rng = NeatRng::new_from_seed(&vec!["one".to_string()]).unwrap();
+        for _ in 0..100 {
+            assert_eq!(model.sample_ccf(&mut rng).unwrap(), 0.4);
+        }
+    }
+}

--- a/eidolon/tests/cancer_reads_e2e.rs
+++ b/eidolon/tests/cancer_reads_e2e.rs
@@ -271,3 +271,106 @@ fn subclonal_somatic_variants_span_a_vaf_spectrum() {
         "measured AF should track dosage × NEAT_CCF; mean |err| = {mean_err:.4} over {checked} sites"
     );
 }
+
+/// End-to-end contract for #405 reproductive mode: a supplied `somatic_vcf` is
+/// replayed in the tumor pass at its observed VAF. Each variant must land in the
+/// merged truth as `NEAT_ORIGIN=somatic` (not `shared`, despite coming from a
+/// file), tagged `NEAT_PROVENANCE=somatic_input`, with its tumor-pass AF scaled to
+/// `VAF/purity` so the merged reads reproduce the input VAF after mixing.
+#[test]
+fn reproductive_somatic_vcf_is_replayed_and_tagged_somatic() {
+    let (_dir, work) = fresh_workdir();
+
+    // Two somatic SNVs at distinct observed VAFs, well inside H1N1_HA (1701 bp).
+    let som = work.join("somatic.vcf");
+    std::fs::write(
+        &som,
+        "##fileformat=VCFv4.2\n\
+         ##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele frequency\">\n\
+         ##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n\
+         H1N1_HA\t500\t.\tA\tT\t60\tPASS\tAF=0.30\tGT\t0/1\n\
+         H1N1_HA\t1200\t.\tA\tC\t60\tPASS\tAF=0.18\tGT\t0/1\n",
+    )
+    .unwrap();
+
+    let yaml = work.join("repro.yml");
+    // purity 0.6 → tumor-pass AF = VAF/0.6 (0.30→0.50, 0.18→0.30). High coverage for
+    // a tight per-site estimate; no de-novo somatic (pure replay).
+    std::fs::write(
+        &yaml,
+        format!(
+            "reference: {ref}\n\
+             output_dir: {out}\n\
+             output_prefix: rep\n\
+             total_coverage: 300\n\
+             purity: 0.6\n\
+             read_len: 70\n\
+             paired_ended: true\n\
+             fragment_mean: 250\n\
+             fragment_st_dev: 30\n\
+             normal_mutation_rate: 0.005\n\
+             tumor_mutation_rate: 0.0\n\
+             somatic_vcf: {som}\n\
+             overwrite_output: true\n\
+             rng_seed: repro-e2e\n",
+            ref = h1n1_reference().display(),
+            out = work.display(),
+            som = som.display(),
+        ),
+    )
+    .unwrap();
+
+    eidolon()
+        .args(["gen-cancer-reads", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let truth = read_gz_lines(&work.join("rep_merged_truth.vcf.gz"));
+    let record = |pos: &str| -> String {
+        truth
+            .iter()
+            .find(|l| {
+                let mut c = l.split('\t');
+                c.next() == Some("H1N1_HA") && c.next() == Some(pos)
+            })
+            .unwrap_or_else(|| panic!("no merged-truth record at H1N1_HA:{pos}"))
+            .clone()
+    };
+    let meas_af = |l: &str| -> f64 {
+        l.split('\t')
+            .next_back()
+            .unwrap()
+            .split(':')
+            .next_back()
+            .unwrap()
+            .parse()
+            .unwrap()
+    };
+
+    // Both replayed variants: origin somatic (not shared), provenance somatic_input.
+    for pos in ["500", "1200"] {
+        let r = record(pos);
+        assert!(
+            r.contains("NEAT_ORIGIN=somatic"),
+            "replayed somatic {pos} not tagged somatic: {r}"
+        );
+        assert!(
+            r.contains("NEAT_PROVENANCE=somatic_input"),
+            "replayed somatic {pos} not tagged somatic_input: {r}"
+        );
+    }
+    // Tumor-pass AF ≈ VAF/purity: 0.30/0.6 = 0.50 and 0.18/0.6 = 0.30. The merged
+    // reads then pile up to the input VAF after purity mixing.
+    assert!(
+        (meas_af(&record("500")) - 0.50).abs() < 0.08,
+        "H1N1_HA:500 AF {} should be ~0.50 (0.30/0.6)",
+        meas_af(&record("500"))
+    );
+    assert!(
+        (meas_af(&record("1200")) - 0.30).abs() < 0.08,
+        "H1N1_HA:1200 AF {} should be ~0.30 (0.18/0.6)",
+        meas_af(&record("1200"))
+    );
+}

--- a/eidolon/tests/cancer_reads_e2e.rs
+++ b/eidolon/tests/cancer_reads_e2e.rs
@@ -96,3 +96,90 @@ fn gen_cancer_reads_produces_tagged_fastqs_and_origin_truth() {
         "some truth records lack NEAT_ORIGIN"
     );
 }
+
+/// End-to-end contract for #405 (generative subclonal VAF): with a `subclones:`
+/// architecture, de-novo somatic variants must spread across the configured
+/// cancer-cell fractions instead of collapsing to the Genotype default
+/// (het 0.5 / hom 1.0). A minor subclone at CCF 0.3 is the discriminating signal:
+/// its measured AF (~0.3, in the tumor-pass golden VCF the truth VCF carries
+/// through) is a value the pre-#405 single-fraction model cannot produce.
+#[test]
+fn subclonal_somatic_variants_span_a_vaf_spectrum() {
+    let (_dir, work) = fresh_workdir();
+    let yaml = work.join("cancer_subclonal.yml");
+    // High somatic rate → many somatic SNVs; high coverage → tight per-site AF.
+    // Two equal-weight subclones: clonal (1.0) and a minor subclone (0.3).
+    std::fs::write(
+        &yaml,
+        format!(
+            "reference: {ref}\n\
+             output_dir: {out}\n\
+             output_prefix: sctest\n\
+             total_coverage: 160\n\
+             purity: 0.5\n\
+             read_len: 70\n\
+             paired_ended: true\n\
+             fragment_mean: 250\n\
+             fragment_st_dev: 30\n\
+             normal_mutation_rate: 0.001\n\
+             tumor_mutation_rate: 0.02\n\
+             subclones:\n\
+             \x20 - {{ccf: 1.0, weight: 1.0}}\n\
+             \x20 - {{ccf: 0.3, weight: 1.0}}\n\
+             overwrite_output: true\n\
+             rng_seed: cancer-subclonal-e2e\n",
+            ref = h1n1_reference().display(),
+            out = work.display(),
+        ),
+    )
+    .unwrap();
+
+    eidolon()
+        .args(["gen-cancer-reads", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    // Measured AF (final subfield of the GT:AD:DP:AF sample column) for every
+    // somatic-tagged truth record.
+    let truth = read_gz_lines(&work.join("sctest_merged_truth.vcf.gz"));
+    let somatic_afs: Vec<f64> = truth
+        .iter()
+        .filter(|l| !l.starts_with('#') && l.contains("NEAT_ORIGIN=somatic"))
+        .filter_map(|l| {
+            let sample = l.split('\t').next_back()?;
+            sample.split(':').next_back()?.parse::<f64>().ok()
+        })
+        .collect();
+
+    assert!(
+        somatic_afs.len() >= 10,
+        "need a meaningful somatic sample to judge the spectrum; got {}: {somatic_afs:?}",
+        somatic_afs.len()
+    );
+
+    // The minor-subclone cluster: AFs near 0.3 that the het(0.5)/hom(1.0) default
+    // cannot produce. Window [0.15, 0.45] is clear of both defaults.
+    let minor = somatic_afs
+        .iter()
+        .filter(|&&a| (0.15..=0.45).contains(&a))
+        .count();
+    // The clonal cluster: high AFs.
+    let clonal = somatic_afs.iter().filter(|&&a| a >= 0.7).count();
+
+    assert!(
+        minor > 0,
+        "no somatic AF near the 0.3 subclone — subclonal CCF not applied: {somatic_afs:?}"
+    );
+    assert!(
+        clonal > 0,
+        "no somatic AF near the clonal (1.0) subclone: {somatic_afs:?}"
+    );
+    // A genuine spectrum, not a single fraction: both clusters populated.
+    assert!(
+        minor >= somatic_afs.len() / 5 && clonal >= somatic_afs.len() / 5,
+        "expected both subclones well-represented (minor={minor}, clonal={clonal}, \
+         n={}): {somatic_afs:?}",
+        somatic_afs.len()
+    );
+}

--- a/eidolon/tests/cancer_reads_e2e.rs
+++ b/eidolon/tests/cancer_reads_e2e.rs
@@ -97,12 +97,13 @@ fn gen_cancer_reads_produces_tagged_fastqs_and_origin_truth() {
     );
 }
 
-/// End-to-end contract for #405 (generative subclonal VAF): with a `subclones:`
-/// architecture, de-novo somatic variants must spread across the configured
-/// cancer-cell fractions instead of collapsing to the Genotype default
-/// (het 0.5 / hom 1.0). A minor subclone at CCF 0.3 is the discriminating signal:
-/// its measured AF (~0.3, in the tumor-pass golden VCF the truth VCF carries
-/// through) is a value the pre-#405 single-fraction model cannot produce.
+/// End-to-end contract for #405 (generative subclonal VAF): a `subclones:`
+/// architecture spreads de-novo somatic variants across cancer-cell fractions,
+/// and each CCF *composes with the variant's dosage* (alt = dosage × CCF) rather
+/// than replacing it. With two subclones (CCF 1.0, 0.3) over het/hom de-novo
+/// variants the measured somatic AFs land at {0.5·1, 1·1, 0.5·0.3, 1·0.3} =
+/// {0.5, 1.0, 0.15, 0.3}. The discriminating signal is any AF below ~0.4 — a
+/// value the pre-#405 dosage-only model (het 0.5 / hom 1.0) cannot produce.
 #[test]
 fn subclonal_somatic_variants_span_a_vaf_spectrum() {
     let (_dir, work) = fresh_workdir();
@@ -158,24 +159,25 @@ fn subclonal_somatic_variants_span_a_vaf_spectrum() {
         somatic_afs.len()
     );
 
-    // The minor-subclone cluster: AFs near 0.3 that the het(0.5)/hom(1.0) default
-    // cannot produce. Window [0.15, 0.45] is clear of both defaults.
+    // The minor-subclone cluster: dosage × 0.3 ∈ {0.15, 0.3}, i.e. AFs at/below
+    // ~0.4 that the dosage-only default (het 0.5 / hom 1.0) cannot produce.
     let minor = somatic_afs
         .iter()
-        .filter(|&&a| (0.15..=0.45).contains(&a))
+        .filter(|&&a| (0.05..=0.4).contains(&a))
         .count();
-    // The clonal cluster: high AFs.
-    let clonal = somatic_afs.iter().filter(|&&a| a >= 0.7).count();
+    // The clonal cluster: dosage × 1.0 ∈ {0.5, 1.0}.
+    let clonal = somatic_afs.iter().filter(|&&a| a >= 0.45).count();
 
     assert!(
         minor > 0,
-        "no somatic AF near the 0.3 subclone — subclonal CCF not applied: {somatic_afs:?}"
+        "no somatic AF below ~0.4 — subclonal CCF not composed in: {somatic_afs:?}"
     );
     assert!(
         clonal > 0,
-        "no somatic AF near the clonal (1.0) subclone: {somatic_afs:?}"
+        "no somatic AF at the clonal (CCF 1.0) fractions: {somatic_afs:?}"
     );
-    // A genuine spectrum, not a single fraction: both clusters populated.
+    // A genuine spectrum, not a single fraction: both clusters populated. With
+    // equal subclone weights ~half the somatic burden falls in each.
     assert!(
         minor >= somatic_afs.len() / 5 && clonal >= somatic_afs.len() / 5,
         "expected both subclones well-represented (minor={minor}, clonal={clonal}, \

--- a/eidolon/tests/cancer_reads_e2e.rs
+++ b/eidolon/tests/cancer_reads_e2e.rs
@@ -270,6 +270,37 @@ fn subclonal_somatic_variants_span_a_vaf_spectrum() {
         mean_err < 0.05,
         "measured AF should track dosage × NEAT_CCF; mean |err| = {mean_err:.4} over {checked} sites"
     );
+
+    // ── INFO/NEAT_VAF: intended observed (post-mixing) VAF = purity × dosage × CCF ──
+    assert!(
+        truth.iter().any(|l| l.contains("##INFO=<ID=NEAT_VAF")),
+        "merged truth missing NEAT_VAF header declaration"
+    );
+    let vaf_of = |line: &str| -> Option<f64> {
+        line.split('\t')
+            .nth(7)?
+            .split(';')
+            .find_map(|kv| kv.strip_prefix("NEAT_VAF="))?
+            .parse()
+            .ok()
+    };
+    // purity 0.5 in this run → NEAT_VAF should equal 0.5 × dosage × NEAT_CCF exactly
+    // (it's the intended value, not a measurement — no sampling noise).
+    let mut vaf_checked = 0;
+    for l in &somatic {
+        let (Some(vaf), Some(ccf), Some(d)) = (vaf_of(l), ccf_of(l), dosage_of(l)) else {
+            panic!("somatic record missing NEAT_VAF/NEAT_CCF/GT: {l}");
+        };
+        assert!(
+            (vaf - 0.5 * d * ccf).abs() < 1e-4,
+            "NEAT_VAF {vaf} should equal purity·dosage·CCF = 0.5·{d}·{ccf}: {l}"
+        );
+        vaf_checked += 1;
+    }
+    assert!(
+        vaf_checked >= 10,
+        "too few somatic NEAT_VAF checks ({vaf_checked})"
+    );
 }
 
 /// End-to-end contract for #405 reproductive mode: a supplied `somatic_vcf` is
@@ -372,5 +403,26 @@ fn reproductive_somatic_vcf_is_replayed_and_tagged_somatic() {
         (meas_af(&record("1200")) - 0.30).abs() < 0.08,
         "H1N1_HA:1200 AF {} should be ~0.30 (0.18/0.6)",
         meas_af(&record("1200"))
+    );
+
+    // INFO/NEAT_VAF carries the intended *observed* VAF — the exact input value
+    // (purity × scaled AF = the original), not the noisy tumor-only FORMAT/AF.
+    let neat_vaf = |l: &str| -> f64 {
+        l.split('\t')
+            .nth(7)
+            .unwrap()
+            .split(';')
+            .find_map(|kv| kv.strip_prefix("NEAT_VAF="))
+            .expect("somatic record has NEAT_VAF")
+            .parse()
+            .unwrap()
+    };
+    assert!(
+        (neat_vaf(&record("500")) - 0.30).abs() < 1e-4,
+        "NEAT_VAF should be the input 0.30"
+    );
+    assert!(
+        (neat_vaf(&record("1200")) - 0.18).abs() < 1e-4,
+        "NEAT_VAF should be the input 0.18"
     );
 }

--- a/eidolon/tests/cancer_reads_e2e.rs
+++ b/eidolon/tests/cancer_reads_e2e.rs
@@ -184,4 +184,90 @@ fn subclonal_somatic_variants_span_a_vaf_spectrum() {
          n={}): {somatic_afs:?}",
         somatic_afs.len()
     );
+
+    // ── INFO/NEAT_CCF ground-truth tag (#405) ────────────────────────────────
+    // The header must declare it, every somatic record must carry the *intended*
+    // CCF (one of the two configured values), and no germline/shared record may.
+    assert!(
+        truth.iter().any(|l| l.contains("##INFO=<ID=NEAT_CCF")),
+        "merged truth missing NEAT_CCF header declaration"
+    );
+
+    let ccf_of = |line: &str| -> Option<f64> {
+        let info = line.split('\t').nth(7)?;
+        info.split(';')
+            .find_map(|kv| kv.strip_prefix("NEAT_CCF="))?
+            .parse::<f64>()
+            .ok()
+    };
+    // Dosage from the GT string (alt copies / total called), mirroring
+    // Variant::dosage_fraction — the sampler's per-copy alt probability.
+    let dosage_of = |line: &str| -> Option<f64> {
+        let gt = line.split('\t').next_back()?.split(':').next()?;
+        let (mut alt, mut total) = (0u32, 0u32);
+        for a in gt.split(['/', '|']) {
+            match a {
+                "." | "" => {}
+                "0" => total += 1,
+                _ => {
+                    alt += 1;
+                    total += 1;
+                }
+            }
+        }
+        (total > 0).then(|| alt as f64 / total as f64)
+    };
+    let dp_of = |line: &str| -> Option<u32> {
+        line.split('\t')
+            .next_back()?
+            .split(':')
+            .nth(2)?
+            .parse()
+            .ok()
+    };
+
+    let body: Vec<&String> = truth.iter().filter(|l| !l.starts_with('#')).collect();
+
+    // Germline / shared records never carry a somatic CCF.
+    for l in body.iter().filter(|l| !l.contains("NEAT_ORIGIN=somatic")) {
+        assert!(
+            ccf_of(l).is_none(),
+            "non-somatic record carries NEAT_CCF: {l}"
+        );
+    }
+
+    // Every somatic record carries a NEAT_CCF from the configured architecture.
+    let somatic: Vec<&&String> = body
+        .iter()
+        .filter(|l| l.contains("NEAT_ORIGIN=somatic"))
+        .collect();
+    let mut checked = 0;
+    let mut err_sum = 0.0;
+    for l in &somatic {
+        let ccf = ccf_of(l).unwrap_or_else(|| panic!("somatic record lacks NEAT_CCF: {l}"));
+        assert!(
+            (ccf - 1.0).abs() < 1e-6 || (ccf - 0.3).abs() < 1e-6,
+            "unexpected NEAT_CCF {ccf} (configured 1.0 / 0.3): {l}"
+        );
+        // Ground-truth relationship: measured AF ≈ dosage × NEAT_CCF. Average the
+        // absolute error over adequately-covered sites to stay robust to per-site
+        // binomial noise (the assertion is on the aggregate, not each record).
+        if let (Some(d), Some(dp)) = (dosage_of(l), dp_of(l))
+            && dp >= 25
+        {
+            let sample = l.split('\t').next_back().unwrap();
+            let af: f64 = sample.split(':').next_back().unwrap().parse().unwrap();
+            err_sum += (af - d * ccf).abs();
+            checked += 1;
+        }
+    }
+    assert!(
+        checked >= 10,
+        "too few well-covered somatic sites to validate ({checked})"
+    );
+    let mean_err = err_sum / checked as f64;
+    assert!(
+        mean_err < 0.05,
+        "measured AF should track dosage × NEAT_CCF; mean |err| = {mean_err:.4} over {checked} sites"
+    );
 }

--- a/template_config/gen_cancer_reads_template.yml
+++ b/template_config/gen_cancer_reads_template.yml
@@ -68,6 +68,14 @@ fragment_st_dev: 50     # required when paired_ended
 # ── Structural variants (optional) ────────────────────────────────────────
 sv_rate_scale: 0.0      # 0 = no de-novo SVs; 1.0 = the tumor model's nominal SV rate
 
+# ── Reproductive somatic replay (optional) ────────────────────────────────
+# Replay a real tumor's somatic calls instead of (or on top of) generating them.
+# Each variant is honored at its observed VAF (INFO/AF, else FORMAT/AD), divided
+# by purity so the merged reads reproduce that VAF, and tagged `somatic` in the
+# truth. For pure replay set `tumor_mutation_rate: 0`. A variant with no AF falls
+# back to its genotype dosage. (Observed VAF above purity is clamped to 1.0.)
+# somatic_vcf: /path/to/somatic_calls.vcf.gz
+
 # ── Misc (optional) ───────────────────────────────────────────────────────
 # germline_vcf: /path/to/germline.vcf.gz  # supply a fixed germline instead of de-novo
 # keep_per_pass: true                     # keep per-pass FASTQs (false = merged only)

--- a/template_config/gen_cancer_reads_template.yml
+++ b/template_config/gen_cancer_reads_template.yml
@@ -40,6 +40,20 @@ fragment_st_dev: 50     # required when paired_ended
 # tumor_mutation_rate: 1e-5
 # normal_mutation_rate: <float>           # default: normal model's fitted rate
 
+# ── Subclonal architecture (optional) ─────────────────────────────────────
+# By default every somatic variant lands at ~one effective VAF (purity alone).
+# `subclones` splits the somatic burden across cell populations at distinct
+# cancer-cell fractions (CCF): each de-novo somatic variant is assigned a
+# subclone (share ∝ weight) and takes its CCF. Composes with purity — the
+# observed VAF in the merged output is `purity × CCF`. Yields the realistic
+# somatic VAF spectrum that subclonal-deconvolution tools (PyClone, etc.) expect.
+# ccf ∈ (0, 1]; weight optional (default 1.0, equal share). Omit for the
+# single-fraction default.
+# subclones:
+#   - {ccf: 1.0, weight: 0.6}   # clonal / truncal — in every tumor cell
+#   - {ccf: 0.4, weight: 0.3}   # major subclone
+#   - {ccf: 0.15, weight: 0.1}  # minor subclone
+
 # ── Structural variants (optional) ────────────────────────────────────────
 sv_rate_scale: 0.0      # 0 = no de-novo SVs; 1.0 = the tumor model's nominal SV rate
 

--- a/template_config/gen_cancer_reads_template.yml
+++ b/template_config/gen_cancer_reads_template.yml
@@ -54,6 +54,16 @@ fragment_st_dev: 50     # required when paired_ended
 #   - {ccf: 1.0, weight: 0.6}   # clonal / truncal — in every tumor cell
 #   - {ccf: 0.4, weight: 0.3}   # major subclone
 #   - {ccf: 0.15, weight: 0.1}  # minor subclone
+#
+# Or build the architecture from real data instead of hand-authoring it: point at
+# a deconvolution-tool cluster table (tab-separated, with a header). Mutually
+# exclusive with the inline `subclones:` list above. Two shapes are accepted:
+#   • per-mutation (PyClone / PyClone-VI): columns `cluster_id` + `cellular_prevalence`
+#     → grouped by cluster (weight = mutation count)
+#   • cluster table (PCAWG-11 / DPClust): columns `cluster` + `ccf` + a size column
+#     (`n_ssms` / `size` / `weight`) → used directly
+# CCF > 1.0 is clamped to 1.0; non-positive-CCF rows are skipped (both warned).
+# subclones_file: /path/to/pyclone_clusters.tsv
 
 # ── Structural variants (optional) ────────────────────────────────────────
 sv_rate_scale: 0.0      # 0 = no de-novo SVs; 1.0 = the tumor model's nominal SV rate

--- a/template_config/gen_cancer_reads_template.yml
+++ b/template_config/gen_cancer_reads_template.yml
@@ -41,14 +41,15 @@ fragment_st_dev: 50     # required when paired_ended
 # normal_mutation_rate: <float>           # default: normal model's fitted rate
 
 # ── Subclonal architecture (optional) ─────────────────────────────────────
-# By default every somatic variant lands at ~one effective VAF (purity alone).
+# By default somatic VAF is driven by dosage (het/hom) and purity alone.
 # `subclones` splits the somatic burden across cell populations at distinct
 # cancer-cell fractions (CCF): each de-novo somatic variant is assigned a
-# subclone (share ∝ weight) and takes its CCF. Composes with purity — the
-# observed VAF in the merged output is `purity × CCF`. Yields the realistic
-# somatic VAF spectrum that subclonal-deconvolution tools (PyClone, etc.) expect.
-# ccf ∈ (0, 1]; weight optional (default 1.0, equal share). Omit for the
-# single-fraction default.
+# subclone (share ∝ weight). The CCF *composes* — it does not replace the
+# variant's dosage or purity — so the observed VAF in the merged output is
+# `purity × dosage × CCF` (a het somatic at CCF f lands at ~f/2). Yields the
+# realistic somatic VAF spectrum that subclonal-deconvolution tools (PyClone,
+# etc.) expect. ccf ∈ (0, 1]; weight optional (default 1.0, equal share). Omit
+# for the dosage-only default.
 # subclones:
 #   - {ccf: 1.0, weight: 0.6}   # clonal / truncal — in every tumor cell
 #   - {ccf: 0.4, weight: 0.3}   # major subclone


### PR DESCRIPTION
## Summary

Implements **both halves of #405** end-to-end — model a tumor as a mixture of subclones at distinct cancer-cell fractions (CCF), replay real tumors, and build the architecture from real data — replacing the single-effective-VAF behavior with a realistic multi-modal somatic VAF spectrum. This is the input signal subclonal-deconvolution tools (PyClone, SciClone, …) consume, which the simulator could not produce before.

Builds on #398 (`allele_fraction`, merged). Part of epic #311. Coordinated with the polyploidy epic via a note on #266.

## The model

```
observed VAF  =  purity  ×  dosage  ×  CCF
```
- **purity** — normal contamination, realized as the tumor/normal coverage split at merge.
- **dosage** — alt-copies / ploidy, from the GT string (`Variant::dosage_fraction`; correct for diploid today, polyploid-ready).
- **CCF** — subclonal cellular fraction: sampled from a model, ingested from real data, or replayed from a somatic VCF.

Three orthogonal axes — a heterozygous somatic SNV at CCF `f` lands at `~purity·f/2`.

## What's in this PR (7 commits)

1. **Generative subclonal VAF** — a validated `SubcloneModel` + weighted `sample_ccf`; opt-in `subclones:` config stamps each de-novo somatic variant's `allele_fraction` in the tumor pass.
2. **Compose CCF with dosage** — CCF *multiplies onto* dosage rather than overwriting it, fixing a ~2× overstatement of het somatic VAF and future-proofing polyploidy (#266/#267).
3. **`INFO/NEAT_CCF`** — records each somatic variant's intended CCF (ground truth).
4. **Build from data (`subclones_file:`)** — ingest a deconvolution tool's cluster table (PyClone/PyClone-VI per-mutation tables and PCAWG-11/DPClust cluster tables both fold to `{ccf, weight}`), so the architecture is fitted, not hand-authored.
5. **Reproductive replay (`somatic_vcf:`)** — replay a real tumor's somatic calls, honored at their observed VAF (÷purity so they reproduce after mixing), tagged `somatic` via a distinct `Provenance::SomaticVcf`.
6. **`INFO/NEAT_VAF`** — records each somatic variant's intended *observed* VAF (`purity × dosage × CCF`), directly comparable to a caller's VAF on the merged reads.
7. **Docs** — `cancer_howto.md` + template for composition, both tags, `subclones_file`, and `somatic_vcf`.

## Config

```yaml
purity: 0.8
# generative, inline:
subclones:
  - {ccf: 1.0, weight: 0.6}   # clonal / truncal
  - {ccf: 0.3, weight: 0.4}   # subclone
# …or generative from real data (mutually exclusive with inline):
# subclones_file: pyclone_clusters.tsv
# …or reproductive replay of a real somatic VCF:
# somatic_vcf: tumor_calls.vcf.gz     # tumor_mutation_rate: 0 for pure replay
```

`subclones_file` accepts, tool-agnostically:
- per-mutation (PyClone/PyClone-VI): `cluster_id` + `cellular_prevalence` → grouped, weight = count
- cluster table (PCAWG-11/CSR/DPClust): `cluster` + `ccf` + size (`n_ssms`/`size`/`weight`) → direct

(CCF > 1.0 clamped to 1.0; non-positive-CCF rows skipped; header-driven column detection with synonyms.)

## Golden-VCF ground truth (per somatic record)

| Field | Meaning | Score against |
|---|---|---|
| `FORMAT/AF` | measured **per-pass** (tumor-only) = `dosage × CCF`, noisy | tumor-cell fraction |
| `INFO/NEAT_CCF` | intended cellular fraction | deconvolution recovery |
| `INFO/NEAT_VAF` | intended **observed** VAF after mixing = `purity × dosage × CCF` (or the input VAF for replay) | a caller's reported VAF |

`NEAT_ORIGIN` classifies every truth record `germline` / `somatic` / `shared`; reproductive replays classify as `somatic` (not `shared`) even though they come from a file.

## Compatibility & determinism

**Opt-in and additive.** With none of `subclones`/`subclones_file`/`somatic_vcf` set, no stamping runs, `allele_fraction` stays `None`, no `NEAT_CCF`/`NEAT_VAF` records are emitted, and output is byte-identical to pre-#405. A stamped variant draws once more from the RNG only when a model is configured. `Provenance::SomaticVcf` and the `tumor_origin` update are additive (leave `denovo`→somatic / `input`→shared untouched), so `cancer_parity` (native merge vs the bcftools+awk shell merge) stays byte-identical. The writer's INFO passthrough is gated to `Denovo`/`SomaticVcf`, so germline input-VCF golden output is unchanged.

## Testing

Full workspace suite green (eidolon-core + eidolon), clippy + fmt clean.
- unit: `SubcloneModel` validation + weighted sampling; `dosage_fraction` (diploid/polyploid/phased/missing); `subclones_file` both shapes + clamp/skip/missing-column/mutual-exclusion; `tumor_origin(somatic_input)`=somatic; `somatic_vcf` wiring at 1/purity
- e2e: composed `{0.15, 0.3, 0.5, 1.0}` spectrum; `NEAT_CCF` present on somatic / absent on germline; mean `|AF − dosage×CCF| < 0.05`; `NEAT_VAF == purity·dosage·CCF`; reproductive replay tagged somatic with tumor-pass AF = VAF/purity and `NEAT_VAF` = the exact input VAF
- byte-exact: `cancer_parity`, `model_parity`, `allele_fraction_e2e` (input-VCF path) all unchanged
- hand-verified: determinism (same seed → identical AFs), weight skew (9:1 → ~91% clonal), data round-trip (PyClone-style 3:1 table → planted `NEAT_CCF` {1.0, 0.35} at ~3:1), and merged-pileup arithmetic (input VAF reproduced from tumor AD + added normal ref reads)

## Follow-ups (out of scope)

- B3 corpus prior: per-tissue default architectures (where a bundled `.json.gz` earns its place)
- Confirm exact PCAWG-11 `subclonal_structure` column spelling against a real file on Delta (parser adapts by adding a column synonym)
- `FORMAT/AD`-derived AF replay path (inherited from #398) not yet covered by a targeted test

🤖 Generated with [Claude Code](https://claude.com/claude-code)