### PR TITLE
chore(conda-recipe): bump to v3.0.0 + sha256

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "eidolon" %}
-{% set version = "2.0.0" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   url: https://github.com/ncsa/eidolon/archive/refs/tags/v{{ version }}.tar.gz
   # Update on each release:
   #   curl -sL https://github.com/ncsa/eidolon/archive/refs/tags/v{{ version }}.tar.gz | sha256sum
-  sha256: 288c80e1b9eafbd9579ad614d046a48e7a95e083539a499548078118e62b064a
+  sha256: 72db57a181255efb983c06d87e6e2d43a58cced61cee01a15cad2f7d3ffaa01e
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

Post-tag conda recipe bump for v3.0.0, following the established pattern — the recipe's `sha256` needs the published release tarball, so it can't land with the version bump itself (same sequencing as `0aacf6f` for v2.0.0 and the equivalent commits for 1.21.1 / 1.21.0 / 1.20.x).

```
version: 2.0.0 -> 3.0.0
sha256:  72db57a181255efb983c06d87e6e2d43a58cced61cee01a15cad2f7d3ffaa01e
```

## Checksum provenance

Verified against the right artifact rather than just fetched and pasted:

- the `v3.0.0` tag resolves to **`af39e73`**, identical to `origin/main` HEAD
- the tarball's root directory is `eidolon-3.0.0/` and its `Cargo.toml` reads `version = '3.0.0'`
- it contains both `tools/migrate_legacy_tokens.sh` and `eidolon/tests/vcf_validation.rs`, so it is the v3 tree — not a stale tag or one cut before those landed

That last check matters more than usual here: a tag placed a commit or two early would still produce a plausible tarball and a valid-looking checksum.

## Unchanged and still correct

- `build.number: 0` — resets on a version change, already 0
- `run_exports` `max_pin="x.x"` — correct across a major bump

## Note

This updates the in-repo reference copy of the recipe. Submitting the corresponding bioconda PR against `bioconda-recipes` is a separate step outside this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
