### PR TITLE
fix: strip current-generation routing tokens on INFO passthrough (v2.1.0 review blocker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 > NEAT lineage; the `rneat` command still works as a deprecated alias for one transition
 > release. See `CHANGELOG.md`.
 
+> **Upgrading from 2.0.0 → 2.1.0? The names of emitted output tokens changed.**
+> See [Upgrading from 2.0.0](#upgrading-from-200) below — **read it if you have any
+> script that parses eidolon VCFs or FASTQ/BAM read names.**
+
 Welcome to `eidolon`, a Rust port of NEAT (https://github.com/ncsa/neat), a genetic simulation program that creates fastq that appear to be from sequencers, carry the same statistical properties as your data, and generate a golden bam and fastq that gives you ideal alignments and what variants were inserted. In addition, `eidolon` generates "noise" in the form of sequencing errors as it is writing out files. These features can help you hone in your alignment and variant calling software to your data. Training models on your data will allow `eidolon` to faithfully reproduce the statistical properties of your dataset.
 
 We have spent some dedicated time toward gearing the current version of `eidolon` to simulate cancer genetics, including adding structural variant simulations (CNV, BND, SVs, and others), and creating a wrapper that simulates purity levels and then stitches the results back together. We've geared this software with an aim at keeping memory usage as low and CPU time as short as possible. Let us know your real world experience by creating a Feedback issue, if you have something that's not quite a bug, or have a positive experience to share. As always, let us know if you find a bug and give as many details as you can to help us troubleshoot.
@@ -79,6 +83,63 @@ when you want:
 - **Easy deployment** — a single self-contained binary with no Python
   environment to manage, installable via Bioconda
   (`conda install -c bioconda eidolon`).
+
+## Upgrading from 2.0.0
+
+v2.1.0 renamed the tokens eidolon **emits**. There is no behavior change — the same
+reads and variants are produced — but anything that *parses* eidolon output needs
+attention. In-tree consumers were all migrated; your own scripts were not.
+
+| Surface | v2.0.0 and earlier | v2.1.0+ | Migration |
+|---|---|---|---|
+| VCF INFO tags | `NEAT_ORIGIN`, `NEAT_PROVENANCE`, `NEAT_REASON`, `NEAT_CCF`, `NEAT_VAF` | `EIDOLON_*` | **converter provided** |
+| VCF sample column | `NEAT_simulated_sample` | `EIDOLON_simulated_sample` | **converter provided** |
+| FASTQ read names | `@RNEAT_generated_*`, `RNEAT_chimeric_*` | `@EIDOLON_generated_*`, `EIDOLON_chimeric_*` | **not converted** — see below |
+| BAM read names (QNAME) | `RNEAT_generated_*` | `EIDOLON_generated_*` | **not converted** — see below |
+
+### VCFs — convert them
+
+```bash
+tools/migrate_legacy_tokens.sh old_truth.vcf.gz new_truth.vcf.gz
+tools/migrate_legacy_tokens.sh --check old_truth.vcf.gz   # report only; exit 10 = legacy
+```
+
+Idempotent: safe to run on a file that's already current, or on a non-eidolon VCF, so
+you can call it unconditionally in a pipeline. It rewrites the header declarations and
+the record fields together, so the result is a valid VCF.
+
+Note you **cannot** work around this with a dual-name bcftools filter — bcftools rejects
+an undefined tag in a `-i` expression at parse time, so even
+`INFO/EIDOLON_ORIGIN="somatic" || INFO/NEAT_ORIGIN="somatic"` fails outright on a file
+that carries only one of the two. Convert the file instead.
+
+### Read names — NOT converted, and this is the part that can bite you
+
+Read names are **not** rewritten, in either FASTQ or BAM. Rewriting files that are
+routinely hundreds of GB to change ~19 bytes per record isn't a reasonable ask, so
+instead `eidolon filter-reads` accepts **both** prefixes natively — legacy FASTQs keep
+working with no conversion step, and it warns once when it sees an old prefix.
+
+**Nothing protects your own scripts.** A `grep '^@RNEAT_generated_'`, `awk` field split,
+or regex over read names will match **zero records and exit 0** against v2.1.0 output —
+a silent empty result, not an error. Audit for the old prefix before upgrading:
+
+```bash
+grep -rn 'RNEAT_generated_\|RNEAT_chimeric_' your_scripts/
+```
+
+If you must rewrite existing files rather than update the scripts:
+
+```bash
+# FASTQ (expensive — a full re-compress; prefer updating your scripts)
+zcat old_r1.fastq.gz | sed 's/^@RNEAT_generated_/@EIDOLON_generated_/' | gzip > new_r1.fastq.gz
+
+# BAM QNAMEs
+samtools view -h old.bam | sed 's/^RNEAT_generated_/EIDOLON_generated_/' | samtools view -b -o new.bam
+```
+
+BAM QNAMEs are covered by no in-tree tooling at all — `filter-reads` reads FASTQ, and the
+converter is VCF-only. If you parse BAM read names, the `sed` above is the whole story.
 
 # How to use `eidolon`
 

--- a/eidolon-core/src/file_tools/vcf_tools.rs
+++ b/eidolon-core/src/file_tools/vcf_tools.rs
@@ -187,7 +187,7 @@ pub fn write_vcf(
             let info_str = if is_symbolic {
                 match variant.info.as_deref() {
                     None | Some(".") | Some("") => format!("EIDOLON_PROVENANCE={prov}"),
-                    Some(existing) => match strip_legacy_output_tokens(existing) {
+                    Some(existing) => match strip_own_output_tokens(existing) {
                         Some(kept) => format!("{kept};EIDOLON_PROVENANCE={prov}"),
                         None => format!("EIDOLON_PROVENANCE={prov}"),
                     },
@@ -202,9 +202,13 @@ pub fn write_vcf(
                     (Provenance::Denovo | Provenance::SomaticVcf, Some(extra))
                         if !extra.is_empty() && extra != "." =>
                     {
-                        // SomaticVcf variants come from a user-supplied `somatic_vcf:`,
-                        // which may itself be v2.0.0 eidolon output — so strip here too.
-                        match strip_legacy_output_tokens(extra) {
+                        // Denovo `info` is generated fresh (EIDOLON_CCF / EIDOLON_VAF),
+                        // so in practice there is nothing to strip on this path — the
+                        // SomaticVcf arm never carries source INFO either, since
+                        // gen_reads::runner clears it on ingest. Kept as a cheap
+                        // invariant so a future path that does populate `info` from a
+                        // file can't reintroduce a duplicate provenance key.
+                        match strip_own_output_tokens(extra) {
                             Some(kept) => format!("{kept};EIDOLON_PROVENANCE={prov}"),
                             None => format!("EIDOLON_PROVENANCE={prov}"),
                         }
@@ -250,25 +254,46 @@ pub fn write_vcf(
     Ok(())
 }
 
-/// Drop eidolon's own **pre-v2.1.0** output tokens from an INFO field that is about
-/// to be passed through into new output.
+/// Drop the eidolon-emitted routing tokens that this writer owns, from an INFO field
+/// about to be passed through into new output.
 ///
-/// v2.0.0 and earlier emitted `NEAT_*` names. When such a VCF is fed back in (via
-/// `input_vcf:` or `somatic_vcf:`), `write_vcf` preserves the source INFO verbatim on
-/// symbolic and de-novo/somatic literal records — which would reproduce those tokens
-/// in a file whose header only declares the `EIDOLON_*` names. bcftools tolerates that
-/// when streaming VCF→VCF but hard-fails on BCF translation (`bcftools concat | sort`
-/// does exactly that internally), so the record must not carry them.
+/// `write_vcf` preserves a source record's INFO verbatim on symbolic (and de-novo
+/// literal) records, so feeding a golden VCF back in via `input_vcf:` reproduces
+/// whatever tokens it carried. Two classes must not survive that round trip:
 ///
-/// Dropping rather than renaming is deliberate: this writer re-emits the current
-/// equivalents itself, so a stale `NEAT_PROVENANCE=denovo` would *contradict* the
-/// fresh `EIDOLON_PROVENANCE=input` describing how this pass actually used the record.
+/// * **`*_PROVENANCE`** — this writer re-emits it from `variant.provenance`. A stale
+///   copy yields a duplicate key with *contradictory* values (`=denovo` from the source
+///   next to the fresh `=input` describing how this pass actually used the record).
+///   Worse, `vcf_merge::tumor_origin` tests for the exact field
+///   `EIDOLON_PROVENANCE=denovo`, so a stale copy makes it label a variant present in
+///   **both** passes as `somatic` — putting a germline carry-through into the somatic
+///   ground truth that every bundled benchmark scores against.
+/// * **`*_ORIGIN`** — added *after* this writer by `vcf_merge`, which is also the only
+///   place that declares it. Passing one through emits an undeclared INFO tag: fine when
+///   streaming VCF→VCF, but a hard failure on BCF translation, which
+///   `bcftools concat | sort` does internally.
+///
+/// Both the current `EIDOLON_*` spellings and the pre-v2.1.0 `NEAT_*` ones are stripped.
+/// Scoping this to only the legacy names would fix the shrinking half of the problem
+/// (v2.0.0 goldens) and leave the growing half (v2.1.0 goldens, which is what users
+/// produce from now on).
+///
+/// **`EIDOLON_CCF` / `EIDOLON_VAF` are deliberately kept.** Unlike provenance, they are
+/// #405's ground truth and live *in* `variant.info` — `gen_reads::runner` appends them
+/// there before the write — so stripping them would destroy the tags on every de-novo
+/// somatic record. They are declared by this writer, so passing one through is harmless.
+/// `NEAT_CCF`/`NEAT_VAF`/`NEAT_REASON` are still dropped: those spellings are never
+/// re-emitted, so a survivor would be an undeclared tag.
 ///
 /// Returns `None` when nothing is left to keep, so callers can emit provenance alone
-/// instead of a leading `;`. Only these exact eidolon-emitted keys are removed —
-/// third-party INFO (`DP`, `AF`, `SVTYPE`, …) is untouched.
-fn strip_legacy_output_tokens(info: &str) -> Option<String> {
-    const LEGACY_KEYS: [&str; 5] = [
+/// instead of a leading `;`. Only these exact keys are removed — third-party INFO
+/// (`DP`, `AF`, `SVTYPE`, …) is untouched.
+fn strip_own_output_tokens(info: &str) -> Option<String> {
+    const OWNED_KEYS: [&str; 7] = [
+        // Current spellings: re-emitted here, or declared only downstream.
+        "EIDOLON_PROVENANCE",
+        "EIDOLON_ORIGIN",
+        // Pre-v2.1.0 spellings: never re-emitted, so any survivor is undeclared.
         "NEAT_PROVENANCE",
         "NEAT_ORIGIN",
         "NEAT_CCF",
@@ -279,7 +304,7 @@ fn strip_legacy_output_tokens(info: &str) -> Option<String> {
         .split(';')
         .filter(|field| {
             let key = field.split('=').next().unwrap_or(field);
-            !LEGACY_KEYS.contains(&key)
+            !OWNED_KEYS.contains(&key)
         })
         .filter(|field| !field.is_empty())
         .collect();
@@ -1534,19 +1559,19 @@ chr1\t100\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;END=500\n";
     }
 
     #[test]
-    fn strip_legacy_output_tokens_drops_only_pre_rename_eidolon_keys() {
+    fn strip_own_output_tokens_drops_routing_keys_both_spellings() {
         // Third-party / SV INFO must survive untouched.
         assert_eq!(
-            strip_legacy_output_tokens("SVTYPE=DEL;END=200;DP=30").as_deref(),
+            strip_own_output_tokens("SVTYPE=DEL;END=200;DP=30").as_deref(),
             Some("SVTYPE=DEL;END=200;DP=30")
         );
-        // Each pre-v2.1.0 key is removed, order of the rest preserved.
+        // Pre-v2.1.0 keys removed, order of the rest preserved.
         assert_eq!(
-            strip_legacy_output_tokens("SVTYPE=DEL;NEAT_PROVENANCE=denovo;END=200").as_deref(),
+            strip_own_output_tokens("SVTYPE=DEL;NEAT_PROVENANCE=denovo;END=200").as_deref(),
             Some("SVTYPE=DEL;END=200")
         );
         assert_eq!(
-            strip_legacy_output_tokens(
+            strip_own_output_tokens(
                 "NEAT_ORIGIN=somatic;NEAT_CCF=1.0;NEAT_VAF=0.3;NEAT_REASON=unknown;AF=0.5"
             )
             .as_deref(),
@@ -1554,20 +1579,45 @@ chr1\t100\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;END=500\n";
         );
         // Nothing left to keep -> None, so the caller emits provenance alone
         // rather than a record starting with ';'.
-        assert_eq!(strip_legacy_output_tokens("NEAT_PROVENANCE=input"), None);
-        // Current-generation tags must NOT be caught by the legacy filter.
+        assert_eq!(strip_own_output_tokens("NEAT_PROVENANCE=input"), None);
+
+        // The CURRENT spellings must be stripped too. Round-tripping a v2.1.0 golden
+        // through input_vcf: is the common case, not the legacy one.
         assert_eq!(
-            strip_legacy_output_tokens("EIDOLON_CCF=1.0;EIDOLON_VAF=0.3").as_deref(),
-            Some("EIDOLON_CCF=1.0;EIDOLON_VAF=0.3")
+            strip_own_output_tokens("SVTYPE=DEL;EIDOLON_PROVENANCE=denovo;END=200").as_deref(),
+            Some("SVTYPE=DEL;END=200")
         );
-        // Exact-key matching: a lookalike key is not a legacy token.
         assert_eq!(
-            strip_legacy_output_tokens("XNEAT_ORIGIN=x;NEAT_ORIGINAL=y").as_deref(),
-            Some("XNEAT_ORIGIN=x;NEAT_ORIGINAL=y")
+            strip_own_output_tokens("SVTYPE=DEL;EIDOLON_ORIGIN=somatic").as_deref(),
+            Some("SVTYPE=DEL")
+        );
+        // A stale EIDOLON_PROVENANCE=denovo surviving here is what made
+        // vcf_merge::tumor_origin label a germline carry-through as `somatic`.
+        assert_eq!(
+            strip_own_output_tokens("EIDOLON_PROVENANCE=denovo;EIDOLON_ORIGIN=shared"),
+            None
+        );
+
+        // #405 ground truth is KEPT: gen_reads::runner puts EIDOLON_CCF/EIDOLON_VAF in
+        // `variant.info` before the write, so stripping them would destroy the tags on
+        // every de-novo somatic record. This writer declares both.
+        assert_eq!(
+            strip_own_output_tokens("EIDOLON_CCF=1.0000;EIDOLON_VAF=0.3000").as_deref(),
+            Some("EIDOLON_CCF=1.0000;EIDOLON_VAF=0.3000")
+        );
+        assert_eq!(
+            strip_own_output_tokens("EIDOLON_CCF=1.0000;EIDOLON_PROVENANCE=denovo").as_deref(),
+            Some("EIDOLON_CCF=1.0000")
+        );
+
+        // Exact-key matching: lookalikes are not owned tokens.
+        assert_eq!(
+            strip_own_output_tokens("XNEAT_ORIGIN=x;NEAT_ORIGINAL=y;EIDOLON_ORIGINS=z").as_deref(),
+            Some("XNEAT_ORIGIN=x;NEAT_ORIGINAL=y;EIDOLON_ORIGINS=z")
         );
         // Bare flags (no '=') are preserved.
         assert_eq!(
-            strip_legacy_output_tokens("IMPRECISE;NEAT_VAF=0.1").as_deref(),
+            strip_own_output_tokens("IMPRECISE;NEAT_VAF=0.1").as_deref(),
             Some("IMPRECISE")
         );
     }

--- a/eidolon/src/filter_reads/utils/filter_lib.rs
+++ b/eidolon/src/filter_reads/utils/filter_lib.rs
@@ -7,7 +7,13 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Lines, Write};
 use std::path::PathBuf;
+use std::sync::Once;
 use thiserror::Error;
+
+/// Guards the one-time pre-v2.1.0 read-name-prefix warning in
+/// `parse_fastq_record_name` — it is called once per FASTQ record, and a per-read
+/// warning on a multi-million-read file would be worse than silence.
+static LEGACY_PREFIX_WARNED: Once = Once::new();
 
 use eidolon_core::file_tools::file_io::{create_output_file, read_gzip_lines, read_lines};
 /// The purpose of this module is to filter a eidolon-generated fastq and vcf file, so that they only show regions
@@ -87,6 +93,22 @@ fn parse_fastq_record_name(line: &str) -> Result<(String, usize, usize), FilterL
     let prefix = if line.starts_with(PREFIX) {
         PREFIX
     } else if line.starts_with(LEGACY_PREFIX) {
+        // Warn once. Accepting the old prefix silently is the only remaining path where
+        // a user's pre-v2.1.0 data flows through v2.1.0 with no signal that the output
+        // format changed — and a user's own `grep '^@RNEAT_generated_'` over the same
+        // file returns zero rows with exit 0. This is the cheapest place to make that
+        // discoverable, so say it out loud (once, not per read).
+        LEGACY_PREFIX_WARNED.call_once(|| {
+            warn!(
+                "input uses the pre-v2.1.0 read-name prefix \"{}\" (v2.1.0 renamed it to \
+                 \"{}\"). Accepting it for compatibility. Note eidolon does NOT rewrite \
+                 read names — any of your own scripts matching the old prefix will \
+                 silently match nothing. See the \"Upgrading from 2.0.0\" section in the \
+                 README.",
+                LEGACY_PREFIX.trim_start_matches('@'),
+                PREFIX.trim_start_matches('@'),
+            );
+        });
         LEGACY_PREFIX
     } else {
         // A line that *embeds* a known prefix without starting with one is a read

--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -333,15 +333,23 @@ conda_activate bioinf
 # current file, so calling it unconditionally is safe. It matters because bcftools
 # rejects an undefined INFO tag in the -i expression below at parse time.
 # `|| rc=$?` (not `; echo $?`) so the non-zero --check status is *tested* — under
-# set -e an untested non-zero would abort before we could read it.
+# set -e an untested non-zero would abort before we could read it. Only 0 and 10 are
+# meaningful: any other status means the pre-flight itself failed (missing input, no
+# bcftools, bad converter path) and must NOT be mistaken for "already current", or the
+# auto-convert silently no-ops and the run dies later on a raw undefined-tag error.
+# stderr is deliberately not suppressed so the reason is visible.
 migrate_rc=0
-bash "$REPO_ROOT/tools/migrate_legacy_tokens.sh" --check "$TRUTH_VCF" >/dev/null 2>&1 \
+bash "$REPO_ROOT/tools/migrate_legacy_tokens.sh" --check "$TRUTH_VCF" >/dev/null \
     || migrate_rc=$?
-if [[ "$migrate_rc" -eq 10 ]]; then
-    MIGRATED_TRUTH="$OUTDIR/truth_migrated.vcf.gz"
-    bash "$REPO_ROOT/tools/migrate_legacy_tokens.sh" "$TRUTH_VCF" "$MIGRATED_TRUTH"
-    TRUTH_VCF="$MIGRATED_TRUTH"
-fi
+case "$migrate_rc" in
+    0) ;;   # already current
+    10) MIGRATED_TRUTH="$OUTDIR/truth_migrated.vcf.gz"
+        bash "$REPO_ROOT/tools/migrate_legacy_tokens.sh" "$TRUTH_VCF" "$MIGRATED_TRUTH"
+        TRUTH_VCF="$MIGRATED_TRUTH" ;;
+    *)  echo "ERROR: legacy-token pre-flight failed (rc=$migrate_rc) on $TRUTH_VCF" >&2
+        echo "  Not proceeding: an unconverted truth VCF would fail the filter below." >&2
+        exit 1 ;;
+esac
 
 SCORE_TRUTH="$OUTDIR/scoring_truth.vcf.gz"
 if [[ ! -f "$SCORE_TRUTH" ]]; then

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -180,14 +180,22 @@ index_and_align "${PREFIX}_merged_r1.fastq.gz" "$TUMOR_BAM" "TUMOR"
 # re-scoring an archived artifact). Idempotent and a no-op on a current file, so
 # the unconditional call is safe. `|| rc=$?` (not `; echo $?`) so the non-zero
 # --check status is *tested* — under set -e an untested non-zero would abort here.
+# Only 0 and 10 are meaningful: any other status means the pre-flight itself failed
+# (missing input, no bcftools, bad converter path) and must NOT be mistaken for
+# "already current", or the auto-convert silently no-ops and the run dies later on a
+# raw undefined-tag error. stderr is deliberately not suppressed.
 migrate_rc=0
-bash "$REPO_ROOT/tools/migrate_legacy_tokens.sh" --check "$TRUTH_VCF" >/dev/null 2>&1 \
+bash "$REPO_ROOT/tools/migrate_legacy_tokens.sh" --check "$TRUTH_VCF" >/dev/null \
     || migrate_rc=$?
-if [[ "$migrate_rc" -eq 10 ]]; then
-    MIGRATED_TRUTH="$OUTDIR/truth_migrated.vcf.gz"
-    bash "$REPO_ROOT/tools/migrate_legacy_tokens.sh" "$TRUTH_VCF" "$MIGRATED_TRUTH"
-    TRUTH_VCF="$MIGRATED_TRUTH"
-fi
+case "$migrate_rc" in
+    0) ;;   # already current
+    10) MIGRATED_TRUTH="$OUTDIR/truth_migrated.vcf.gz"
+        bash "$REPO_ROOT/tools/migrate_legacy_tokens.sh" "$TRUTH_VCF" "$MIGRATED_TRUTH"
+        TRUTH_VCF="$MIGRATED_TRUTH" ;;
+    *)  echo "ERROR: legacy-token pre-flight failed (rc=$migrate_rc) on $TRUTH_VCF" >&2
+        echo "  Not proceeding: an unconverted truth VCF would fail the filter below." >&2
+        exit 1 ;;
+esac
 
 TRUTH_SV="$OUTDIR/truth_sv.vcf.gz"
 echo "[3b/5] Inspecting eidolon SV truth..."

--- a/tools/migrate_legacy_tokens.sh
+++ b/tools/migrate_legacy_tokens.sh
@@ -16,9 +16,16 @@
 # fails outright rather than falling back. Converting the file up front is the
 # reliable fix, and it's what this script does.
 #
-# The conversion is IDEMPOTENT and quiet: running it on an already-migrated file
-# (or on a non-eidolon VCF) copies the input through unchanged and exits 0. That
-# means callers can invoke it unconditionally without probing first.
+# The conversion is IDEMPOTENT and quiet: running it on an already-migrated file (or a
+# non-eidolon VCF) leaves every record and declaration untouched and exits 0, so callers
+# can invoke it unconditionally without probing first.
+#
+# "Untouched" is about the DATA, not the bytes — every pass goes through bcftools, which
+# adds a `##bcftools_viewCommand` provenance line and normalizes float formatting
+# (`1.0` -> `1`). Two other cosmetic effects of `--rename-annots`: the tag's
+# `Description=` text is not rewritten, so a converted header can still read
+# "...is NEAT_CCF x allele dosage"; and output is always BGZF even if the input was
+# plain gzip. None of these change record semantics.
 #
 # NOT handled: FASTQ/BAM read-name prefixes (@RNEAT_generated_ / RNEAT_chimeric_).
 # Rewriting those means a full pass over files that are routinely hundreds of GB,
@@ -67,14 +74,27 @@ for tag in "${LEGACY_INFO[@]}"; do
 done
 
 # Sample columns: rename only names we know are ours, never an arbitrary sample.
+#
+# Take the names from the #CHROM line of the header we already captured, NOT from a
+# second `bcftools query -l`. A process substitution's failure is invisible to set -e:
+# if the command died, the loop body would simply never run, `legacy_samples` would
+# stay 0, and we'd rename the INFO tags while silently leaving the sample column as
+# NEAT_simulated_sample — a half-converted file returned with exit 0.
+chrom_line="$(grep -m1 '^#CHROM' <<<"$header")" \
+    || die "no #CHROM header line in $IN — not a VCF?"
 legacy_samples=0
 new_samples=""
-while IFS= read -r s; do
-    case "$s" in
-        NEAT_simulated_sample) new_samples+="EIDOLON_simulated_sample"$'\n'; legacy_samples=1 ;;
-        *)                     new_samples+="$s"$'\n' ;;
-    esac
-done < <(bcftools query -l "$IN")
+# Fields 1-9 are the fixed VCF columns; 10+ are samples (absent in a sites-only VCF).
+n_fields="$(awk -F'\t' '{print NF; exit}' <<<"$chrom_line")"
+if [[ "$n_fields" -gt 9 ]]; then
+    while IFS= read -r s; do
+        [[ -n "$s" ]] || continue
+        case "$s" in
+            NEAT_simulated_sample) new_samples+="EIDOLON_simulated_sample"$'\n'; legacy_samples=1 ;;
+            *)                     new_samples+="$s"$'\n' ;;
+        esac
+    done < <(cut -f10- <<<"$chrom_line" | tr '\t' '\n')
+fi
 
 if [[ "$CHECK_ONLY" -eq 1 ]]; then
     if [[ ${#found[@]} -eq 0 && "$legacy_samples" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Release-blocker fix plus three hardening items from the pre-release review of the v2.1.0 token migration (#443). Gates the v2.1.0 release PR (#445).

## 1. `strip_own_output_tokens` — release blocker

The compat layer in #443 stripped only the **previous** generation of eidolon's tokens. So feeding a **v2.1.0** golden VCF back in via `input_vcf:` reproduced the exact regression the layer was written to fix — it addressed the shrinking half of the problem (v2.0.0 goldens) and left the growing half, since v2.1.0 goldens are what users produce from now on.

`EIDOLON_PROVENANCE` and `EIDOLON_ORIGIN` are now stripped alongside the `NEAT_*` names.

**Verified before/after** on the symbolic path with an `<INV>` carrying stale tokens:

```
pre-fix:  SVTYPE=INV;END=400;EIDOLON_PROVENANCE=denovo;EIDOLON_ORIGIN=somatic;EIDOLON_PROVENANCE=input
          -> [E::bcf_write] Unchecked error (2 Tag not defined in header) at H1N1_HA:200
post-fix: SVTYPE=INV;END=400;EIDOLON_PROVENANCE=input        (BCF translation OK)
```

Three failure modes closed:
1. A **duplicate `EIDOLON_PROVENANCE`** key with contradictory values (`=denovo` from the source beside the fresh `=input`).
2. An **undeclared `EIDOLON_ORIGIN`** — only `vcf_merge` declares it — which hard-fails BCF translation, and `bcftools concat | sort` does that internally.
3. Worst: **a germline variant labelled as somatic ground truth.** `vcf_merge::tumor_origin` tests for the exact field `EIDOLON_PROVENANCE=denovo`, so a stale copy makes it label a variant present in *both* passes as `somatic`. Every bundled benchmark filters `INFO/EIDOLON_ORIGIN="somatic"`, so that germline carry-through enters the somatic truth set and becomes a guaranteed FN for a correctly-behaving T/N caller.

**`EIDOLON_CCF` / `EIDOLON_VAF` are deliberately kept.** Unlike provenance they are #405's ground truth and live *in* `variant.info` — `gen_reads::runner` appends them there before the write — so stripping them would destroy the tags on every de-novo somatic record. Both are declared by this writer, so passing one through is harmless. Pinned by test.

## 2. Harness auto-convert no longer swallows unexpected exit codes

`cancer_pipeline.sbatch` / `sv_pipeline.sbatch` treated **every** non-zero `--check` status except 10 as "already current", with stderr discarded. A missing input (rc 1), unreadable file (255), or wrong converter path (127) silently no-opped the auto-convert and let the run die later on bcftools' raw undefined-tag error. Now a `case` that fails loudly on anything unexpected, with stderr visible. Verified for rc 0 / 10 / 1.

## 3. `migrate_legacy_tokens.sh` — no more silent half-conversion

Sample names came from `bcftools query -l` through a **process substitution, whose failure `set -e` cannot see**: the loop body would simply never run, `legacy_samples` would stay 0, and the INFO tags would be renamed while the sample column was left as `NEAT_simulated_sample` — a partial conversion returned with exit 0. Names now come from the `#CHROM` line of the header already captured, with an explicit guard, and a sites-only VCF is handled explicitly.

Re-verified after the change: legacy conversion, idempotency (byte-identical modulo the bcftools provenance line), foreign sample preserved, sites-only VCF.

## 4. Discoverability — the review's condition for shipping 2.1.0 rather than 3.0.0

- **`filter-reads` logs a one-time WARN** when it accepts a pre-v2.1.0 `@RNEAT_generated_` prefix. This was the only remaining path where a user's legacy data flows through v2.1.0 with no signal the format changed — while their own `grep '^@RNEAT_generated_'` over the same file returns zero rows and exits 0.
- **README gains an "Upgrading from 2.0.0" section**: the full token table, the converter invocation, why a dual-name bcftools filter cannot work, an audit grep for the old prefix, and explicit `sed` recipes for FASTQ and BAM — stating plainly that read names are **not** converted and that BAM QNAMEs are covered by no in-tree tooling.

## Also corrected

The script header and CHANGELOG claimed conversion "copies the input through unchanged", which isn't literally true — bcftools adds a `##bcftools_viewCommand` line, normalizes float formatting (`1.0` → `1`), `--rename-annots` doesn't rewrite `Description=` text, and output is always BGZF. Now describes what's actually preserved: record semantics. Also removed a dead comment on the `SomaticVcf` literal branch (`gen_reads::runner` clears `v.info` on ingest, so that arm never carries source INFO).

## Testing

Full workspace suite green (27 groups, 0 failures); `cargo fmt --all --check` clean; `bash -n` clean on all modified shell/sbatch files.

Still outstanding for the release, tracked on #445: the Delta smoke tests, the missing #405 CHANGELOG entry, and the 2.1.0-vs-3.0.0 version decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
