### PR TITLE
fix(delta): fail loudly on an empty truth set; stop mis-prefixing accession-named references

### DIFF
--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -359,7 +359,16 @@ if [[ ! -f "$SCORE_TRUTH" ]]; then
 fi
 somatic_count=$(bcftools view -H "$SCORE_TRUTH" | wc -l)
 echo "      Somatic truth records: $somatic_count"
-[[ "$somatic_count" -eq 0 ]] && echo "WARNING: no somatic truth records — check EIDOLON_ORIGIN." >&2
+if [[ "$somatic_count" -eq 0 ]]; then
+    echo "ERROR: no somatic truth records after filtering with:" >&2
+    echo "         INFO/EIDOLON_ORIGIN=\"somatic\"" >&2
+    echo "  Scoring against an empty truth would report every caller as 0 recall with" >&2
+    echo "  no indication why, so this is fatal. Check INFO/EIDOLON_ORIGIN is present" >&2
+    echo "  in $TRUTH_VCF (pre-v3.0.0 truth VCFs use NEAT_ORIGIN — convert with" >&2
+    echo "  tools/migrate_legacy_tokens.sh), or that the tumor pass planted somatic" >&2
+    echo "  variants at all (raise TUMOR_MUTATION_RATE / coverage)." >&2
+    exit 1
+fi
 [[ -f "$HAPPY_SIF" ]] || { echo "hap.py SIF not found: $HAPPY_SIF — run setup.sh first" >&2; exit 1; }
 
 # hap.py/som.py hardcodes UCSC chr-prefixing of input VCFs (perl s/^([0-9XYM])/chr/),
@@ -369,7 +378,13 @@ echo "      Somatic truth records: $somatic_count"
 # chr-prefixed copy for scoring so the renamed VCFs match. (chr22.fa etc. pass
 # through unchanged.) Alignment/Mutect2 already used $REFERENCE as-is — unaffected.
 SCORE_REF_DIR="$REF_DIR"; SCORE_REF_NAME="$REF_NAME"
-if ! head -1 "${REFERENCE}.fai" 2>/dev/null | grep -q '^chr'; then
+# Only build the chr-prefixed copy when som.py will ACTUALLY rename the VCF contigs.
+# Its perl is `s/^([0-9XYM])/chr/`, so it renames 1/2/X/Y/MT but leaves anything else
+# alone — including GenBank accession names (CM000851.4, soybean). Keying off "not
+# chr-prefixed" lumped those in with Ensembl-numeric and prefixed the REFERENCE while
+# som.py left the VCF unprefixed, so scoring died with a contig mismatch
+# ("Error running BCFTOOLS ... vcfcheck") on a reference that needed no help at all.
+if head -1 "${REFERENCE}.fai" 2>/dev/null | grep -qE '^[0-9XYM]'; then
     SCORE_REF="${REFERENCE%.fa}.chr.fa"
     if [[ ! -f "$SCORE_REF" ]]; then
         echo "[6/6] Reference is Ensembl-named; building chr-prefixed copy for som.py..."

--- a/tools/cancer_benchmark.sh
+++ b/tools/cancer_benchmark.sh
@@ -321,8 +321,12 @@ if [[ -n "$TRUTH_FILTER" ]]; then
     filtered_count=$(run_in "$BCFTOOLS_IMG" sh -c \
         "bcftools view -H '/work/$SCORING_TRUTH_NAME' | wc -l" | tr -d '\r\n')
     if [[ "$filtered_count" == "0" ]]; then
-        echo "WARNING: truth filter '$TRUTH_FILTER' matched zero records." >&2
+        # Fatal, not a warning: scoring against an empty truth reports every caller as
+        # 0 recall and looks like a caller failure rather than a filter mistake.
+        echo "ERROR: truth filter '$TRUTH_FILTER' matched zero records." >&2
+        echo "  Refusing to score against an empty truth set." >&2
         echo "  If your truth VCF doesn't have INFO/EIDOLON_ORIGIN, pass --truth-filter ''" >&2
+        exit 1
     else
         echo "    Filtered truth: $filtered_count records retained."
     fi

--- a/tools/cancer_sv_benchmark.sh
+++ b/tools/cancer_sv_benchmark.sh
@@ -324,9 +324,14 @@ else
         filtered_count=$(run_in "$BCFTOOLS_IMG" sh -c \
             "bcftools view -H '/work/$SCORING_TRUTH_NAME' | wc -l" | tr -d '\r\n')
         if [[ "$filtered_count" == "0" ]]; then
-            echo "WARNING: truth filter matched zero SV records." >&2
+            # Fatal, not a warning: truvari against an empty truth yields recall=0 for
+            # every caller, which reads as a caller/simulator problem rather than a
+            # filter mistake.
+            echo "ERROR: truth filter matched zero SV records." >&2
+            echo "  Refusing to score against an empty truth set." >&2
             echo "  If your truth VCF doesn't carry SVs (or doesn't have INFO/EIDOLON_ORIGIN)," >&2
             echo "  pass --truth-filter '' or a custom expression." >&2
+            exit 1
         else
             echo "    Filtered truth: $filtered_count SV records retained."
         fi


### PR DESCRIPTION
## Summary

Two harness defects of the "reports success over nothing" class. **The second one is the cause of the som.py failure in the t5_cancer run** — it is a harness bug, not a data bug.

## 1. chr-prefixing broke GenBank-accession references — the t5_cancer failure

som.py hardcodes UCSC-style renaming of the input VCF's contigs via `perl s/^([0-9XYM])/chr/`, so `cancer_pipeline.sbatch` builds a chr-prefixed copy of the reference to keep the two in sync. But it keyed that decision off *"the reference is not already chr-prefixed"*, which lumps three distinct cases together:

| contig names | som.py renames the VCF? | reference needs prefixing? |
|---|---|---|
| `1`, `2`, `X`, `MT` | yes | **yes** — the case the workaround was written for |
| `chr1`, `chr2` | no (already prefixed) | no — handled |
| `CM000851.4`, … | **no** — doesn't match `^[0-9XYM]` | **no** — but it was prefixed anyway |

The third case is a GenBank accession assembly — soybean Wm82 fetched from NCBI GCA, i.e. the reference `fetch_validation_data.sh` produces. The script prefixed the reference to `>chrCM000851.4` while som.py left the VCF at `CM000851.4`, and scoring died with:

```
Error running BCFTOOLS; please check your file for compatibility issues using vcfcheck
```

…on a reference that needed no help at all.

Now keys off `^[0-9XYM]` — the same pattern som.py itself uses — so accession-named references pass through untouched.

**Worth noting the failure shape**: alignment and Mutect2 both used `$REFERENCE` as-is and succeeded (16.8 minutes of Mutect2), so the run looked healthy right up to the final step, and the error names *bcftools* rather than the contig mismatch that caused it. Diagnostics confirmed the truth VCF itself is fine — `bcftools view -O b` succeeds, `bcftools norm` reports `0 mismatch_removed`, and the only symbolic records are `<DUP>`/`<INV>`/`<DEL>` with no BND involved.

## 2. An empty truth set now aborts instead of warning

Three sites counted the filtered truth, printed `WARNING` on zero, and carried on to score against it — which reports every caller as 0 recall and reads as a caller or simulator problem rather than a filter mistake:

- `scripts/delta/cancer_pipeline.sbatch` (`somatic_count -eq 0`)
- `tools/cancer_benchmark.sh` (`filtered_count == 0`)
- `tools/cancer_sv_benchmark.sh` (`filtered_count == 0`, SV subset)

All three now `exit 1` with a message naming the filter expression and the likely causes — including that a **pre-v3.0.0 truth VCF uses `NEAT_ORIGIN`** and needs `tools/migrate_legacy_tokens.sh`.

`sv_pipeline.sbatch:222` already did this correctly and was the model.

## Not addressed here

The broader finding from the audit: nearly every harness guard is a `wc -l` compared against 0, so *quantity* is checked and *content* almost never is. That is how the `AF=AF=0.3000` bug passed a `nsom > 0` guard. The durable fix is probably to expose the new `vcf_validation.rs` logic as an `eidolon validate-vcf` subcommand so harnesses get one content-level gate instead of growing more bash checks — a design proposal, not bundled here.

## Testing

`bash -n` clean on all three files. No Rust changes.

Recommended verification once merged: re-run `cancer_pipeline.sbatch` on the same soy reference — it should now reach scoring. That is also the regression test for defect 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
