### PR TITLE
docs: name both archive roots — the rename split the results directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,15 @@ Hand-written guidance below; the GitNexus block that follows is auto-generated
 ## Delta / HPC (`scripts/delta/`)
 - Real-data validation runs on **NCSA Delta** (SLURM, account `bhrd-delta-cpu`). The
   cluster filesystem is **not reachable from this workstation** — the user runs jobs
-  and pastes results; artifacts archive to `/projects/bhrd/jallen17/eidolon-access-results/`.
+  and pastes results. Artifacts archive to **two** roots — the project was renamed
+  partway through, so Phase 1 / pre-v2.0.0 runs are under
+  `/projects/bhrd/jallen17/rneat-access-results/` (germline, cancer, sv, benchmark,
+  baseline, tune, threadscale, ppn, modelbuild — the corpus behind the ACCESS report's
+  §3.1–3.11) and v2.0.0-onward runs under
+  `/projects/bhrd/jallen17/eidolon-access-results/`. `lib_report.sh` writes only to the
+  latter (`RESULTS_DIR`, overridable), and `collect_report.sh` scans one root at a time —
+  so pass `RESULTS_DIR=` explicitly when looking for historical runs, or you will
+  conclude they are missing.
 - Staging: `fetch_validation_data.sh` (references), `stage_soy.sh` (align + call a
   self-consistent ref/BAM/VCF; `FULL_GENOME=1` for the whole-genome stress vs the
   fast single-chromosome default). `model_builders.sbatch` exercises the builders.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,15 @@ contributed the *fragility* (see the footguns below), not the blind spots.
 ## Delta / HPC (`scripts/delta/`)
 - Real-data validation runs on **NCSA Delta** (SLURM, account `bhrd-delta-cpu`). The
   cluster filesystem is **not reachable from this workstation** — the user runs jobs
-  and pastes results; artifacts archive to `/projects/bhrd/jallen17/eidolon-access-results/`.
+  and pastes results. Artifacts archive to **two** roots — the project was renamed
+  partway through, so Phase 1 / pre-v2.0.0 runs are under
+  `/projects/bhrd/jallen17/rneat-access-results/` (germline, cancer, sv, benchmark,
+  baseline, tune, threadscale, ppn, modelbuild — the corpus behind the ACCESS report's
+  §3.1–3.11) and v2.0.0-onward runs under
+  `/projects/bhrd/jallen17/eidolon-access-results/`. `lib_report.sh` writes only to the
+  latter (`RESULTS_DIR`, overridable), and `collect_report.sh` scans one root at a time —
+  so pass `RESULTS_DIR=` explicitly when looking for historical runs, or you will
+  conclude they are missing.
 - Staging: `fetch_validation_data.sh` (references), `stage_soy.sh` (align + call a
   self-consistent ref/BAM/VCF; `FULL_GENOME=1` for the whole-genome stress vs the
   fast single-chromosome default). `model_builders.sbatch` exercises the builders.

--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -898,4 +898,9 @@ constraint.
 
 _Run-level metrics and provenance for every job (version, git commit, reference,
 core-hours) are archived under the project results directory and assembled by
-`scripts/delta/collect_report.sh`._
+`scripts/delta/collect_report.sh`. Note the archive spans **two roots** because the
+project was renamed `rusty-neat`/`rneat` → `eidolon` partway through (v2.0.0): Phase 1
+runs — everything backing §3.1–§3.11 — are under
+`/projects/bhrd/jallen17/rneat-access-results/`, while runs from v2.0.0 onward are under
+`/projects/bhrd/jallen17/eidolon-access-results/`. Each job directory records its own
+version and git commit, so provenance is per-run regardless of which root holds it._


### PR DESCRIPTION
## Summary

The v2.0.0 rename updated `lib_report.sh`'s `RESULTS_DIR` default to `eidolon-access-results`, so runs from v2.0.0 onward archive there while **every Phase 1 run stayed under `rneat-access-results`**. Nothing documented the split, and three places asserted a single root.

## Why it matters

`eidolon-access-results/` currently holds four sparse directories. `rneat-access-results/` holds the entire Phase 1 corpus — germline (73), cancer (62), sv (29), plus baseline, tune, benchmark, threadscale, ppn, modelbuild, and a `REPORT.md`.

So a reviewer following the ACCESS report's provenance pointer would look in the wrong place and conclude the evidence behind §3.1–3.11 is missing. That's the one assertion in the report a reader can independently check.

The misdirection isn't hypothetical: it's why a search for archived pre-rename truth VCFs came up empty earlier in this cycle and was briefly taken for data loss. **Nothing was lost.**

## Changes

- **`docs/access_report_draft.md`** — the closing provenance note now names both roots, explains the rename, and points out that each job directory records its own version and git commit, so provenance is per-run regardless of which root holds it.
- **`CLAUDE.md` / `AGENTS.md`** — same, plus the operational trap: `collect_report.sh` scans **one root at a time**, so `RESULTS_DIR=` must be passed explicitly to reach historical runs or you'll conclude they're absent.

Docs only; no code or behaviour change.

## On merging the two roots

Worth doing, and I'd lean yes — but it's a filesystem operation on ~1 GB that I can't reach, so it's deliberately not part of this PR. The case for it is stronger than cosmetics: **`collect_report.sh:14` scans a single `RESULTS_DIR`**, so the tool that assembles the report's provenance table cannot currently see the runs that back most of the report.

Two objections I checked and cleared:
- *Would a rename break citations?* No. A repo-wide grep finds **zero** references to `rneat-access-results`, and the report says only "the project results directory".
- *Does the directory name carry provenance worth keeping?* Not uniquely — each job directory already records its version and commit, so merging loses nothing.

If you do merge, prefer `rsync` → verify → delete over `mv`, so an interruption leaves both copies rather than a half-moved tree:

```bash
SRC=/projects/bhrd/jallen17/rneat-access-results
DST=/projects/bhrd/jallen17/eidolon-access-results
rsync -av --ignore-existing "$SRC"/ "$DST"/          # job_<id> dirs are unique; no collisions expected
diff <(cd "$SRC" && find . | sort) <(cd "$DST" && find . | sort) | grep '^<'   # must be empty
# only then remove $SRC
```

After merging, this PR's doc text collapses to a single path plus a one-line historical note — happy to follow up with that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
