### PR TITLE
fix(delta): lock OUTDIR and the shared bwa-mem2 index against concurrent jobs

### DIFF
--- a/scripts/delta/cancer_pipeline.sbatch
+++ b/scripts/delta/cancer_pipeline.sbatch
@@ -99,6 +99,9 @@ setup_conda
 conda_activate bioinf   # provides bwa-mem2, gatk4, bcftools (not available as modules)
 
 mkdir -p "$OUTDIR"
+# Refuse to run concurrently in an OUTDIR another job already owns —
+# interleaved writes yield results computed from corrupted intermediates.
+lock_outdir "$OUTDIR" || exit 1
 REF_DIR="$(dirname "$REFERENCE")"
 REF_NAME="$(basename "$REFERENCE")"
 
@@ -174,16 +177,10 @@ index_and_align() {
         return 0
     fi
 
-    # Index reference once (idempotent). Guard on -s, not -f: a build killed
-    # mid-write leaves a 0-byte .bwt.2bit.64 that -f treats as present, poisoning
-    # every later run (bwa-mem2: "Unexpected end of file"). -s rebuilds on empty.
-    if [[ ! -s "${REFERENCE}.bwt.2bit.64" ]] && [[ ! -s "${REFERENCE}.bwt" ]]; then
-        echo "  Indexing reference for BWA-MEM2 (one-time, ~2 min)..."
-        bwa-mem2 index "$REFERENCE" 2>&1 | tail -3
-    fi
-    if [[ ! -f "${REFERENCE}.fai" ]]; then
-        samtools faidx "$REFERENCE"
-    fi
+    # Index reference once, serialized so concurrent jobs can't race the shared
+    # index. The -s (not -f) guard against a 0-byte .bwt.2bit.64 from a build
+    # killed mid-write lives in index_reference_locked (lib_report.sh).
+    index_reference_locked "$REFERENCE"
 
     echo "  Aligning $sample..."
     local rg="@RG\tID:${sample}\tSM:${sample}\tLB:${sample}\tPL:ILLUMINA"

--- a/scripts/delta/lib_report.sh
+++ b/scripts/delta/lib_report.sh
@@ -211,3 +211,64 @@ check_outdir_version() {
 stamp_outdir_version() {
     printf '%s\n' "$EIDOLON_VERSION" > "$1/.eidolon_version"
 }
+
+# ── OUTDIR concurrency lock ─────────────────────────────────────────────────
+# Two jobs pointed at one OUTDIR silently interleave their writes — the same
+# FASTQ, BAM, truth-VCF and caller-output paths — and still produce numbers,
+# derived from corrupted intermediates. Observed with SLURM jobs 20635663 and
+# 20636020, which both simulated into $SCRATCH/t6_sv_v3 concurrently; neither
+# reported anything wrong.
+#
+# The lock is held for the life of the job because fd 9 stays open. flock is
+# released by the kernel when the holder exits, so a killed job leaves NO stale
+# lock to clean up — the lockfile persisting on disk is harmless.
+lock_outdir() {
+    local outdir="$1" lockfile="$1/.lock"
+    mkdir -p "$outdir"
+    # <> not > : opening for write would TRUNCATE the holder's identity before we
+    # even try to acquire, so a rejected job couldn't report who has it.
+    if ! exec 9<>"$lockfile"; then
+        echo "ERROR: cannot open lock file $lockfile" >&2
+        return 1
+    fi
+    if ! flock -n 9; then
+        local holder
+        holder="$(tr -d '\r' < "$lockfile" 2>/dev/null | head -1)"
+        echo "ERROR: another job is already running in $outdir" >&2
+        echo "       held by: ${holder:-<unknown>}" >&2
+        echo "  Concurrent runs sharing an OUTDIR interleave their writes and yield" >&2
+        echo "  results computed from corrupted intermediates — with no warning." >&2
+        echo "  Use a different OUTDIR, or wait for that job to finish." >&2
+        return 1
+    fi
+    printf 'SLURM job %s on %s since %s\n' \
+        "${SLURM_JOB_ID:-manual}" "$(hostname)" "$(date -Is 2>/dev/null || date)" \
+        > "$lockfile"
+    return 0
+}
+
+# Serialize the shared bwa-mem2 index build. Two jobs that both see no index will
+# both run `bwa-mem2 index` against the SAME path and interleave writes, poisoning
+# it for both — the 0-byte .bwt.2bit.64 state the call sites already guard against
+# after the fact. Blocking lock: the second job waits, then finds the index present
+# and skips. Degrades to the unlocked check if the reference dir isn't writable.
+index_reference_locked() {
+    local ref="$1"
+    if exec 8<>"${ref}.index.lock" 2>/dev/null; then
+        flock 8
+        if [[ ! -s "${ref}.bwt.2bit.64" ]] && [[ ! -s "${ref}.bwt" ]]; then
+            echo "  Indexing reference for BWA-MEM2 (one-time, lock held)..."
+            bwa-mem2 index "$ref" 2>&1 | tail -3
+        fi
+        flock -u 8
+        exec 8>&-
+    else
+        echo "  NOTE: cannot create ${ref}.index.lock (read-only dir?) — indexing" >&2
+        echo "        unserialized; do not run concurrent jobs against a fresh reference." >&2
+        if [[ ! -s "${ref}.bwt.2bit.64" ]] && [[ ! -s "${ref}.bwt" ]]; then
+            echo "  Indexing reference for BWA-MEM2 (one-time)..."
+            bwa-mem2 index "$ref" 2>&1 | tail -3
+        fi
+    fi
+    [[ -f "${ref}.fai" ]] || samtools faidx "$ref"
+}

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -99,6 +99,9 @@ module load htslib/1.22-gcc13.3.1
 setup_conda
 
 mkdir -p "$OUTDIR"
+# Refuse to run concurrently in an OUTDIR another job already owns —
+# interleaved writes yield results computed from corrupted intermediates.
+lock_outdir "$OUTDIR" || exit 1
 REF_NAME="$(basename "$REFERENCE")"
 
 echo "=== eidolon SV validation pipeline: $SLURM_JOB_ID ==="
@@ -152,11 +155,8 @@ index_and_align() {
     # Guard on -s, not -f: a build killed mid-write leaves a 0-byte .bwt.2bit.64
     # that -f treats as present, poisoning every later run (bwa-mem2: "Unexpected
     # end of file"). -s rebuilds on empty/missing.
-    if [[ ! -s "${REFERENCE}.bwt.2bit.64" ]] && [[ ! -s "${REFERENCE}.bwt" ]]; then
-        echo "  Indexing reference for BWA-MEM2 (one-time)..."
-        bwa-mem2 index "$REFERENCE" 2>&1 | tail -3
-    fi
-    [[ -f "${REFERENCE}.fai" ]] || samtools faidx "$REFERENCE"
+    # Serialized: concurrent jobs must not race the shared index (lib_report.sh).
+    index_reference_locked "$REFERENCE"
     echo "  Aligning $sample..."
     local rg="@RG\tID:${sample}\tSM:${sample}\tLB:${sample}\tPL:ILLUMINA"
     if [[ "$PAIRED" == "true" ]]; then


### PR DESCRIPTION
## Summary

Two jobs pointed at one OUTDIR silently interleave their writes — the same FASTQ, BAM, truth-VCF and caller-output paths — and still produce plausible numbers, computed from corrupted intermediates.

Observed live: SLURM jobs **20635663** and **20636020** both simulated into `$SCRATCH/t6_sv_v3` concurrently. Neither printed "Simulation outputs already present", so both ran the simulation into the same paths. Neither reported anything wrong; both archived results. Two node-hours, unusable output, no signal.

The #455 version guard catches *stale* artifacts. It does not catch *concurrent writers*.

## Two locks, in `lib_report.sh`

**`lock_outdir`** — non-blocking `flock` on `$OUTDIR/.lock`, held for the life of the job. A second job exits immediately naming the holder rather than corrupting the first:

```
ERROR: another job is already running in /scratch/.../od
       held by: SLURM job 111 on cn012 since 2026-07-30T21:44:00-05:00
  Concurrent runs sharing an OUTDIR interleave their writes and yield
  results computed from corrupted intermediates — with no warning.
```

Subtlety worth reviewing: the lockfile is opened `<>` rather than `>`. Opening for write would **truncate the holder's identity before `flock` is even attempted**, so a rejected job could not report who owns it.

**`index_reference_locked`** — blocking `flock` around the shared `bwa-mem2 index` build. Two jobs that both see no index would otherwise both build against the same path and interleave writes, poisoning it for both — the 0-byte `.bwt.2bit.64` state the call sites already guarded for *after the fact*. The second job now waits, then finds the index present and skips. Degrades to the unlocked check with a warning if the reference directory isn't writable.

This also replaces the duplicated inline index blocks in both pipelines, so the `-s`-not-`-f` guard lives in one place.

## Verified, not assumed

- first job acquires; second is refused with `exit 1` and names the holder
- after the holder exits normally, a new job acquires — no cleanup step
- after `kill -9` of the holder, a new job **still** acquires: `flock` is released by the kernel, so a crashed job leaves no stale lock. That's why there's no unlink dance — a persisting lockfile is harmless.

## Testing

`bash -n` clean on `lib_report.sh`, `cancer_pipeline.sbatch`, `sv_pipeline.sbatch`. No Rust changes.

One behavioural note: a job that legitimately wants to resume an interrupted OUTDIR still works, because the previous job's lock died with it. The lock only rejects a *live* concurrent holder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
