### PR TITLE
test(delta): fix OOM on chr-scale subclonal-VAF references

### DIFF
--- a/scripts/delta/run_hcc1395_reproductive.sh
+++ b/scripts/delta/run_hcc1395_reproductive.sh
@@ -38,7 +38,7 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
-#SBATCH --mem=48G
+#SBATCH --mem=96G
 #SBATCH --time=10:00:00
 #SBATCH --output=%x_%j.out
 #SBATCH --error=%x_%j.err

--- a/scripts/delta/run_subclonal_vaf_validation.sh
+++ b/scripts/delta/run_subclonal_vaf_validation.sh
@@ -44,7 +44,7 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
-#SBATCH --mem=48G
+#SBATCH --mem=64G
 #SBATCH --time=8:00:00
 #SBATCH --output=%x_%j.out
 #SBATCH --error=%x_%j.err
@@ -187,13 +187,15 @@ SORT_TMP="$OUTDIR/sort_tmp"; mkdir -p "$SORT_TMP"
 echo "=== bwa-mem2 mem + sort (merged tumor+normal reads) ==="
 echo "  scratch free before align: $(df -h "$OUTDIR" | awk 'NR==2{print $4" free ("$5" used)"}')"
 # Explicit -T keeps sort spill files on this scratch dir (a node-local $TMPDIR can be
-# too small or vanish); -m caps per-thread RAM. pipefail turns a bwa-mem2 crash into a
-# hard failure here rather than a downstream "0 sites". A large reference at high COV
-# can exhaust scratch — that surfaces as a samtools write error, so report space + the
-# bwa log on failure (shrink with a single-scaffold REFERENCE and/or lower COV).
+# too small or vanish). -m 1G caps per-thread sort RAM: with -@ N that is N GB, which
+# must sit alongside bwa-mem2's index+buffers under --mem (a chr-scale reference's
+# index is several GB — 2G/thread OOM-killed a chr1 job at --mem=48G). pipefail turns a
+# bwa-mem2 crash into a hard failure here rather than a downstream "0 sites". A large
+# reference at high COV can also exhaust scratch — that surfaces as a samtools write
+# error, so report space + the bwa log on failure.
 if ! bwa-mem2 mem -t "$THREADS" -R '@RG\tID:subvaf\tSM:merged\tPL:ILLUMINA' "$REF" "$R1" "$R2" \
       2>"$OUTDIR/bwa.log" \
-    | samtools sort -@ "$THREADS" -m 2G -T "$SORT_TMP/st" -o "$MERGED_BAM"; then
+    | samtools sort -@ "$THREADS" -m 1G -T "$SORT_TMP/st" -o "$MERGED_BAM"; then
   echo "ALIGN/SORT FAILED. scratch: $(df -h "$OUTDIR" | awk 'NR==2{print $4" free, "$5" used"}')" >&2
   echo "--- last 20 lines of bwa.log ---" >&2; tail -20 "$OUTDIR/bwa.log" >&2
   echo "  If this is a disk/quota issue, re-run with a single-scaffold REFERENCE and/or lower COV." >&2


### PR DESCRIPTION
## Summary

A chr1 (250 Mb) HCC1395 reproductive run at `COV=200` was **OOM-killed** at `--mem=48G` — `359 G` scratch free, so not disk. `samtools sort -@16 -m 2G` reserves **32 GB** of sort buffers, which must coexist with bwa-mem2's several-GB chr-scale index; the soy scaffold survived only because its tiny index left headroom.

- engine `samtools sort`: `-m 2G → -m 1G` (16 GB at `-@16`, spills to `-T` on scratch), with a comment on the RAM budget.
- engine standalone default `--mem 48G → 64G` (single scaffold/chromosome, safe with `-m 1G`).
- `run_hcc1395_reproductive.sh` `--mem 48G → 96G` (the chr-scale entry point at high COV).

Immediate workaround (no merge needed): `sbatch --mem=96G scripts/delta/run_hcc1395_reproductive.sh` — CLI overrides the `#SBATCH` directive.

Context: the run that hit this produced a beautiful real HCC1395 VAF spectrum (2,950 somatic sites spanning every decile); only the align step OOM'd. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)