### PR TITLE
docs: add the #405 subclonal-heterogeneity entry to the v3.0.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7/28/2026
 =========
-## eidolon v3.0.0 — output tokens renamed NEAT_* / RNEAT_* → EIDOLON_*; adopting SemVer
+## eidolon v3.0.0 — subclonal heterogeneity (#405); output tokens renamed NEAT_* / RNEAT_* → EIDOLON_*; adopting SemVer
 
 **Breaking output-format change** — no behavior change, only the names of emitted tokens.
 Completes decision 1 of `docs/rename_eidolon_scope.md` (the post-2.0.0 output-token
@@ -39,6 +39,61 @@ For a read simulator the emitted format is the interface downstream code actuall
 to, which is why it heads the list. That is also the reasoning that makes this release
 major: renaming the tokens is a breaking change to that interface, notwithstanding that
 it was pre-announced and that no behavior changed.
+
+### New feature — subclonal heterogeneity for gen-cancer-reads (#405)
+
+The tumor is no longer a single global purity split, which collapsed every somatic variant
+to ~one effective VAF. A tumor is now a mixture of **subclones** at distinct cancer-cell
+fractions (CCF), and each somatic variant's observed alt fraction composes as
+`purity × dosage × CCF` — the CCF *composes* with the variant's dosage and purity rather
+than replacing them, so a het somatic at CCF *f* lands at ~*f*/2 in the merged output.
+This is the intra-tumor heterogeneity axis the predecessor could not represent at all.
+
+Three ways to specify the architecture (mutually exclusive):
+
+- **Inline** — `subclones:`, a list of `{ccf, weight}`; the somatic burden is split across
+  populations in proportion to `weight` (default 1.0 = equal share), `ccf ∈ (0, 1]`.
+- **Fitted from real data** — `subclones_file:` accepts a **PyClone-VI** per-mutation table
+  (grouped by cluster, weight = mutation count) or a **PCAWG-11 / DPClust** cluster table
+  (`cluster` + `ccf` + a size column: `n_ssms` / `size` / `weight`).
+- **Replayed** — `somatic_vcf:` honors a real tumor's *observed* VAF per site: each input
+  site's VAF is divided by purity so the merged reads reproduce it, and the record is
+  tagged `somatic`. Observed VAF above purity is clamped to 1.0; sites with no usable VAF
+  fall back to genotype dosage.
+
+**Ground truth in the truth VCF.** Every somatic record carries `INFO/EIDOLON_CCF` (the
+intended CCF) and `INFO/EIDOLON_VAF` (the intended *observed* VAF — what a caller should
+measure on the merged sample). Note `FORMAT/AF` in the truth is measured per-pass
+(tumor-only, = dosage × CCF); `EIDOLON_VAF` is that × purity, so `EIDOLON_VAF` is the
+correct target when scoring a somatic caller against the merged output.
+
+**Real-data validation (Delta).** A round-trip the unit tests cannot reach: simulate, align
+the merged reads with bwa-mem2, and measure the observed VAF at each somatic site against
+the intended `EIDOLON_VAF`. Two complementary runs:
+
+| Metric | Generative — soy scaffold | Reproductive — HCC1395 chr1 |
+|---|---|---|
+| Input VAF spectrum | 3 synthetic CCF clusters (≈0.04 / 0.16 / 0.40) | real tumor's empirical VAF, all deciles 0.1–1.0 |
+| Coverage / purity | 200× / 0.8 | 200× / 0.9 |
+| Somatic sites (compared) | 567 planted (387 scored) | 2,948 (2,698 scored) |
+| Bias, mean(observed − intended) | −0.003 | −0.004 |
+| MAE (vs ~200× noise floor) | 0.026 | 0.024 |
+| Pearson r | 0.95 | **0.99** |
+
+The generative run confirms the `purity × dosage × CCF` composition is unbiased and
+accurate to the sampling limit; per-site Pearson is a spread-dependent summary for tight
+discrete clusters, so fidelity is gated on bias + MAE-vs-noise-floor rather than r. The
+reproductive run replays SEQC2 **HCC1395** (a triple-negative breast cancer cell line) at
+its observed VAF over GRCh38 chr1 — a real tumor's full *continuous* distribution, where
+Pearson is fully meaningful: r = 0.99, unbiased (−0.004), per-decile MAE uniform at
+0.009–0.027 across the whole 0.1–1.0 range.
+
+Harnesses: `scripts/delta/run_subclonal_vaf_validation.sh` (generative) and
+`scripts/delta/run_hcc1395_reproductive.sh` (reproductive). Config template:
+`template_config/gen_cancer_reads_template.yml`; details in `docs/cancer_simulator.md` and
+`docs/cancer_howto.md`.
+
+### Output tokens renamed NEAT_* / RNEAT_* → EIDOLON_*
 
 - **VCF INFO tags:** `NEAT_ORIGIN` → `EIDOLON_ORIGIN`, `NEAT_PROVENANCE` → `EIDOLON_PROVENANCE`,
   `NEAT_REASON` → `EIDOLON_REASON`, `NEAT_CCF` → `EIDOLON_CCF`, `NEAT_VAF` → `EIDOLON_VAF`.

--- a/README.md
+++ b/README.md
@@ -155,18 +155,41 @@ a silent empty result, not an error. Audit for the old prefix before upgrading:
 grep -rn 'RNEAT_generated_\|RNEAT_chimeric_' your_scripts/
 ```
 
-If you must rewrite existing files rather than update the scripts:
+#### Best fix: make your parser prefix-agnostic
+
+**Only the prefix changed.** Everything after `_generated_` —
+`<contig>_<start>_<end>_<uniq>/<mate>` — is byte-for-byte identical between versions
+(verified across every read of a golden BAM re-prefixed both ways). So rather than
+rewriting files, strip the prefix and your script works against *either* version, and
+against any future rename:
 
 ```bash
-# FASTQ (expensive — a full re-compress; prefer updating your scripts)
+# version-proof: drop whatever prefix is present, keep the encoded fields
+samtools view x.bam | cut -f1 | sed -E 's/^[A-Z]+_generated_//'
+zcat x_r1.fastq.gz  | awk 'NR%4==1' | sed -E 's/^@[A-Z]+_generated_//'
+```
+
+Same trick for chimeric reads: `sed -E 's/^@?[A-Z]+_chimeric_//'`.
+
+If you are joining an old artifact against a new one on read name, normalize both sides
+this way. One unrelated gotcha for QNAME joins: eidolon's golden BAM **keeps** the `/1`
+`/2` mate suffix, while bwa strips it from aligned BAMs — so strip that too
+(`sed 's|/[12]$||'`) when joining a golden BAM to an aligner's output. That mismatch
+predates this release.
+
+#### If you must rewrite the files instead
+
+```bash
+# FASTQ (expensive — a full re-compress; prefer the prefix-agnostic parse above)
 zcat old_r1.fastq.gz | sed 's/^@RNEAT_generated_/@EIDOLON_generated_/' | gzip > new_r1.fastq.gz
 
-# BAM QNAMEs
+# BAM QNAMEs (QNAME is field 1, and no header line contains the prefix, so ^ is safe)
 samtools view -h old.bam | sed 's/^RNEAT_generated_/EIDOLON_generated_/' | samtools view -b -o new.bam
 ```
 
-BAM QNAMEs are covered by no in-tree tooling at all — `filter-reads` reads FASTQ, and the
-converter is VCF-only. If you parse BAM read names, the `sed` above is the whole story.
+BAM QNAMEs are covered by no in-tree tooling — `filter-reads` reads FASTQ, and the
+converter is bcftools-based so it cannot touch a BAM. Nothing eidolon ships parses BAM
+read names either, so this only affects your own scripts.
 
 # How to use `eidolon`
 


### PR DESCRIPTION
## Summary

The #405 subclonal-heterogeneity work — nine feature commits plus the Delta real-data validation — shipped to `develop` with **no CHANGELOG entry at all**. The v3.0.0 release notes therefore documented only the token rename, omitting the release's headline feature. This adds it.

Also gives the existing token-rename bullets their own `###` subheading (they were dangling after the versioning-policy section), so the entry now has a clear two-part structure: new feature, then breaking rename.

## What the #405 entry covers

- The `purity × dosage × CCF` composition, and that CCF *composes* with dosage/purity rather than replacing them (a het somatic at CCF *f* lands at ~*f*/2)
- The three mutually-exclusive ways to specify an architecture: inline `subclones:`, `subclones_file:` fitted from PyClone-VI / PCAWG-11 (DPClust) tables, and `somatic_vcf:` reproductive replay
- The `INFO/EIDOLON_CCF` / `INFO/EIDOLON_VAF` ground-truth tags — including why `EIDOLON_VAF`, not `FORMAT/AF`, is the correct target when scoring a somatic caller against merged output (`FORMAT/AF` is per-pass = dosage × CCF; `EIDOLON_VAF` is that × purity)
- Both Delta validation runs with their metrics (generative: bias −0.003, MAE 0.026, r 0.95; reproductive HCC1395: 2,948 sites, bias −0.004, MAE 0.024, **r 0.99**), and why the generative run is gated on bias + MAE-vs-noise-floor rather than Pearson

## README: better read-name migration guidance

The previous note only offered file-rewriting recipes. But **only the prefix changed** — everything after `_generated_` (`<contig>_<start>_<end>_<uniq>/<mate>`) is byte-for-byte identical between versions. I verified this across every read of a golden BAM re-prefixed both ways.

So the recommended fix is now a prefix-agnostic parse, which works against either version *and* any future rename:

```bash
samtools view x.bam | cut -f1 | sed -E 's/^[A-Z]+_generated_//'
```

That's strictly better than rewriting hundreds of GB of FASTQ/BAM. The rewrite recipes remain as a fallback.

Also documents one unrelated gotcha for anyone joining on QNAME: eidolon's golden BAM **keeps** the `/1` `/2` mate suffix while bwa strips it from aligned BAMs. That mismatch predates this release, but it would silently break a naive join.

## Testing

Docs only — no code change. Full workspace suite green (27 groups, 0 failures).

Last item on #445's release checklist before the Delta runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
