### PR TITLE
chore!: release as 3.0.0 and adopt Semantic Versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,44 @@
 7/28/2026
 =========
-## eidolon v2.1.0 — output tokens renamed NEAT_* / RNEAT_* → EIDOLON_*
+## eidolon v3.0.0 — output tokens renamed NEAT_* / RNEAT_* → EIDOLON_*; adopting SemVer
 
 **Breaking output-format change** — no behavior change, only the names of emitted tokens.
 Completes decision 1 of `docs/rename_eidolon_scope.md` (the post-2.0.0 output-token
 migration). Downstream code that parses the old names must update.
+
+### Why 3.0.0, and a versioning policy going forward
+
+This release is **3.0.0**, not 2.1.0, and from here on eidolon follows
+[Semantic Versioning 2.0.0](https://semver.org).
+
+Earlier releases were versioned by feel, and by that habit this would have been a minor
+bump: it completes a rename announced back in v2.0.0, and three prior releases shipped
+breaking output changes as minor bumps (v1.11.0 and v1.12.0 both changed the FASTQ
+read-name format; v1.6.0 removed config fields under a bolded "Breaking change"). That
+pattern was not doing users any favours — a minor bump tells you it is safe to upgrade
+without reading anything, and for these releases that was not true.
+
+SemVer requires a project to **declare what its public API is**, so eidolon's is now
+stated explicitly (also in the README):
+
+**Part of the public API** — changes here require a MAJOR bump:
+- Names and semantics of emitted VCF INFO tags, the VCF sample-column name, and the
+  `FILTER`/`FORMAT` fields eidolon writes
+- FASTQ/BAM **read-name (QNAME) format**, including the `EIDOLON_generated_` /
+  `EIDOLON_chimeric_` prefixes and the positional fields encoded after them
+- CLI subcommand names, flags, and configuration-YAML keys
+- Model-file format compatibility (a model built by version *N* being readable by *N+1*)
+
+**Not part of the public API** — these may change in a MINOR or PATCH release:
+- The Rust library (`eidolon-core`) API surface; this crate exists to serve the binary
+- Log output, progress reporting, and human-readable messages
+- Exact simulated *content* for a given seed — reads are a random draw, and any change
+  to the sampler or models legitimately changes output while preserving the format
+
+For a read simulator the emitted format is the interface downstream code actually binds
+to, which is why it heads the list. That is also the reasoning that makes this release
+major: renaming the tokens is a breaking change to that interface, notwithstanding that
+it was pre-announced and that no behavior changed.
 
 - **VCF INFO tags:** `NEAT_ORIGIN` → `EIDOLON_ORIGIN`, `NEAT_PROVENANCE` → `EIDOLON_PROVENANCE`,
   `NEAT_REASON` → `EIDOLON_REASON`, `NEAT_CCF` → `EIDOLON_CCF`, `NEAT_VAF` → `EIDOLON_VAF`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ keywords:
   - vcf
   - rust
 license: BSD-3-Clause
-version: 2.1.0
+version: 3.0.0
 identifiers:
   - type: doi
     value: 10.5281/zenodo.20100558

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "eidolon"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "eidolon-core"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '2.1.0'
+version = '3.0.0'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > NEAT lineage; the `rneat` command still works as a deprecated alias for one transition
 > release. See `CHANGELOG.md`.
 
-> **Upgrading from 2.0.0 → 2.1.0? The names of emitted output tokens changed.**
+> **Upgrading from 2.0.0 → 3.0.0? The names of emitted output tokens changed.**
 > See [Upgrading from 2.0.0](#upgrading-from-200) below — **read it if you have any
 > script that parses eidolon VCFs or FASTQ/BAM read names.**
 
@@ -44,7 +44,7 @@ line), the current Python 3 NEAT 4.x, and `eidolon`.
 
 |                                            | **NEAT 2.x** (genReads)        | **NEAT 4.x**                              | **`eidolon`**                                              |
 | ------------------------------------------ | ------------------------------ | ----------------------------------------- | -------------------------------------------------------- |
-| Latest version                             | 2.1                            | 4.5.3                                      | 2.1.0                                                    |
+| Latest version                             | 2.1                            | 4.5.3                                      | 3.0.0                                                    |
 | Language                                   | Python 2                       | Python 3                                  | Rust                                                     |
 | FASTQ reads (single / paired)              | ✅                             | ✅                                        | ✅                                                       |
 | Golden BAM + VCF truth set                 | ✅                             | ✅                                        | ✅                                                       |
@@ -84,13 +84,40 @@ when you want:
   environment to manage, installable via Bioconda
   (`conda install -c bioconda eidolon`).
 
+## Versioning and the public API
+
+As of **v3.0.0**, eidolon follows [Semantic Versioning 2.0.0](https://semver.org): a
+MAJOR bump means something you may depend on changed incompatibly, a MINOR bump adds
+functionality compatibly, and a PATCH bump is fixes only. Releases before v3.0.0 were
+versioned less strictly — notably v1.11.0 and v1.12.0 changed the FASTQ read-name format
+in minor bumps.
+
+SemVer requires a project to say what its public API is. For eidolon:
+
+**Public API — a change here means a MAJOR bump:**
+- Names and semantics of emitted VCF INFO tags, the VCF sample-column name, and the
+  `FILTER` / `FORMAT` fields eidolon writes
+- FASTQ/BAM **read-name (QNAME) format** — the `EIDOLON_generated_` /
+  `EIDOLON_chimeric_` prefixes and the positional fields encoded after them
+- CLI subcommand names, flags, and configuration-YAML keys
+- Model-file compatibility (a model built by one version staying readable by the next)
+
+**Not public API — may change in a MINOR or PATCH release:**
+- The `eidolon-core` Rust library surface; it exists to serve the binary
+- Log output, progress reporting, and human-readable messages
+- The exact simulated *content* for a given seed — reads are a random draw, so sampler
+  and model changes legitimately alter output while preserving the format
+
+If you parse eidolon's output, the first list is what you are relying on, and a major
+version bump is your signal to check this file before upgrading.
+
 ## Upgrading from 2.0.0
 
-v2.1.0 renamed the tokens eidolon **emits**. There is no behavior change — the same
+v3.0.0 renamed the tokens eidolon **emits**. There is no behavior change — the same
 reads and variants are produced — but anything that *parses* eidolon output needs
 attention. In-tree consumers were all migrated; your own scripts were not.
 
-| Surface | v2.0.0 and earlier | v2.1.0+ | Migration |
+| Surface | v2.0.0 and earlier | v3.0.0+ | Migration |
 |---|---|---|---|
 | VCF INFO tags | `NEAT_ORIGIN`, `NEAT_PROVENANCE`, `NEAT_REASON`, `NEAT_CCF`, `NEAT_VAF` | `EIDOLON_*` | **converter provided** |
 | VCF sample column | `NEAT_simulated_sample` | `EIDOLON_simulated_sample` | **converter provided** |
@@ -121,7 +148,7 @@ instead `eidolon filter-reads` accepts **both** prefixes natively — legacy FAS
 working with no conversion step, and it warns once when it sees an old prefix.
 
 **Nothing protects your own scripts.** A `grep '^@RNEAT_generated_'`, `awk` field split,
-or regex over read names will match **zero records and exit 0** against v2.1.0 output —
+or regex over read names will match **zero records and exit 0** against v3.0.0 output —
 a silent empty result, not an error. Audit for the old prefix before upgrading:
 
 ```bash
@@ -156,7 +183,7 @@ required. If you prefer to build from source or grab a release binary, read on.
 
 You will need to install the rust toolchain to compile `eidolon`, including `cargo`. Check the cargo documentation for instructions (https://doc.rust-lang.org/cargo/getting-started/installation.html). Alternatively, you can try one of the binaries on the release page. Select the one that matches your system and let us know if you run into errors. During compilation, you may run into errors, such as cmake not found. Some of the packages `eidolon` uses have these dependencies. For Debian/Ubuntu this should be a simple `sudo apt install cmake` and for RHEL/Rocky type distros this should be `sudo dnf install cmake`. There may be some other requirements. Drop a comment if you need specific help.
 
-Download the executable in the release (current version 2.1.0).
+Download the executable in the release (current version 3.0.0).
 
 ```bash
 $ eidolon --help

--- a/docs/rename_eidolon_scope.md
+++ b/docs/rename_eidolon_scope.md
@@ -2,7 +2,7 @@
 
 Planning doc for the project rename. **Status: Phase A DONE (PR #425, merged to `develop`;
 ships in the v2.0.0 release PR #426). Phases B–C pending. Decision-1 output-token migration
-DONE (v2.1.0) — see Decisions §1.**
+DONE (v3.0.0) — see Decisions §1.**
 Target release for the rename: **v2.0.0**, cut *after* v1.21.1 is fully released. Do not
 entangle the rename with any behavior change.
 
@@ -35,19 +35,19 @@ treated differently:
 |---|---|---|
 | **Identity** | `rneat`, `rusty-neat`, `RNEAT_BIN`, `RNEAT_REPO`, `rusty-neat-tests.yml` | → rename to `eidolon` / `EIDOLON_` |
 | **Pedigree** (keep) | `NEAT`, `NEAT2`, `NEAT4`, `neat-genreads`, comparison text | → **leave untouched** |
-| **Output-format tokens** | `NEAT_PROVENANCE`, `NEAT_simulated_sample`, `NEAT_ORIGIN`, `RNEAT_chimeric_*` | → kept for v2.0.0; **migrated to `EIDOLON_*` in v2.1.0** (decision 1) |
+| **Output-format tokens** | `NEAT_PROVENANCE`, `NEAT_simulated_sample`, `NEAT_ORIGIN`, `RNEAT_chimeric_*` | → kept for v2.0.0; **migrated to `EIDOLON_*` in v3.0.0** (decision 1) |
 
 Codebase inventory at scoping time: `rneat` 866× / 129 files, `rusty-neat` 93× / 32 files,
 `RNEAT` 204× / 46 files (mostly `RNEAT_BIN`/`RNEAT_REPO` env vars + `RNEAT_chimeric_` prefixes).
 
 ## Decisions (locked)
 
-1. **Output-format tokens — keep in v2.0.0, migrate later. → DONE (v2.1.0).** The `NEAT_*` INFO tags
+1. **Output-format tokens — keep in v2.0.0, migrate later. → DONE (v3.0.0).** The `NEAT_*` INFO tags
    (`NEAT_PROVENANCE`, `NEAT_ORIGIN`, plus the later `NEAT_REASON`/`NEAT_CCF`/`NEAT_VAF`), the
    `NEAT_simulated_sample` VCF sample column, and the `RNEAT_generated_*` / `RNEAT_chimeric_*`
    FASTQ read-name prefixes appear in generated output, are asserted byte-for-byte in tests
    (`vcf_tools.rs`, `dup_chimeric.rs`), and are parsed downstream (`cancer_benchmark.sh` filters
-   `INFO/NEAT_ORIGIN`). v2.0.0 kept them as-is for output stability; **v2.1.0 migrates all of
+   `INFO/NEAT_ORIGIN`). v2.0.0 kept them as-is for output stability; **v3.0.0 migrates all of
    them to `EIDOLON_*`** as a deliberate, separately-versioned breaking format change — bundled
    scripts and the `filter_reads` read-name parser moved in lockstep and the parity/baseline
    assertions re-blessed. Pedigree `NEAT`/`NEAT2`/`NEAT4` and internal env vars (`NEAT_DATA`,
@@ -69,7 +69,7 @@ Codebase inventory at scoping time: `rneat` 866× / 129 files, `rusty-neat` 93×
   `tests/common/mod.rs`); fixture path references.
 - Source: log/help/`about` strings; `RNEAT_*` → `EIDOLON_*` env-var names in `scripts/` + `tools/`.
 - Leave all `NEAT_*` / `RNEAT_chimeric_*` output tokens untouched **in this phase** (decision 1);
-  they were migrated later, in v2.1.0.
+  they were migrated later, in v3.0.0.
 - CI: `rust_binaries.yml` (artifact names/paths), `rusty-neat-tests.yml` → `eidolon-tests.yml`
   (job name + filename), `thirdparty-licenses.yml`.
 - Docs: `README.md` (keep the NEAT-pedigree section; add a "formerly rusty-neat / rneat" line),

--- a/eidolon-core/src/file_tools/vcf_tools.rs
+++ b/eidolon-core/src/file_tools/vcf_tools.rs
@@ -273,9 +273,9 @@ pub fn write_vcf(
 ///   streaming VCF→VCF, but a hard failure on BCF translation, which
 ///   `bcftools concat | sort` does internally.
 ///
-/// Both the current `EIDOLON_*` spellings and the pre-v2.1.0 `NEAT_*` ones are stripped.
+/// Both the current `EIDOLON_*` spellings and the pre-v3.0.0 `NEAT_*` ones are stripped.
 /// Scoping this to only the legacy names would fix the shrinking half of the problem
-/// (v2.0.0 goldens) and leave the growing half (v2.1.0 goldens, which is what users
+/// (v2.0.0 goldens) and leave the growing half (v3.0.0 goldens, which is what users
 /// produce from now on).
 ///
 /// **`EIDOLON_CCF` / `EIDOLON_VAF` are deliberately kept.** Unlike provenance, they are
@@ -293,7 +293,7 @@ fn strip_own_output_tokens(info: &str) -> Option<String> {
         // Current spellings: re-emitted here, or declared only downstream.
         "EIDOLON_PROVENANCE",
         "EIDOLON_ORIGIN",
-        // Pre-v2.1.0 spellings: never re-emitted, so any survivor is undeclared.
+        // Pre-v3.0.0 spellings: never re-emitted, so any survivor is undeclared.
         "NEAT_PROVENANCE",
         "NEAT_ORIGIN",
         "NEAT_CCF",
@@ -1547,7 +1547,7 @@ chr1\t100\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;END=500\n";
             lines
         );
         // The sample-column name is an emitted output token too (renamed from
-        // NEAT_simulated_sample in v2.1.0). Without this assertion it is the one
+        // NEAT_simulated_sample in v3.0.0). Without this assertion it is the one
         // renamed token no test would catch being reverted.
         assert!(
             lines
@@ -1565,7 +1565,7 @@ chr1\t100\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;END=500\n";
             strip_own_output_tokens("SVTYPE=DEL;END=200;DP=30").as_deref(),
             Some("SVTYPE=DEL;END=200;DP=30")
         );
-        // Pre-v2.1.0 keys removed, order of the rest preserved.
+        // Pre-v3.0.0 keys removed, order of the rest preserved.
         assert_eq!(
             strip_own_output_tokens("SVTYPE=DEL;NEAT_PROVENANCE=denovo;END=200").as_deref(),
             Some("SVTYPE=DEL;END=200")
@@ -1581,7 +1581,7 @@ chr1\t100\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;END=500\n";
         // rather than a record starting with ';'.
         assert_eq!(strip_own_output_tokens("NEAT_PROVENANCE=input"), None);
 
-        // The CURRENT spellings must be stripped too. Round-tripping a v2.1.0 golden
+        // The CURRENT spellings must be stripped too. Round-tripping a v3.0.0 golden
         // through input_vcf: is the common case, not the legacy one.
         assert_eq!(
             strip_own_output_tokens("SVTYPE=DEL;EIDOLON_PROVENANCE=denovo;END=200").as_deref(),

--- a/eidolon/src/filter_reads/utils/filter_lib.rs
+++ b/eidolon/src/filter_reads/utils/filter_lib.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::Once;
 use thiserror::Error;
 
-/// Guards the one-time pre-v2.1.0 read-name-prefix warning in
+/// Guards the one-time pre-v3.0.0 read-name-prefix warning in
 /// `parse_fastq_record_name` — it is called once per FASTQ record, and a per-read
 /// warning on a multi-million-read file would be worse than silence.
 static LEGACY_PREFIX_WARNED: Once = Once::new();
@@ -85,7 +85,7 @@ fn parse_fastq_record_name(line: &str) -> Result<(String, usize, usize), FilterL
     // for why it's necessary). Parser takes the last three underscore-separated
     // tokens as (start, end, uniq) and ignores uniq.
     const PREFIX: &str = "@EIDOLON_generated_";
-    // v2.0.0 and earlier emitted "@RNEAT_generated_" (v2.1.0 renamed the output
+    // v2.0.0 and earlier emitted "@RNEAT_generated_" (v3.0.0 renamed the output
     // tokens). Accept both: FASTQs are far too large to be worth rewriting just to
     // change a 19-byte prefix, so legacy output stays filterable. Note the two
     // prefixes differ in length (19 vs 17), hence the matched-prefix slice below.
@@ -94,13 +94,13 @@ fn parse_fastq_record_name(line: &str) -> Result<(String, usize, usize), FilterL
         PREFIX
     } else if line.starts_with(LEGACY_PREFIX) {
         // Warn once. Accepting the old prefix silently is the only remaining path where
-        // a user's pre-v2.1.0 data flows through v2.1.0 with no signal that the output
+        // a user's pre-v3.0.0 data flows through v3.0.0 with no signal that the output
         // format changed — and a user's own `grep '^@RNEAT_generated_'` over the same
         // file returns zero rows with exit 0. This is the cheapest place to make that
         // discoverable, so say it out loud (once, not per read).
         LEGACY_PREFIX_WARNED.call_once(|| {
             warn!(
-                "input uses the pre-v2.1.0 read-name prefix \"{}\" (v2.1.0 renamed it to \
+                "input uses the pre-v3.0.0 read-name prefix \"{}\" (v3.0.0 renamed it to \
                  \"{}\"). Accepting it for compatibility. Note eidolon does NOT rewrite \
                  read names — any of your own scripts matching the old prefix will \
                  silently match nothing. See the \"Upgrading from 2.0.0\" section in the \

--- a/tools/cancer_benchmark.sh
+++ b/tools/cancer_benchmark.sh
@@ -295,8 +295,8 @@ if [[ -n "$TRUTH_FILTER" && "$TRUTH_FILTER" == *EIDOLON_ORIGIN* ]]; then
     truth_header="$(run_in "$BCFTOOLS_IMG" bcftools view -h "/truth_in/$TRUTH_NAME")"
     if ! grep -q '^##INFO=<ID=EIDOLON_ORIGIN,' <<<"$truth_header"; then
         if grep -q '^##INFO=<ID=NEAT_ORIGIN,' <<<"$truth_header"; then
-            echo "ERROR: $TRUTH_NAME carries the pre-v2.1.0 NEAT_ORIGIN tag." >&2
-            echo "  eidolon v2.1.0 renamed the emitted output tokens. Convert the truth" >&2
+            echo "ERROR: $TRUTH_NAME carries the pre-v3.0.0 NEAT_ORIGIN tag." >&2
+            echo "  eidolon v3.0.0 renamed the emitted output tokens. Convert the truth" >&2
             echo "  VCF once, then re-run against the converted copy:" >&2
             echo "    tools/migrate_legacy_tokens.sh '$TRUTH_VCF' migrated_truth.vcf.gz" >&2
             echo "    $0 --truth-vcf migrated_truth.vcf.gz ..." >&2

--- a/tools/cancer_sv_benchmark.sh
+++ b/tools/cancer_sv_benchmark.sh
@@ -303,8 +303,8 @@ else
         truth_header="$(run_in "$BCFTOOLS_IMG" bcftools view -h "/truth_in/$TRUTH_NAME")"
         if ! grep -q '^##INFO=<ID=EIDOLON_ORIGIN,' <<<"$truth_header"; then
             if grep -q '^##INFO=<ID=NEAT_ORIGIN,' <<<"$truth_header"; then
-                echo "ERROR: $TRUTH_NAME carries the pre-v2.1.0 NEAT_ORIGIN tag." >&2
-                echo "  eidolon v2.1.0 renamed the emitted output tokens. Convert it once:" >&2
+                echo "ERROR: $TRUTH_NAME carries the pre-v3.0.0 NEAT_ORIGIN tag." >&2
+                echo "  eidolon v3.0.0 renamed the emitted output tokens. Convert it once:" >&2
                 echo "    tools/migrate_legacy_tokens.sh '$TRUTH_VCF' migrated_truth.vcf.gz" >&2
                 echo "    $0 --truth-vcf migrated_truth.vcf.gz ..." >&2
             else

--- a/tools/migrate_legacy_tokens.sh
+++ b/tools/migrate_legacy_tokens.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# migrate_legacy_tokens.sh — normalize a pre-v2.1.0 eidolon VCF to the EIDOLON_* tokens.
+# migrate_legacy_tokens.sh — normalize a pre-v3.0.0 eidolon VCF to the EIDOLON_* tokens.
 #
-# v2.1.0 renamed eidolon's emitted output tokens (see CHANGELOG):
+# v3.0.0 renamed eidolon's emitted output tokens (see CHANGELOG):
 #
 #   INFO tags      NEAT_ORIGIN / NEAT_PROVENANCE / NEAT_REASON / NEAT_CCF / NEAT_VAF
 #                    -> EIDOLON_*
@@ -98,7 +98,7 @@ fi
 
 if [[ "$CHECK_ONLY" -eq 1 ]]; then
     if [[ ${#found[@]} -eq 0 && "$legacy_samples" -eq 0 ]]; then
-        echo "already current: no pre-v2.1.0 tokens in $IN"
+        echo "already current: no pre-v3.0.0 tokens in $IN"
         exit 0
     fi
     echo "legacy tokens in $IN:"
@@ -117,7 +117,7 @@ if [[ ${#found[@]} -eq 0 && "$legacy_samples" -eq 0 ]]; then
     exit 0
 fi
 
-echo "migrate_legacy_tokens: converting pre-v2.1.0 tokens in $(basename "$IN")" >&2
+echo "migrate_legacy_tokens: converting pre-v3.0.0 tokens in $(basename "$IN")" >&2
 [[ ${#found[@]} -gt 0 ]] && echo "  INFO: ${found[*]} -> EIDOLON_*" >&2
 [[ "$legacy_samples" -eq 1 ]] && echo "  sample: NEAT_simulated_sample -> EIDOLON_simulated_sample" >&2
 


### PR DESCRIPTION
## Summary

Releases the output-token rename as **3.0.0** rather than 2.1.0, and adopts [Semantic Versioning 2.0.0](https://semver.org) going forward. No functional change — version strings, plus a declared public-API policy.

## Why

The rename is a breaking change to the format downstream code binds to. Under SemVer that is a MAJOR release.

Prior releases were versioned by feel, and by that habit this would have been minor: it completes a rename announced back in v2.0.0, and three earlier releases shipped breaking output changes as minor bumps — v1.11.0 and v1.12.0 both changed the FASTQ read-name format (the v1.11.0 entry even says *"external consumers may not have been"* updated), and v1.6.0 removed config fields under a bolded **"Breaking change."**

That pattern wasn't serving users. A minor bump communicates "safe to upgrade without reading anything," which wasn't true of any of those releases.

## The substantive part: a declared public API

SemVer requires a project to state what its public API *is* — without that, "incompatible change" has no fixed meaning. Now declared in both the README and the CHANGELOG entry:

**Public API — MAJOR to change:**
- Names and semantics of emitted VCF INFO tags, the VCF sample-column name, and emitted `FILTER`/`FORMAT` fields
- FASTQ/BAM **read-name (QNAME) format** — the `EIDOLON_generated_` / `EIDOLON_chimeric_` prefixes and the positional fields encoded after them
- CLI subcommand names, flags, and configuration-YAML keys
- Model-file compatibility across versions

**Not public API — may change in MINOR/PATCH:**
- The `eidolon-core` Rust library surface (it exists to serve the binary)
- Log output, progress reporting, human-readable messages
- The exact simulated *content* for a given seed — reads are a random draw, so sampler/model changes legitimately alter output while preserving format

Declaring the QNAME format as public API is the part that matters going forward: for a read simulator the emitted format is the real interface, and naming it makes future version calls mechanical instead of a judgement each time.

## Scope

- `Cargo.toml` / `Cargo.lock` / `CITATION.cff` → 3.0.0
- README version references (comparison table, download line, upgrade banner)
- Every in-tree `v2.1.0` reference that meant "this release" — code comments, the converter and benchmark script messages, the `filter-reads` legacy-prefix warning, `docs/rename_eidolon_scope.md`
- CHANGELOG: heading → v3.0.0, plus the versioning-policy section
- **`conda-recipe/meta.yaml` intentionally untouched** — per repo history it's bumped in a separate post-tag commit, since its `sha256` needs the published release tarball

Historical CHANGELOG entries are unchanged; they remain accurate as history.

## Testing

Full workspace suite green (27 groups, 0 failures); `cargo fmt --all --check` clean; `eidolon --version` reports `3.0.0`.

Gates #445 (release PR), which needs its title and version references updated to match if this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
