### PR TITLE
fix!: emit BND mate pairs, write the ID column, stop double-counting junctions (#451)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,46 @@ Hand-written guidance below; the GitNexus block that follows is auto-generated
   found no inputs still printed PASS over an empty `summary.tsv` (job 19887446). Open
   the actual output (per-item rows, counts, sizes) before believing a success.
 
+### The recurring failure mode: harnesses that don't check their own coverage
+Every quiet failure found so far has the same shape — the harness reports a *metric*
+without asserting it actually **measured everything it planted**. Verified instances:
+
+| what it reported | what was true |
+|---|---|
+| `VERDICT: PASS`, bias/MAE in range (#450) | 160 of 567 planted sites silently excluded — the whole lowest-VAF cluster, i.e. the case the harness exists to test |
+| `BND recall=0.000` (#451) | truth was emitted unpaired/MATEID-less, so BND was unmatchable by construction; the reads were fine |
+| `nsom > 0` abort guard passed | the VAF values were the malformed string `AF=AF=0.3000`; the guard counted **records**, not content |
+
+**Rules when writing or reviewing a harness:**
+- Assert on **coverage of its own inputs**, not just on the metric: `n_scored` vs
+  `n_planted`, and report the shortfall per stratum. A metric over an unknown
+  denominator is not a result.
+- A zero or unexpectedly-small denominator is a **hard failure**, never a `WARNING`.
+  `cancer_pipeline.sbatch` only warned on an empty somatic truth, so it would have
+  scored every caller against nothing and printed results.
+- Guards must check **content**, not counts. Record counts pass while values are garbage.
+- If a step drops data deliberately (filters, LoD, min-depth), log how much it dropped.
+
+**This is not purely a bash problem.** The two deepest defects (#450, #451) were
+`bcftools` genotype semantics and Rust record emission — a Rust harness that likewise
+never asked "did I score all my planted sites?" would have failed just as silently. Bash
+contributed the *fragility* (see the footguns below), not the blind spots.
+
+### Bash footguns actually hit in this repo
+- `set -euo pipefail` + `zcat … | head` makes `zcat` take SIGPIPE (exit 141) and `set -e`
+  aborts a step that succeeded. Wrap in `set +o pipefail` … `set -o pipefail`.
+- **`$(cmd; echo $?)` does not capture a failing status** — the inherited `set -e` aborts
+  the subshell before `echo` runs, yielding an empty string. Use `cmd || rc=$?`.
+- **A process substitution's failure is invisible to `set -e`** — `while read … done <
+  <(cmd)` just runs zero iterations if `cmd` dies, so downstream logic silently sees "no
+  results". Assign to a variable first, or derive the data from something already captured.
+- Don't `case`/`if` on only the statuses you expect: handle `*)` explicitly, or an
+  unexpected rc gets treated as the happy path (`cancer_pipeline.sbatch` read every rc
+  except 10 as "already current").
+- Hardcoded offsets over token names (`substr($8,RSTART+9,…)`, `line[17..]`) break the
+  moment a token is renamed. Anchor on the token (`sub(/^EIDOLON_VAF=/,"",v)`) or use
+  `PREFIX.len()`.
+
 ## Delta / HPC (`scripts/delta/`)
 - Real-data validation runs on **NCSA Delta** (SLURM, account `bhrd-delta-cpu`). The
   cluster filesystem is **not reachable from this workstation** — the user runs jobs

--- a/eidolon-core/src/file_tools/vcf_tools.rs
+++ b/eidolon-core/src/file_tools/vcf_tools.rs
@@ -100,6 +100,13 @@ pub fn write_vcf(
         &mut buffer,
         "##INFO=<ID=CN,Number=1,Type=Integer,Description=\"Copy number of segment\">"
     )?;
+    // BND mate pairs cross-reference each other by ID. Declared here because this
+    // writer emits it on de-novo breakends and passes it through from input VCFs —
+    // an undeclared INFO tag streams fine VCF->VCF but hard-fails BCF translation.
+    writeln!(
+        &mut buffer,
+        "##INFO=<ID=MATEID,Number=.,Type=String,Description=\"ID of mate breakend(s)\">"
+    )?;
     writeln!(
         &mut buffer,
         "##INFO=<ID=EIDOLON_PROVENANCE,Number=1,Type=String,\
@@ -239,10 +246,18 @@ pub fn write_vcf(
                     variant.genotype_str, ref_count, alt_count, depth, af_str
                 )
             };
+            // The ID column was previously hardcoded to "." — which silently
+            // discarded every record's ID, including the ones an input VCF
+            // supplied. That breaks any INFO field that references an ID by name:
+            // a BND mate pair carries MATEID=<other side's ID>, so dropping IDs
+            // left the linkage dangling on both input-supplied and (post-#451)
+            // de-novo breakends. Emit the ID when the record has one.
+            let id_str = variant.id.as_deref().unwrap_or(".");
             let line = format!(
-                "{}\t{}\t.\t{}\t{}\t37\tPASS\t{}\tGT:AD:DP:AF\t{}",
+                "{}\t{}\t{}\t{}\t{}\t37\tPASS\t{}\tGT:AD:DP:AF\t{}",
                 contig,
                 variant.location + 1,
+                id_str,
                 sequence_array_to_string(&variant.reference),
                 alt_str,
                 info_str,
@@ -1546,6 +1561,13 @@ chr1\t100\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;END=500\n";
             "missing EIDOLON_PROVENANCE INFO header line; got: {:?}",
             lines
         );
+        // MATEID must be declared: BND mate pairs reference each other by ID, and an
+        // undeclared INFO tag hard-fails BCF translation.
+        assert!(
+            lines.iter().any(|l| l.starts_with("##INFO=<ID=MATEID,")),
+            "missing MATEID INFO header line; got: {:?}",
+            lines
+        );
         // The sample-column name is an emitted output token too (renamed from
         // NEAT_simulated_sample in v3.0.0). Without this assertion it is the one
         // renamed token no test would catch being reverted.
@@ -1619,6 +1641,60 @@ chr1\t100\t.\tN\t<DEL>\t60\tPASS\tSVTYPE=DEL;END=500\n";
         assert_eq!(
             strip_own_output_tokens("IMPRECISE;NEAT_VAF=0.1").as_deref(),
             Some("IMPRECISE")
+        );
+    }
+
+    /// The ID column was hardcoded to "." for every record, so a BND's MATEID
+    /// pointed at an ID that never appeared in the file. Nothing asserted on it.
+    #[test]
+    fn test_write_vcf_emits_the_record_id_column() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut sv = SvData::new("G]chr1:1500]", SvType::Bnd);
+        sv.end = Some(500);
+        sv.mate_contig = Some("chr1".to_string());
+        sv.mate_pos = Some(1500);
+        let v = Variant {
+            variant_type: VariantType::Complex,
+            location: 499,
+            reference: vec![Nucleotide::G],
+            alternate: AlternateType::Symbolic(sv),
+            genotype_str: "0/1".to_string(),
+            genotype: Genotype::Heterozygous,
+            allele_fraction: None,
+            id: Some("eidolon_bnd_chr1_500_1500_1".to_string()),
+            quality_score: None,
+            filter: None,
+            info: Some("SVTYPE=BND;MATEID=eidolon_bnd_chr1_500_1500_2".to_string()),
+            format: vec!["GT".to_string()],
+            sample: vec!["0/1".to_string()],
+            provenance: Provenance::Denovo,
+        };
+        let mutated_map = MutatedMap::from_interval(0, 2000, vec![v]).unwrap();
+        let mut mutated_maps = HashMap::new();
+        mutated_maps.insert("chr1".to_string(), vec![mutated_map]);
+        let output_path = temp_dir.path().join("bnd_id.vcf");
+        write_vcf(
+            &mutated_maps,
+            &vec!["chr1".to_string()],
+            &HashMap::from([("chr1".to_string(), 2000usize)]),
+            &PathBuf::from("ref.fa"),
+            false,
+            &output_path,
+            &HashMap::new(),
+        )
+        .unwrap();
+        let lines: Vec<String> = crate::file_tools::file_io::read_gzip_lines(&output_path)
+            .unwrap()
+            .map(|l| l.unwrap())
+            .collect();
+        let rec = lines
+            .iter()
+            .find(|l| !l.starts_with('#'))
+            .expect("no record written");
+        let cols: Vec<&str> = rec.split('\t').collect();
+        assert_eq!(
+            cols[2], "eidolon_bnd_chr1_500_1500_1",
+            "ID column must carry variant.id, not \".\": {rec}"
         );
     }
 

--- a/eidolon-core/src/structs/sv_model.rs
+++ b/eidolon-core/src/structs/sv_model.rs
@@ -446,8 +446,13 @@ impl SvModel {
         let max_retries = ((n_sv as f64 * 10.0 * retry_mult) as usize).max(20);
         let mut out: Vec<Variant> = Vec::with_capacity(n_sv);
         let mut retries = 0usize;
+        // Count placed *events*, not emitted records: a BND is one event that
+        // emits a mate PAIR (two records, see below). Gating the loop on
+        // out.len() would let each BND consume two slots and halve the number of
+        // SVs actually placed. For every other type events == out.len().
+        let mut events = 0usize;
 
-        while out.len() < n_sv && retries < max_retries {
+        while events < n_sv && retries < max_retries {
             retries += 1;
 
             let sv_type = match weighted_pick_with(&types, &type_cum, rng) {
@@ -598,8 +603,12 @@ impl SvModel {
                         // this BND rather than emit an unrecoverable truth.
                         continue;
                     }
+                    // The BND ALT embeds the reference base at THIS breakend
+                    // (VCF 4.2 §5.4). A literal "N" contradicts the REF column,
+                    // which carries the real base — see #451.
+                    let anchor_char: char = anchor_base.into();
                     (
-                        format!("N]{contig_name}:{mp_candidate}]"),
+                        format!("{anchor_char}]{contig_name}:{mp_candidate}]"),
                         Some(contig_name.to_string()),
                         Some(mp_candidate),
                     )
@@ -625,6 +634,39 @@ impl SvModel {
 
             let info_field = build_info_field(sv_type, sv_end_1based, length, copy_number);
 
+            // A BND is a two-sided event. VCF 4.2 §5.4 represents a novel
+            // adjacency as a mate PAIR — one record per breakend, cross-linked by
+            // MATEID — and that is what callers emit, so a one-sided truth record
+            // is unmatchable by any comparison tool (#451). Build stable IDs from
+            // the junction's own coordinates so they're deterministic and unique.
+            let bnd_pair = if sv_type == SvType::Bnd {
+                match (
+                    sv_data.mate_pos,
+                    sequence.get(sv_data.mate_pos.unwrap_or(0).saturating_sub(1)),
+                ) {
+                    (Some(mate_1based), Some(&mate_base)) if mate_base != Nucleotide::N => {
+                        let anchor_1based = anchor_0based + 1;
+                        Some((
+                            format!("eidolon_bnd_{contig_name}_{anchor_1based}_{mate_1based}_1"),
+                            format!("eidolon_bnd_{contig_name}_{anchor_1based}_{mate_1based}_2"),
+                            anchor_1based,
+                            mate_1based,
+                            mate_base,
+                        ))
+                    }
+                    // Mate base unusable (out of range / N). Emitting a lone
+                    // breakend would recreate #451, so drop the whole event.
+                    _ => continue,
+                }
+            } else {
+                None
+            };
+
+            let (info_1, id_1) = match &bnd_pair {
+                Some((id1, id2, ..)) => (format!("{info_field};MATEID={id2}"), Some(id1.clone())),
+                None => (info_field, None),
+            };
+
             occupied.push((affected_start, affected_end));
             out.push(Variant {
                 variant_type: VariantType::Complex,
@@ -632,28 +674,65 @@ impl SvModel {
                 reference: vec![anchor_base],
                 alternate: AlternateType::Symbolic(sv_data),
                 genotype_str: genotype_str.clone(),
-                genotype,
+                genotype: genotype.clone(),
                 allele_fraction: None,
-                id: None,
+                id: id_1,
                 quality_score: None,
                 filter: None,
-                info: Some(info_field),
+                info: Some(info_1),
                 format: vec!["GT".to_string()],
-                sample: vec![genotype_str],
+                sample: vec![genotype_str.clone()],
                 provenance: Provenance::Denovo,
             });
+
+            // The mate breakend. Reciprocal `t]p]` form, matching the spec's own
+            // worked example (`G]17:198982]` <-> `A]2:321681]`) — keeping this
+            // orientation means the junction sequence the chimeric read generator
+            // builds is unchanged; only the record representation is fixed.
+            if let Some((id1, id2, anchor_1based, mate_1based, mate_base)) = bnd_pair {
+                let mate_char: char = mate_base.into();
+                let mut mate_sv = SvData::new(
+                    format!("{mate_char}]{contig_name}:{anchor_1based}]"),
+                    SvType::Bnd,
+                );
+                mate_sv.end = Some(mate_1based);
+                mate_sv.svlen = None;
+                mate_sv.copy_number = None;
+                mate_sv.mate_contig = Some(contig_name.to_string());
+                mate_sv.mate_pos = Some(anchor_1based);
+                let mate_info = format!(
+                    "{};MATEID={id1}",
+                    build_info_field(SvType::Bnd, mate_1based, 1, None)
+                );
+                out.push(Variant {
+                    variant_type: VariantType::Complex,
+                    location: mate_1based.saturating_sub(1),
+                    reference: vec![mate_base],
+                    alternate: AlternateType::Symbolic(mate_sv),
+                    genotype_str: genotype_str.clone(),
+                    genotype,
+                    allele_fraction: None,
+                    id: Some(id2),
+                    quality_score: None,
+                    filter: None,
+                    info: Some(mate_info),
+                    format: vec!["GT".to_string()],
+                    sample: vec![genotype_str],
+                    provenance: Provenance::Denovo,
+                });
+            }
+
+            events += 1;
         }
 
-        if out.len() < n_sv {
+        // Compare EVENTS, not records — a BND emits two records for one event, so
+        // out.len() would mask an under-placement.
+        if events < n_sv {
             warn!(
                 "SvModel: requested {} de novo SV(s) but only placed {} after {} retries \
                  (overlap / N-anchor rejection saturated; cap = {}bp at \
                  max_length_fraction={:.2}). On small contigs, raise sv_max_length_fraction.",
-                n_sv,
-                out.len(),
-                retries,
-                upper_len,
-                frac
+                n_sv, events, retries, upper_len, frac
             );
         } else {
             info!(
@@ -1325,6 +1404,111 @@ mod tests {
         let mut rng = deterministic_rng();
         let out = m.sample_variants("chr1", MIN_SV_LENGTH_BP, &[], &seq, 2, 1.0, 0.25, &mut rng);
         assert!(out.is_empty());
+    }
+
+    /// A BND is a two-sided event: VCF 4.2 §5.4 wants a mate PAIR, cross-linked by
+    /// MATEID, with each record's ALT embedding the reference base at *its own*
+    /// breakend. Before #451 the sampler emitted a single record with `id: None`,
+    /// no MATEID, and a hardcoded `N` in the ALT — unmatchable by any comparison
+    /// tool, and `sample_variants_emits_all_supported_types` passed anyway because
+    /// it only asserts the BND *type appears*.
+    #[test]
+    fn denovo_bnd_emits_a_cross_linked_mate_pair() {
+        let mut m = SvModel::default();
+        m.per_base_rate = 5e-3;
+        m.homozygous_frequency = 0.5;
+        m.type_probabilities.clear();
+        m.type_probabilities.insert(SvType::Bnd, 1.0);
+        m.length_log_normal.insert(SvType::Bnd, (7.0, 0.3));
+        let seq = acgt_sequence(50_000);
+        let mut rng = deterministic_rng();
+        let out = m.sample_variants("chr1", 50_000, &[], &seq, 2, 1.0, 0.25, &mut rng);
+
+        let bnds: Vec<&Variant> = out
+            .iter()
+            .filter(|v| {
+                v.alternate
+                    .as_symbolic()
+                    .map(|s| s.sv_type == SvType::Bnd)
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert!(!bnds.is_empty(), "expected at least one de novo BND");
+        assert_eq!(
+            bnds.len() % 2,
+            0,
+            "BND records must come in pairs: {bnds:?}"
+        );
+
+        // Every record has an ID, and MATEID resolves to a record that points back.
+        let by_id: std::collections::HashMap<&str, &Variant> = bnds
+            .iter()
+            .map(|v| (v.id.as_deref().expect("BND must carry an ID"), *v))
+            .collect();
+        assert_eq!(by_id.len(), bnds.len(), "BND IDs must be unique");
+
+        for v in &bnds {
+            let info = v.info.as_deref().unwrap_or("");
+            let mateid = info
+                .split(';')
+                .find_map(|f| f.strip_prefix("MATEID="))
+                .unwrap_or_else(|| panic!("BND record has no MATEID: {info}"));
+            let mate = by_id
+                .get(mateid)
+                .unwrap_or_else(|| panic!("MATEID={mateid} does not resolve to a record"));
+            let back = mate
+                .info
+                .as_deref()
+                .unwrap_or("")
+                .split(';')
+                .find_map(|f| f.strip_prefix("MATEID="))
+                .unwrap_or("");
+            assert_eq!(
+                back,
+                v.id.as_deref().unwrap(),
+                "MATEID linkage is not reciprocal"
+            );
+
+            // The ALT's embedded breakend base must equal this record's REF.
+            let alt = v.alternate.as_symbolic().unwrap().raw_alt.clone();
+            let ref_char: char = v.reference[0].into();
+            assert_eq!(
+                alt.chars().next().unwrap(),
+                ref_char,
+                "BND ALT must embed its own REF base (not a literal N): REF={ref_char} ALT={alt}"
+            );
+
+            // And the mate's position must be the mate record's own location.
+            let mate_pos_1based = v.alternate.as_symbolic().unwrap().mate_pos.unwrap();
+            assert_eq!(
+                mate_pos_1based.saturating_sub(1),
+                mate.location,
+                "mate_pos must point at the mate record's location"
+            );
+        }
+    }
+
+    /// The sampling loop is gated on placed *events*, not emitted records — a BND
+    /// emits two records, so gating on `out.len()` would halve the SV count.
+    #[test]
+    fn bnd_pair_counts_as_one_event_toward_n_sv() {
+        let mut m = SvModel::default();
+        m.per_base_rate = 5e-3;
+        m.homozygous_frequency = 0.5;
+        m.type_probabilities.clear();
+        m.type_probabilities.insert(SvType::Bnd, 1.0);
+        m.length_log_normal.insert(SvType::Bnd, (7.0, 0.3));
+        let seq = acgt_sequence(50_000);
+        let mut rng = deterministic_rng();
+        let out = m.sample_variants("chr1", 50_000, &[], &seq, 2, 1.0, 0.25, &mut rng);
+        // Junctions, not records.
+        let junctions = out.len() / 2;
+        assert!(
+            junctions >= 2,
+            "an all-BND model should place multiple junctions, got {junctions} \
+             ({} records) — a loop gated on out.len() would halve this",
+            out.len()
+        );
     }
 
     #[test]

--- a/eidolon/src/gen_reads/utils/runner.rs
+++ b/eidolon/src/gen_reads/utils/runner.rs
@@ -1206,19 +1206,29 @@ fn process_chimeric_variants(
                 // lexicographically) and the same-contig case (compare
                 // positions) uniformly. Stored in `processed_ids` keyed by
                 // type-prefixed string so BND and INV share one HashSet.
+                //
+                // BOTH sides must be expressed in the SAME coordinate base or the
+                // two records canonicalize to different keys and the junction is
+                // processed twice (2x chimeric reads). `sv_rec.location` is
+                // 0-based; `sv.mate_pos` is 1-based (it comes from the VCF ALT
+                // string, and line ~2333 does saturating_sub(1) before indexing
+                // the sequence). Normalize the mate to 0-based here.
                 let here = (contig_name.as_str(), sv_rec.location);
-                let mate = (mate_contig.as_str(), mate_pos);
+                let mate_pos_0based = mate_pos.saturating_sub(1);
+                let mate = (mate_contig.as_str(), mate_pos_0based);
+                // The key body must also use the normalized coordinate, not the
+                // 1-based mate_pos, or the two sides still produce different keys.
                 let bnd_id = if here <= mate {
                     (
                         contig_name.clone(),
                         sv_rec.location,
                         mate_contig.clone(),
-                        mate_pos,
+                        mate_pos_0based,
                     )
                 } else {
                     (
                         mate_contig.clone(),
-                        mate_pos,
+                        mate_pos_0based,
                         contig_name.clone(),
                         sv_rec.location,
                     )

--- a/eidolon/tests/bnd_inv_double_count.rs
+++ b/eidolon/tests/bnd_inv_double_count.rs
@@ -165,3 +165,90 @@ fn homozygous_del_breakpoint_has_no_regular_crossing_reads() {
         "deleted interior (600) must have no regular reads (coverage-zeroed)"
     );
 }
+
+/// Run a homozygous BND junction between two H1N1_HA positions, supplying either
+/// one side or the full mate pair, and return the chimeric read names.
+fn run_bnd(test_name: &str, paired: bool) -> Vec<String> {
+    let (_dir, work) = fresh_workdir();
+    let input_vcf = work.join("input_bnd.vcf");
+    {
+        let mut f = std::fs::File::create(&input_vcf).unwrap();
+        writeln!(f, "##fileformat=VCFv4.2").unwrap();
+        writeln!(
+            f,
+            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"GT\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"t\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=MATEID,Number=.,Type=String,Description=\"m\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "H1N1_HA\t500\tbnd_A\tG\tG]H1N1_HA:1500]\t60\tPASS\tSVTYPE=BND;MATEID=bnd_B\tGT\t1/1"
+        )
+        .unwrap();
+        if paired {
+            writeln!(
+                f,
+                "H1N1_HA\t1500\tbnd_B\tC\tC]H1N1_HA:500]\t60\tPASS\tSVTYPE=BND;MATEID=bnd_A\tGT\t1/1"
+            )
+            .unwrap();
+        }
+    }
+
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.clone(), test_name);
+    config.coverage = 100;
+    config.read_len = READ_LEN;
+    config.produce_fastq = true;
+    config.input_vcf = Some(input_vcf);
+    let yaml = config.write_yaml();
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let out = work.join(format!("{test_name}_r1.fastq.gz"));
+    let r = BufReader::new(MultiGzDecoder::new(std::fs::File::open(&out).unwrap()));
+    r.lines()
+        .enumerate()
+        .filter(|(i, _)| i % 4 == 0)
+        .map(|(_, l)| l.unwrap())
+        .filter(|l| l.contains("EIDOLON_chimeric_"))
+        .collect()
+}
+
+/// A BND mate PAIR describes ONE junction from both sides, so it must produce the
+/// same number of chimeric reads as supplying a single side — not double.
+///
+/// The dedup key in the chimeric pass canonicalizes `(contig,pos,mate_contig,mate_pos)`
+/// so both sides collapse to one entry, but `location` is 0-based while `mate_pos` is
+/// 1-based; mixing them made the two sides hash to different keys and the junction was
+/// emitted twice (2x coverage at the breakpoint). This file previously tested only INV
+/// and DEL despite its name, so nothing caught it.
+#[test]
+fn bnd_mate_pair_does_not_double_the_junction_reads() {
+    let single = run_bnd("bnd_dc_single", false).len();
+    let paired = run_bnd("bnd_dc_paired", true).len();
+    assert!(
+        single > 0,
+        "expected chimeric reads for a homozygous BND, got none"
+    );
+    assert_eq!(
+        paired, single,
+        "a BND mate pair must not double the junction's chimeric reads \
+         (paired={paired}, single={single}) — the pair describes one junction"
+    );
+}

--- a/eidolon/tests/vcf_validation.rs
+++ b/eidolon/tests/vcf_validation.rs
@@ -1,0 +1,454 @@
+//! Well-formedness validation for the golden VCF `gen-reads` emits.
+//!
+//! The VCF counterpart to `fastq_validation.rs`. It exists because a whole class of
+//! defect shipped with a green suite: every prior VCF test asserted that *specific
+//! expected content was present* (`lines.iter().any(...)`), and none asserted the
+//! file as a whole was **well formed**. That let through
+//!
+//!   * `MATEID` emitted with no `##INFO=<ID=MATEID,…>` declaration,
+//!   * the record ID column hardcoded to `.`, so `MATEID` pointed at nothing,
+//!   * de-novo BNDs emitted as a lone breakend with no mate record (#451),
+//!   * a BND ALT embedding a literal `N` that contradicted its own REF column.
+//!
+//! An undeclared INFO tag is the sharp edge: bcftools tolerates it streaming
+//! VCF->VCF but hard-fails on BCF translation, and `bcftools concat | sort` does
+//! that internally — so it surfaces far downstream inside a harness rather than here.
+//!
+//! Dependency-free (no bcftools) so it runs in CI. Checks collect every violation
+//! instead of panicking on the first.
+
+mod common;
+
+use common::{GenReadsConfig, eidolon, fresh_workdir, h1n1_reference};
+use flate2::read::MultiGzDecoder;
+use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+struct Vcf {
+    info_declared: HashSet<String>,
+    alt_declared: HashSet<String>,
+    contig_declared: HashSet<String>,
+    column_header: Vec<String>,
+    records: Vec<Record>,
+}
+
+struct Record {
+    line_no: usize,
+    chrom: String,
+    pos: usize,
+    id: String,
+    reference: String,
+    alt: String,
+    info: String,
+    format: String,
+    samples: Vec<String>,
+    raw: String,
+}
+
+impl Record {
+    fn info_has(&self, field: &str) -> bool {
+        self.info.split(';').any(|f| f == field)
+    }
+    fn mateid(&self) -> Option<&str> {
+        self.info.split(';').find_map(|f| f.strip_prefix("MATEID="))
+    }
+    fn is_bnd(&self) -> bool {
+        self.info_has("SVTYPE=BND") || self.alt.contains('[') || self.alt.contains(']')
+    }
+}
+
+fn read_lines(path: &Path) -> Vec<String> {
+    let f = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {path:?}: {e}"));
+    if path.extension().and_then(|e| e.to_str()) == Some("gz") {
+        BufReader::new(MultiGzDecoder::new(f))
+            .lines()
+            .map(|l| l.unwrap())
+            .collect()
+    } else {
+        BufReader::new(f).lines().map(|l| l.unwrap()).collect()
+    }
+}
+
+/// Pull `ID=` out of a `##INFO=<ID=FOO,...>` style header line.
+fn header_id(line: &str) -> Option<String> {
+    let open = line.find('<')?;
+    line[open + 1..]
+        .trim_end_matches('>')
+        .split(',')
+        .find_map(|f| f.strip_prefix("ID=").map(|v| v.to_string()))
+}
+
+fn parse_vcf(path: &Path) -> Vcf {
+    let mut v = Vcf {
+        info_declared: HashSet::new(),
+        alt_declared: HashSet::new(),
+        contig_declared: HashSet::new(),
+        column_header: Vec::new(),
+        records: Vec::new(),
+    };
+    for (i, line) in read_lines(path).into_iter().enumerate() {
+        let line_no = i + 1;
+        if line.starts_with("##INFO=") {
+            v.info_declared.extend(header_id(&line));
+        } else if line.starts_with("##ALT=") {
+            v.alt_declared.extend(header_id(&line));
+        } else if line.starts_with("##contig=") {
+            v.contig_declared.extend(header_id(&line));
+        } else if line.starts_with("#CHROM") {
+            v.column_header = line.split('\t').map(str::to_string).collect();
+        } else if !line.starts_with('#') && !line.trim().is_empty() {
+            let f: Vec<&str> = line.split('\t').collect();
+            assert!(f.len() >= 8, "line {line_no}: <8 columns: {line:?}");
+            v.records.push(Record {
+                line_no,
+                chrom: f[0].to_string(),
+                pos: f[1]
+                    .parse()
+                    .unwrap_or_else(|_| panic!("line {line_no}: POS not numeric: {:?}", f[1])),
+                id: f[2].to_string(),
+                reference: f[3].to_string(),
+                alt: f[4].to_string(),
+                info: f[7].to_string(),
+                format: f.get(8).map(|s| s.to_string()).unwrap_or_default(),
+                samples: f.iter().skip(9).map(|s| s.to_string()).collect(),
+                raw: line.clone(),
+            });
+        }
+    }
+    v
+}
+
+/// Every INFO key a record uses must be declared. This is the BCF-translation class.
+fn check_info_declared(v: &Vcf) -> Vec<String> {
+    let mut p = Vec::new();
+    for r in &v.records {
+        if r.info == "." || r.info.is_empty() {
+            continue;
+        }
+        for field in r.info.split(';').filter(|f| !f.is_empty()) {
+            let key = field.split('=').next().unwrap_or(field);
+            if !v.info_declared.contains(key) {
+                p.push(format!(
+                    "line {}: INFO key `{key}` used but never declared (bcftools rejects \
+                     this on BCF translation)",
+                    r.line_no
+                ));
+            }
+        }
+    }
+    p
+}
+
+/// Symbolic ALTs (`<DEL>`, `<CNV>`, …) need a matching `##ALT=<ID=…>`.
+fn check_alt_declared(v: &Vcf) -> Vec<String> {
+    let mut p = Vec::new();
+    for r in &v.records {
+        if r.alt.starts_with('<') && r.alt.ends_with('>') {
+            let id = &r.alt[1..r.alt.len() - 1];
+            if !v.alt_declared.contains(id) {
+                p.push(format!(
+                    "line {}: symbolic ALT `{}` has no ##ALT=<ID={id}> declaration",
+                    r.line_no, r.alt
+                ));
+            }
+        }
+    }
+    p
+}
+
+/// REF must equal the reference FASTA at POS, and a BND's ALT embeds that same base.
+fn check_ref(v: &Vcf, reference: &HashMap<String, String>) -> Vec<String> {
+    let mut p = Vec::new();
+    for r in &v.records {
+        let Some(seq) = reference.get(&r.chrom) else {
+            p.push(format!(
+                "line {}: CHROM `{}` absent from the reference",
+                r.line_no, r.chrom
+            ));
+            continue;
+        };
+        let (start, end) = (r.pos - 1, r.pos - 1 + r.reference.len());
+        if end > seq.len() {
+            p.push(format!(
+                "line {}: REF runs past end of {}",
+                r.line_no, r.chrom
+            ));
+            continue;
+        }
+        if !seq[start..end].eq_ignore_ascii_case(&r.reference) {
+            p.push(format!(
+                "line {}: REF `{}` != reference `{}` at {}:{}",
+                r.line_no,
+                r.reference,
+                &seq[start..end],
+                r.chrom,
+                r.pos
+            ));
+        }
+        if r.is_bnd() {
+            let embedded: String = r
+                .alt
+                .chars()
+                .take_while(char::is_ascii_alphabetic)
+                .collect();
+            if !embedded.is_empty() && !embedded.eq_ignore_ascii_case(&r.reference) {
+                p.push(format!(
+                    "line {}: BND ALT embeds `{embedded}` but REF is `{}` ({})",
+                    r.line_no, r.reference, r.alt
+                ));
+            }
+        }
+    }
+    p
+}
+
+/// A BND must have a MATEID that resolves to a record pointing back at it. A lone
+/// breakend is unmatchable by any comparison tool.
+fn check_mateid(v: &Vcf) -> Vec<String> {
+    let mut p = Vec::new();
+    let by_id: HashMap<&str, &Record> = v
+        .records
+        .iter()
+        .filter(|r| r.id != ".")
+        .map(|r| (r.id.as_str(), r))
+        .collect();
+    for r in &v.records {
+        if r.is_bnd() && r.mateid().is_none() {
+            p.push(format!(
+                "line {}: BND with no MATEID — a lone breakend cannot be matched",
+                r.line_no
+            ));
+            continue;
+        }
+        if let Some(mid) = r.mateid() {
+            match by_id.get(mid) {
+                None => p.push(format!(
+                    "line {}: MATEID=`{mid}` resolves to no record ID in this file",
+                    r.line_no
+                )),
+                Some(mate) if mate.mateid() != Some(r.id.as_str()) => p.push(format!(
+                    "line {}: MATEID linkage not reciprocal (-> `{mid}` -> `{:?}`)",
+                    r.line_no,
+                    mate.mateid()
+                )),
+                _ => {}
+            }
+        }
+    }
+    p
+}
+
+/// Position-sorted within each contig — tabix requires it, and unsorted output
+/// broke the cancer merge once already (#185).
+fn check_sorted(v: &Vcf) -> Vec<String> {
+    let mut p = Vec::new();
+    let mut last: HashMap<&str, usize> = HashMap::new();
+    for r in &v.records {
+        if let Some(&prev) = last.get(r.chrom.as_str()) {
+            if r.pos < prev {
+                p.push(format!(
+                    "line {}: POS {} < previous {} on {} (tabix needs sorted input)",
+                    r.line_no, r.pos, prev, r.chrom
+                ));
+            }
+        }
+        last.insert(r.chrom.as_str(), r.pos);
+    }
+    p
+}
+
+/// Column count matches #CHROM, and FORMAT key count matches each SAMPLE's values.
+fn check_columns(v: &Vcf) -> Vec<String> {
+    let mut p = Vec::new();
+    let expected = v.column_header.len();
+    for r in &v.records {
+        let got = 9 + r.samples.len();
+        if expected > 0 && got != expected {
+            p.push(format!(
+                "line {}: {got} columns but #CHROM declares {expected}",
+                r.line_no
+            ));
+        }
+        if r.format.is_empty() || r.format == "." {
+            continue;
+        }
+        let nkeys = r.format.split(':').count();
+        for (i, s) in r.samples.iter().enumerate() {
+            if s.split(':').count() != nkeys {
+                p.push(format!(
+                    "line {}: FORMAT has {nkeys} keys but sample {i} has {} values ({} vs {s})",
+                    r.line_no,
+                    s.split(':').count(),
+                    r.format
+                ));
+            }
+        }
+    }
+    p
+}
+
+fn check_contigs(v: &Vcf) -> Vec<String> {
+    if v.contig_declared.is_empty() {
+        return vec![
+            "header declares no ##contig lines — BCF translation and any tool building a \
+             sequence dictionary from the VCF need them"
+                .to_string(),
+        ];
+    }
+    v.records
+        .iter()
+        .filter(|r| !v.contig_declared.contains(&r.chrom))
+        .map(|r| {
+            format!(
+                "line {}: CHROM `{}` has no ##contig declaration",
+                r.line_no, r.chrom
+            )
+        })
+        .collect()
+}
+
+fn load_reference(path: &Path) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let (mut name, mut seq) = (String::new(), String::new());
+    for line in read_lines(path) {
+        if let Some(h) = line.strip_prefix('>') {
+            if !name.is_empty() {
+                out.insert(name.clone(), std::mem::take(&mut seq));
+            }
+            name = h.split_whitespace().next().unwrap_or("").to_string();
+        } else {
+            seq.push_str(line.trim());
+        }
+    }
+    if !name.is_empty() {
+        out.insert(name, seq);
+    }
+    out
+}
+
+fn report(label: &str, problems: Vec<String>) -> Vec<String> {
+    if !problems.is_empty() {
+        eprintln!("--- {label}: {} problem(s) ---", problems.len());
+        for x in problems.iter().take(20) {
+            eprintln!("  {x}");
+        }
+    }
+    problems
+}
+
+fn golden_vcf(test_name: &str, sv_rate_scale: Option<f64>) -> (Vcf, HashMap<String, String>) {
+    let (_dir, work) = fresh_workdir();
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.clone(), test_name);
+    config.coverage = 20;
+    config.read_len = 101;
+    config.produce_fastq = false;
+    config.produce_vcf = true;
+    config.sv_rate_scale = sv_rate_scale;
+    let yaml = config.write_yaml();
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let path = work.join(format!("{test_name}.vcf.gz"));
+    assert!(path.exists(), "golden VCF not produced at {path:?}");
+    let parsed = parse_vcf(&path);
+    assert!(
+        !parsed.records.is_empty(),
+        "golden VCF has no records — validating an empty file proves nothing"
+    );
+    // Keep the tempdir alive by leaking it: the Vcf is fully parsed into memory, so
+    // the directory can go, but the reference must still be readable.
+    let reference = load_reference(&h1n1_reference());
+    std::mem::forget(_dir);
+    (parsed, reference)
+}
+
+fn validate_all(v: &Vcf, reference: &HashMap<String, String>) -> Vec<String> {
+    let mut p = Vec::new();
+    p.extend(report("INFO declared", check_info_declared(v)));
+    p.extend(report("ALT declared", check_alt_declared(v)));
+    p.extend(report("REF matches reference", check_ref(v, reference)));
+    p.extend(report("MATEID resolves", check_mateid(v)));
+    p.extend(report("sorted", check_sorted(v)));
+    p.extend(report("columns", check_columns(v)));
+    p
+}
+
+#[test]
+fn golden_vcf_without_svs_is_well_formed() {
+    let (v, r) = golden_vcf("vcfval_nosv", None);
+    let p = validate_all(&v, &r);
+    assert!(
+        p.is_empty(),
+        "golden VCF not well formed ({} problem(s)); first: {}",
+        p.len(),
+        p[0]
+    );
+}
+
+/// With SVs the file carries symbolic ALTs, SV INFO fields and BND mate pairs — the
+/// surface where every previous defect lived.
+#[test]
+fn golden_vcf_with_svs_is_well_formed() {
+    let (v, r) = golden_vcf("vcfval_sv", Some(8.0));
+    let svs = v
+        .records
+        .iter()
+        .filter(|x| x.alt.starts_with('<') || x.is_bnd())
+        .count();
+    assert!(svs > 0, "no SV records emitted — test would vacuously pass");
+    let p = validate_all(&v, &r);
+    assert!(
+        p.is_empty(),
+        "golden VCF with SVs not well formed ({} problem(s)); first: {}",
+        p.len(),
+        p[0]
+    );
+}
+
+/// Every BND must be a reciprocal mate pair whose two ALTs name each other's
+/// position. Before #451 the de-novo path emitted a single ID-less breakend.
+#[test]
+fn every_bnd_is_a_reciprocal_mate_pair() {
+    let (v, _r) = golden_vcf("vcfval_bnd", Some(8.0));
+    let bnds: Vec<&Record> = v.records.iter().filter(|r| r.is_bnd()).collect();
+    assert!(
+        !bnds.is_empty(),
+        "no BND records emitted — test would vacuously pass"
+    );
+    assert_eq!(
+        bnds.len() % 2,
+        0,
+        "odd BND count ({}) — a breakend has no mate",
+        bnds.len()
+    );
+    let by_id: HashMap<&str, &Record> = bnds.iter().map(|r| (r.id.as_str(), *r)).collect();
+    for r in &bnds {
+        assert_ne!(r.id, ".", "BND record has no ID: {}", r.raw);
+        let mid = r
+            .mateid()
+            .unwrap_or_else(|| panic!("BND without MATEID: {}", r.raw));
+        let mate = by_id
+            .get(mid)
+            .unwrap_or_else(|| panic!("MATEID={mid} unresolved: {}", r.raw));
+        assert!(
+            r.alt.contains(&format!("{}:{}", mate.chrom, mate.pos)),
+            "BND ALT `{}` does not name its mate at {}:{}",
+            r.alt,
+            mate.chrom,
+            mate.pos
+        );
+    }
+}
+
+/// Missing `##contig` lines are a real interoperability gap — assert on it rather
+/// than leaving it an unstated assumption.
+#[test]
+fn golden_vcf_declares_contigs() {
+    let (v, _r) = golden_vcf("vcfval_contig", None);
+    let p = report("contigs", check_contigs(&v));
+    assert!(p.is_empty(), "contig declarations missing: {}", p[0]);
+}


### PR DESCRIPTION
## Summary

Fixes #451 — and pulling that thread surfaced **three more coupled defects**. Every one was invisible to the test suite for the same reason: the BND tests assert that things *exist* rather than that they are *correct*.

## 1. De-novo BNDs were emitted as a single record (#451)

VCF 4.2 §5.4 represents a novel adjacency as a mate **pair**, one record per breakend, cross-linked by `MATEID`. The sampler emitted one record with `id: None`, no `MATEID`, and a hardcoded `N` in the ALT contradicting the real REF base — unmatchable by any comparison tool.

Now emits both breakends with reciprocal `t]p]` ALTs, deterministic IDs, cross-referencing MATEIDs, and each record's own reference base:

```
H1N1_HA  21   eidolon_bnd_H1N1_HA_21_364_1  T  T]H1N1_HA:364]  SVTYPE=BND;END=21;MATEID=..._2
H1N1_HA  364  eidolon_bnd_H1N1_HA_21_364_2  T  T]H1N1_HA:21]   SVTYPE=BND;END=364;MATEID=..._1
```

Keeping the `t]p]` orientation (the spec's own worked example, `G]17:198982]` ↔ `A]2:321681]`) means **the junction sequence the chimeric read generator builds is unchanged** — `runner.rs` parses the bracket form, and Case 1 vs Case 2 revcomp differently. Only the record representation is fixed.

Verified on a realistic run: 44 junctions, all with exactly 2 records, zero REF/ALT base mismatches against the reference, BCF translation clean.

## 2. The sampling loop was gated on records, not events

`while out.len() < n_sv` would let each BND consume two slots and **halve the number of SVs placed**. Now counts events; for every non-BND type `events == out.len()`, so sampling and the RNG stream are unchanged.

## 3. A BND mate pair double-counted the junction (2× chimeric reads)

The chimeric pass dedupes by a canonicalized `(contig,pos,mate_contig,mate_pos)` key so both sides collapse to one entry — but `location` is **0-based** and `mate_pos` is **1-based**, so the two sides hashed to different keys. Measured:

```
pair.vcf   (both sides, per spec) -> 200 chimeric reads
single.vcf (one side)             -> 100 chimeric reads
```

This already affected anyone supplying paired BNDs via `input_vcf` — the documented way to supply them — and would have silently doubled de-novo BND coverage once fix 1 landed.

## 4. The ID column was hardcoded to `.`

`write_vcf` never emitted `variant.id`, so IDs an input VCF supplied were discarded and `MATEID` references dangled on **both** input-supplied and de-novo breakends. Also adds the missing `##INFO=<ID=MATEID,…>` declaration — an undeclared INFO tag streams fine VCF→VCF but hard-fails BCF translation, the same class as #444.

## Why none of this was caught

`sample_variants_emits_all_supported_types` builds a `HashSet` of seen `SvType`s and asserts BND **appears**. A single unpaired record with a bogus ALT satisfies that. The integration tests (`multi_sv_integration.rs`, `bnd_fastq.rs`) all feed a **hand-written, already-correct pair** via `input_vcf` and assert on the reads — they never exercise model → truth-VCF. And `bnd_inv_double_count.rs`, despite its name, tested only INV and DEL.

Telling detail: before adding tests, these four changes altered the golden VCF's ID column, added a header line, and doubled de-novo BND records — and the full suite stayed green.

## Tests added — each verified to fail against the old behavior

- `denovo_bnd_emits_a_cross_linked_mate_pair` — pairing, unique IDs, reciprocal MATEID *resolution*, ALT base == REF base, `mate_pos` pointing at the mate's location
- `bnd_pair_counts_as_one_event_toward_n_sv` — the event-vs-record gate
- `bnd_mate_pair_does_not_double_the_junction_reads` — reverting fix 3 makes it fail with `paired=200, single=100`
- `test_write_vcf_emits_the_record_id_column`, plus a MATEID-declaration assertion

## Breaking output change

BND-containing truth VCFs now carry two records per junction and a populated ID column. Under the v3.0.0 SemVer policy the emitted VCF format is public API, so this is a MAJOR-visible change — it should land **in** v3.0.0 rather than after it, which is the argument for holding #445 until this merges.

## Known edge

At absurd SV density (`sv_rate_scale=400`, ~2400 junctions on a 13 kb genome) one junction came out unpaired — mate positions are not registered in the overlap `occupied` list, so two junctions can collide on a breakend and hence on an ID. Not reproducible at realistic rates (44/44 clean). Registering mates in `occupied` would change the sampling RNG stream and move every SV baseline, so it's deliberately left out of this fix; worth a follow-up decision.

## Testing

Full workspace suite green (27 groups, 0 failures); `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
