### PR TITLE
fix(delta): guard OUTDIR reuse against a binary-version change

### DIFF
--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -114,8 +114,12 @@ MERGED_R1="${PREFIX}_merged_r1.fastq.gz"
 NORMAL_R1="${PREFIX}_normal_r1.fastq.gz"
 TRUTH_VCF="${PREFIX}_merged_truth.vcf.gz"
 
+# Refuse to score fresh caller output against a truth VCF written by a different
+# build of eidolon (see lib_report.sh::check_outdir_version).
+check_outdir_version "$EIDOLON_BIN" "$OUTDIR" || exit 1
+
 SIM_REGENERATED=0
-if [[ -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then
+if [[ "$FORCE_RESIM" == "0" && -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then
     echo "[1/6] Simulation outputs already present — skipping."
 else
     echo "[1/6] Simulating tumor/normal reads..."
@@ -141,6 +145,7 @@ else
         $PAIRED_FLAG
     echo "[1/6] Simulation complete."
     SIM_REGENERATED=1
+    stamp_outdir_version "$OUTDIR"
 fi
 
 # ── Stage 2 & 3: Index reference, align FASTQs ──────────────────────────

--- a/scripts/delta/lib_report.sh
+++ b/scripts/delta/lib_report.sh
@@ -159,3 +159,55 @@ archive_run() {
 
     echo "[archive] $kind -> $dest  (core_hours=${core_hours:-0.0}, files: $*)"
 }
+
+# ── OUTDIR provenance guard ─────────────────────────────────────────────────
+# Reusing an OUTDIR across a rebuild silently mixes artifacts from two code
+# versions: fresh caller VCFs scored against a truth VCF written by the OLD
+# binary. The per-script "simulation regenerated — invalidating stale downstream
+# outputs" logic only fires when the simulation RE-RUNS, so nothing catches the
+# inverse (new binary, skipped simulation). That is a wrong answer with no
+# warning, which is the failure mode this repo keeps hitting.
+#
+# check_outdir_version sets EIDOLON_VERSION and FORCE_RESIM (0/1).
+# Call it before the simulation stage; call stamp_outdir_version after a
+# successful simulation.
+check_outdir_version() {
+    local bin="$1" outdir="$2"
+    EIDOLON_VERSION="$("$bin" --version 2>/dev/null | tr -d '\r\n')"
+    if [[ -z "$EIDOLON_VERSION" ]]; then
+        echo "ERROR: could not read '$bin --version' — is it built?" >&2
+        return 1
+    fi
+    FORCE_RESIM=0
+    local stamp="$outdir/.eidolon_version"
+    if [[ ! -f "$stamp" ]]; then
+        # No stamp: either a fresh OUTDIR, or one predating this guard. If it
+        # already holds simulation outputs we cannot know what produced them —
+        # say so rather than assume, but don't force an expensive redo of a
+        # legacy directory the user may know is fine.
+        if compgen -G "$outdir"/*_merged_truth.vcf.gz >/dev/null 2>&1; then
+            echo "WARNING: $outdir has simulation outputs but no .eidolon_version stamp," >&2
+            echo "         so their provenance is unknown. If they predate your last" >&2
+            echo "         rebuild, the truth VCF and the caller inputs come from" >&2
+            echo "         different code. Use a fresh OUTDIR if in doubt." >&2
+        fi
+        return 0
+    fi
+    local prev
+    prev="$(tr -d '\r\n' < "$stamp")"
+    [[ "$prev" == "$EIDOLON_VERSION" ]] && return 0
+    if [[ "${ALLOW_VERSION_MISMATCH:-0}" == "1" ]]; then
+        echo "WARNING: $outdir was built by '$prev' but this binary is" >&2
+        echo "         '$EIDOLON_VERSION'; ALLOW_VERSION_MISMATCH=1 — reusing anyway." >&2
+        return 0
+    fi
+    echo "  OUTDIR was built by '$prev' but this binary is '$EIDOLON_VERSION'."
+    echo "  Regenerating the simulation so the truth VCF and the caller inputs come"
+    echo "  from the same code. Set ALLOW_VERSION_MISMATCH=1 to reuse as-is."
+    FORCE_RESIM=1
+    return 0
+}
+
+stamp_outdir_version() {
+    printf '%s\n' "$EIDOLON_VERSION" > "$1/.eidolon_version"
+}

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -114,7 +114,11 @@ MERGED_R1="${PREFIX}_merged_r1.fastq.gz"
 NORMAL_R1="${PREFIX}_normal_r1.fastq.gz"
 TRUTH_VCF="${PREFIX}_merged_truth.vcf.gz"
 
-if [[ -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then
+# Refuse to score fresh caller output against a truth VCF written by a different
+# build of eidolon (see lib_report.sh::check_outdir_version).
+check_outdir_version "$EIDOLON_BIN" "$OUTDIR" || exit 1
+
+if [[ "$FORCE_RESIM" == "0" && -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then
     echo "[1/5] Simulation outputs already present — skipping."
 else
     echo "[1/5] Simulating SV-rich tumor/normal reads..."
@@ -133,6 +137,7 @@ else
         --eidolon-bin "$EIDOLON_BIN" \
         $PAIRED_FLAG
     echo "[1/5] Simulation complete."
+    stamp_outdir_version "$OUTDIR"
 fi
 
 # ── Stage 2 & 3: Index reference, align ──────────────────────────────────


### PR DESCRIPTION
## Summary

Reusing an OUTDIR across a rebuild silently mixes artifacts from two code versions: fresh caller VCFs scored against a truth VCF written by the **old** binary.

The existing `"Simulation regenerated — invalidating stale downstream outputs"` logic only fires when the simulation **re-runs**. Nothing caught the inverse — new binary, simulation skipped because its outputs already exist. That produces a wrong answer with no warning, which is the failure mode this repo keeps hitting.

Surfaced concretely: a `cancer_pipeline.sbatch` run was launched against an existing OUTDIR after merging #453 (which changed the SV emitter) without rebuilding. Had the rebuild happened, the run would have scored new calls against an old-emitter truth and reported plausible numbers.

## Implementation

`check_outdir_version` / `stamp_outdir_version` live in `lib_report.sh` — both pipelines already source it, so the logic isn't duplicated. The simulation stage stamps `$OUTDIR/.eidolon_version`; re-entry compares and forces regeneration on a mismatch, which cascades through the invalidation that already exists.

| situation | behaviour |
|---|---|
| fresh OUTDIR | proceed |
| stamp matches | reuse — the common case, silent |
| stamp differs | **force resim**, explaining why |
| differs + `ALLOW_VERSION_MISMATCH=1` | reuse with a warning |
| outputs but no stamp | warn that provenance is unknown; does *not* force a redo |
| binary unreadable/unbuilt | `exit 1` — "is it built?" |

All six paths exercised against a stub binary before committing.

## Design notes

**Force-regeneration rather than refusing**, so a re-run is self-correcting — matching the script's existing idempotent-but-self-invalidating idiom. The `ALLOW_VERSION_MISMATCH=1` escape hatch covers a rebuild the user knows is output-neutral (a docs or harness change), where redoing ~17 minutes of Mutect2 would be pure waste.

**The no-stamp case only warns.** Provenance genuinely cannot be determined for a directory predating this guard, and forcing a redo would penalise every existing OUTDIR — including the ones in flight right now. It names the risk and points at the remedy (use a fresh OUTDIR) rather than guessing.

The guard also catches the plainer mistake of *forgetting* to rebuild, since a stale binary reports its own older version.

## Testing

`bash -n` clean on `lib_report.sh`, `cancer_pipeline.sbatch`, `sv_pipeline.sbatch`. No Rust changes, so the Rust suite is unaffected.

Note for the first run after this merges: existing OUTDIRs have no stamp, so you'll see the provenance-unknown warning once. A fresh OUTDIR, or a run that regenerates the simulation, lays down the stamp and the warning stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
