### PR TITLE
fix(compare-vcfs): inherit header declarations from the source VCF (#444)

### DIFF
--- a/eidolon/src/compare_vcfs/utils/runner.rs
+++ b/eidolon/src/compare_vcfs/utils/runner.rs
@@ -255,10 +255,13 @@ pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
     // Write per-record VCF artifacts before the JSON/TXT report so the
     // report's `outputs` section can name them. FN_with_reasons.vcf is
     // always written; FP.vcf is gated on the config flag.
+    // Each artifact inherits declarations from the VCF ITS records came from:
+    // FNs are golden-VCF records, FPs are called-VCF records (#444).
     let fn_vcf_path = write_fn_with_reasons(
         &attribution_result,
         &config.output_dir,
         config.overwrite_output,
+        &config.golden_vcf,
     )?;
     info!("Wrote {}", fn_vcf_path.display());
 
@@ -269,7 +272,12 @@ pub fn runner(config: &RunConfiguration) -> Result<(), CompareVcfsError> {
                 fp_pairs.push((chrom.clone(), v));
             }
         }
-        let p = write_fp_vcf(&fp_pairs, &config.output_dir, config.overwrite_output)?;
+        let p = write_fp_vcf(
+            &fp_pairs,
+            &config.output_dir,
+            config.overwrite_output,
+            &config.called_vcf,
+        )?;
         info!("Wrote {}", p.display());
         Some(p)
     } else {

--- a/eidolon/src/compare_vcfs/utils/vcf_writer.rs
+++ b/eidolon/src/compare_vcfs/utils/vcf_writer.rs
@@ -7,26 +7,138 @@
 //!     `write_fp_vcf` in the config because some pipelines accumulate
 //!     large FP sets and the user may not want the extra artifact.
 //!
-//! Both writers emit minimal VCFv4.2 headers and reuse the original
-//! Variant's per-column data (ID, QUAL, FILTER, INFO, FORMAT, SAMPLE).
-//! We do **not** preserve the source VCF's `##contig=` lines because
-//! that would require re-reading the input header; downstream tools that
-//! need it can re-create from the reference FASTA.
+//! Both writers reuse the original Variant's per-column data (ID, QUAL, FILTER,
+//! INFO, FORMAT, SAMPLE), and therefore **inherit the declaration lines from the
+//! VCF those records came from** (#444).
+//!
+//! An earlier version emitted a fixed minimal header, on the reasoning that
+//! re-reading the input header was avoidable and "downstream tools that need
+//! `##contig` can re-create it from the reference FASTA". That does not hold: a
+//! record's INFO column is passed through verbatim, so the artifact carried tags
+//! its own header never declared, and no downstream tool can invent a declaration
+//! for a tag it has never seen. bcftools tolerates that streaming VCF→VCF but
+//! **hard-fails on BCF translation** — which `bcftools concat | sort` does
+//! internally — so it surfaced far downstream as an opaque failure.
+//!
+//! A fixed declaration set cannot work either, because the two artifacts have
+//! different provenance: FN records come from the **golden** VCF, while FP records
+//! come from the **called** VCF, whose INFO is whatever the caller emitted
+//! (Mutect2's `TLOD`/`MBQ`, Strelka's `SomaticEVS`, …). Each artifact therefore
+//! inherits from its own source.
 use crate::compare_vcfs::errors::CompareVcfsError;
 use crate::compare_vcfs::utils::attribution::{AttributionResult, Reason};
+use eidolon_core::file_tools::file_io::{is_gzipped_file, read_gzip_lines, read_lines};
 use eidolon_core::structs::{
     nucleotides::sequence_array_to_string,
     variants::{AlternateType, Variant},
 };
+use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-const HEADER_BASE: &str = "\
-##fileformat=VCFv4.2
-##source=eidolon compare-vcfs
-##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">
-";
+/// Declaration lines carried over from the VCF a set of records came from.
+struct SourceHeader {
+    /// `##INFO` / `##FILTER` / `##FORMAT` / `##ALT` / `##contig` lines, in source order.
+    meta: Vec<String>,
+    /// Declared `##contig` IDs, so undeclared record contigs can be backfilled.
+    contig_ids: HashSet<String>,
+    /// True if the source declared a `GT` FORMAT key. When it didn't, we add one,
+    /// because `format_record` synthesizes a GT column for records with no FORMAT.
+    has_gt: bool,
+}
+
+/// Read the `##`-meta lines up to (not including) `#CHROM`.
+fn read_meta_lines(vcf: &PathBuf) -> Result<Vec<String>, CompareVcfsError> {
+    let mut out = Vec::new();
+    // The two readers have different concrete types; box them rather than making
+    // this generic (matches the idiom in gen_seq_error_model's runner).
+    let lines: Box<dyn Iterator<Item = std::io::Result<String>>> = if is_gzipped_file(vcf)? {
+        Box::new(read_gzip_lines(vcf)?)
+    } else {
+        Box::new(read_lines(vcf)?)
+    };
+    for line in lines {
+        let line = line?;
+        if line.starts_with("#CHROM") {
+            break;
+        }
+        out.push(line);
+    }
+    Ok(out)
+}
+
+/// Extract the `ID=` value from a structured header line (`##INFO=<ID=FOO,...>`).
+fn header_line_id(line: &str) -> Option<&str> {
+    let open = line.find('<')?;
+    line[open + 1..]
+        .trim_end_matches('>')
+        .split(',')
+        .find_map(|f| f.strip_prefix("ID="))
+}
+
+/// Collect the declarations an artifact must carry, from the VCF its records came from.
+fn source_header(vcf: &PathBuf) -> Result<SourceHeader, CompareVcfsError> {
+    const KEEP: [&str; 5] = ["##INFO=", "##FILTER=", "##FORMAT=", "##ALT=", "##contig="];
+    let mut meta = Vec::new();
+    let mut contig_ids = HashSet::new();
+    let mut has_gt = false;
+    for line in read_meta_lines(vcf)? {
+        if !KEEP.iter().any(|k| line.starts_with(k)) {
+            continue;
+        }
+        if let Some(id) = header_line_id(&line) {
+            if line.starts_with("##contig=") {
+                contig_ids.insert(id.to_string());
+            } else if line.starts_with("##FORMAT=") && id == "GT" {
+                has_gt = true;
+            }
+        }
+        meta.push(line);
+    }
+    Ok(SourceHeader {
+        meta,
+        contig_ids,
+        has_gt,
+    })
+}
+
+/// Write the header: fileformat, inherited declarations, a backfilled `##contig`
+/// for any record contig the source didn't declare, then the column line.
+///
+/// The backfill emits an ID-only contig (length is optional in VCF 4.2). It exists
+/// so an artifact is self-describing even when the source header was itself
+/// incomplete — a truth VCF from a third-party tool need not declare contigs.
+fn write_header<W: Write>(
+    out: &mut W,
+    src: &SourceHeader,
+    record_contigs: &[&str],
+    extra_info: Option<&str>,
+) -> Result<(), CompareVcfsError> {
+    out.write_all(b"##fileformat=VCFv4.2\n")?;
+    out.write_all(b"##source=eidolon compare-vcfs\n")?;
+    for line in &src.meta {
+        out.write_all(line.as_bytes())?;
+        out.write_all(b"\n")?;
+    }
+    if !src.has_gt {
+        out.write_all(GT_FORMAT.as_bytes())?;
+    }
+    if let Some(info) = extra_info {
+        out.write_all(info.as_bytes())?;
+    }
+    let mut seen: HashSet<&str> = HashSet::new();
+    for c in record_contigs {
+        if src.contig_ids.contains(*c) || !seen.insert(*c) {
+            continue;
+        }
+        writeln!(out, "##contig=<ID={c}>")?;
+    }
+    out.write_all(COLUMN_HEADER.as_bytes())?;
+    Ok(())
+}
+
+const GT_FORMAT: &str = "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n";
 const EIDOLON_REASON_INFO: &str = "##INFO=<ID=EIDOLON_REASON,Number=.,Type=String,\
 Description=\"Comma-separated NEAT-aware false-negative attribution reasons\">\n";
 const COLUMN_HEADER: &str = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n";
@@ -34,19 +146,27 @@ const COLUMN_HEADER: &str = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORM
 /// Write FN records with EIDOLON_REASON annotations to
 /// `<output_dir>/FN_with_reasons.vcf`. Returns the written path.
 ///
+/// `golden_vcf` is the VCF the FN records came from; its declaration lines are
+/// inherited so every INFO/FILTER/FORMAT tag the records carry is declared.
+///
 /// If `attribution.per_fn` is empty, the file is still written (header
 /// only) so downstream tools can rely on the artifact existing.
 pub fn write_fn_with_reasons(
     attribution: &AttributionResult,
     output_dir: &Path,
     overwrite_output: bool,
+    golden_vcf: &PathBuf,
 ) -> Result<PathBuf, CompareVcfsError> {
     let path = output_dir.join("FN_with_reasons.vcf");
     check_overwrite(&path, overwrite_output)?;
+    let src = source_header(golden_vcf)?;
+    let contigs: Vec<&str> = attribution
+        .per_fn
+        .iter()
+        .map(|(chrom, _, _)| chrom.as_str())
+        .collect();
     let mut file = fs::File::create(&path)?;
-    file.write_all(HEADER_BASE.as_bytes())?;
-    file.write_all(EIDOLON_REASON_INFO.as_bytes())?;
-    file.write_all(COLUMN_HEADER.as_bytes())?;
+    write_header(&mut file, &src, &contigs, Some(EIDOLON_REASON_INFO))?;
     for (chrom, variant, reasons) in &attribution.per_fn {
         let line = format_record(chrom, variant, Some(reasons));
         file.write_all(line.as_bytes())?;
@@ -56,16 +176,21 @@ pub fn write_fn_with_reasons(
 }
 
 /// Write FP records to `<output_dir>/FP.vcf`. Returns the written path.
+///
+/// `called_vcf` is the VCF the FP records came from — *not* the golden VCF. An FP's
+/// INFO is whatever the caller emitted, so its declarations must come from there.
 pub fn write_fp_vcf(
     fps_by_contig: &[(String, &Variant)],
     output_dir: &Path,
     overwrite_output: bool,
+    called_vcf: &PathBuf,
 ) -> Result<PathBuf, CompareVcfsError> {
     let path = output_dir.join("FP.vcf");
     check_overwrite(&path, overwrite_output)?;
+    let src = source_header(called_vcf)?;
+    let contigs: Vec<&str> = fps_by_contig.iter().map(|(c, _)| c.as_str()).collect();
     let mut file = fs::File::create(&path)?;
-    file.write_all(HEADER_BASE.as_bytes())?;
-    file.write_all(COLUMN_HEADER.as_bytes())?;
+    write_header(&mut file, &src, &contigs, None)?;
     for (chrom, v) in fps_by_contig {
         let line = format_record(chrom, v, None);
         file.write_all(line.as_bytes())?;
@@ -184,6 +309,23 @@ mod tests {
         assert!(!line.contains("EIDOLON_REASON"));
     }
 
+    /// A source VCF whose header declares tags the artifact must inherit. `DP` stands
+    /// in for a caller-specific tag we could never have enumerated ahead of time.
+    fn source_vcf(dir: &std::path::Path, name: &str) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(
+            &p,
+            "##fileformat=VCFv4.2\n\
+             ##contig=<ID=chr1,length=1000>\n\
+             ##INFO=<ID=DP,Number=1,Type=Integer,Description=\"depth\">\n\
+             ##FILTER=<ID=LowQual,Description=\"low\">\n\
+             ##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n",
+        )
+        .unwrap();
+        p
+    }
+
     #[test]
     fn format_record_synthesizes_gt_column_when_format_empty() {
         let v = snp_with(100, None);
@@ -194,6 +336,110 @@ mod tests {
         assert_eq!(parts[9], "0/1");
     }
 
+    /// #444: the artifact must declare every INFO tag its records carry. A record's
+    /// INFO is passed through verbatim from the source VCF, so a fixed header left
+    /// undeclared tags behind — fine streaming VCF->VCF, a hard failure on BCF
+    /// translation (which `bcftools concat | sort` does internally).
+    #[test]
+    fn artifact_declares_every_info_tag_its_records_carry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut v = snp_with(100, None);
+        // A caller-specific tag we could not have enumerated in a fixed header.
+        v.info = Some("DP=30".to_string());
+        let attribution = AttributionResult {
+            per_fn: vec![("chr1".to_string(), v, vec![Reason::Unknown])],
+            counts: Default::default(),
+        };
+        let src = source_vcf(dir.path(), "golden.vcf");
+        let path = write_fn_with_reasons(&attribution, dir.path(), false, &src).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+
+        let declared: HashSet<&str> = body
+            .lines()
+            .filter(|l| l.starts_with("##INFO="))
+            .filter_map(header_line_id)
+            .collect();
+        let record = body
+            .lines()
+            .find(|l| !l.starts_with('#'))
+            .expect("no record written");
+        let info = record.split('\t').nth(7).unwrap();
+        for field in info.split(';') {
+            let key = field.split('=').next().unwrap();
+            assert!(
+                declared.contains(key),
+                "INFO key `{key}` used but not declared (declared: {declared:?}) in:\n{body}"
+            );
+        }
+        // Specifically: inherited from the source, not invented by us.
+        assert!(body.contains("##INFO=<ID=DP,"), "DP not inherited:\n{body}");
+        assert!(body.contains("##INFO=<ID=EIDOLON_REASON,"));
+    }
+
+    /// FILTER and contig declarations are inherited too, and a record contig the
+    /// source failed to declare is backfilled so the artifact is self-describing.
+    #[test]
+    fn artifact_inherits_filter_and_backfills_undeclared_contigs() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut v = snp_with(100, None);
+        v.filter = Some("LowQual".to_string());
+        let other = snp_with(200, None);
+        let attribution = AttributionResult {
+            per_fn: vec![
+                ("chr1".to_string(), v, vec![Reason::Unknown]),
+                // chrUn is absent from the source header -> must be backfilled.
+                ("chrUn".to_string(), other, vec![Reason::Unknown]),
+            ],
+            counts: Default::default(),
+        };
+        let src = source_vcf(dir.path(), "golden.vcf");
+        let path = write_fn_with_reasons(&attribution, dir.path(), false, &src).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            body.contains("##FILTER=<ID=LowQual,"),
+            "FILTER not inherited"
+        );
+        assert!(
+            body.contains("##contig=<ID=chr1,length=1000>"),
+            "contig not inherited"
+        );
+        assert!(
+            body.contains("##contig=<ID=chrUn>"),
+            "undeclared contig not backfilled"
+        );
+        // GT was declared by the source, so we must not emit a duplicate.
+        assert_eq!(
+            body.matches("##FORMAT=<ID=GT,").count(),
+            1,
+            "duplicate GT decl"
+        );
+    }
+
+    /// FP records come from the CALLED vcf, so they must inherit its declarations —
+    /// using the golden VCF's header here would leave caller tags undeclared.
+    #[test]
+    fn fp_artifact_inherits_from_the_called_vcf() {
+        let dir = tempfile::tempdir().unwrap();
+        let called = dir.path().join("called.vcf");
+        std::fs::write(
+            &called,
+            "##fileformat=VCFv4.2\n\
+             ##contig=<ID=chr1,length=1000>\n\
+             ##INFO=<ID=TLOD,Number=1,Type=Float,Description=\"mutect\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n",
+        )
+        .unwrap();
+        let mut v = snp_with(100, None);
+        v.info = Some("TLOD=12.5".to_string());
+        let fps = vec![("chr1".to_string(), &v)];
+        let path = write_fp_vcf(&fps, dir.path(), false, &called).unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            body.contains("##INFO=<ID=TLOD,"),
+            "caller tag not inherited:\n{body}"
+        );
+    }
+
     #[test]
     fn fn_with_reasons_writes_header_and_records() {
         let dir = tempfile::tempdir().unwrap();
@@ -202,7 +448,8 @@ mod tests {
             per_fn: vec![("chr1".to_string(), v, vec![Reason::Unknown])],
             counts: Default::default(),
         };
-        let path = write_fn_with_reasons(&attribution, dir.path(), false).unwrap();
+        let src = source_vcf(dir.path(), "golden.vcf");
+        let path = write_fn_with_reasons(&attribution, dir.path(), false, &src).unwrap();
         let body = std::fs::read_to_string(&path).unwrap();
         assert!(body.contains("##fileformat=VCFv4.2"));
         assert!(body.contains("##INFO=<ID=EIDOLON_REASON"));
@@ -217,7 +464,8 @@ mod tests {
             per_fn: Vec::new(),
             counts: Default::default(),
         };
-        let path = write_fn_with_reasons(&attribution, dir.path(), false).unwrap();
+        let src = source_vcf(dir.path(), "golden.vcf");
+        let path = write_fn_with_reasons(&attribution, dir.path(), false, &src).unwrap();
         let body = std::fs::read_to_string(&path).unwrap();
         assert!(body.contains("##fileformat=VCFv4.2"));
         // Last line should be the column header — no data rows past it.
@@ -237,7 +485,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let v = snp_with(200, None);
         let fps: Vec<(String, &Variant)> = vec![("chr2".to_string(), &v)];
-        let path = write_fp_vcf(&fps, dir.path(), false).unwrap();
+        let src = source_vcf(dir.path(), "called.vcf");
+        let path = write_fp_vcf(&fps, dir.path(), false, &src).unwrap();
         let body = std::fs::read_to_string(&path).unwrap();
         assert!(!body.contains("EIDOLON_REASON"));
         assert!(body.contains("chr2\t200"));
@@ -251,7 +500,8 @@ mod tests {
             per_fn: Vec::new(),
             counts: Default::default(),
         };
-        let err = write_fn_with_reasons(&attribution, dir.path(), false).unwrap_err();
+        let src = source_vcf(dir.path(), "golden.vcf");
+        let err = write_fn_with_reasons(&attribution, dir.path(), false, &src).unwrap_err();
         assert!(matches!(err, CompareVcfsError::OverwriteFileError(_)));
     }
 }

--- a/eidolon/tests/vcf_validation.rs
+++ b/eidolon/tests/vcf_validation.rs
@@ -452,3 +452,163 @@ fn golden_vcf_declares_contigs() {
     let p = report("contigs", check_contigs(&v));
     assert!(p.is_empty(), "contig declarations missing: {}", p[0]);
 }
+
+// ── compare-vcfs artifacts (#444) ────────────────────────────────────────────
+// FN_with_reasons.vcf / FP.vcf pass each record's INFO through verbatim from the
+// VCF it came from, so they must declare those tags. A fixed minimal header left
+// them undeclared, which streams fine VCF->VCF but hard-fails BCF translation.
+// Validate them as whole artifacts, the same way the golden VCF is validated
+// above — the missing check is what let the defect ship.
+
+fn write_fasta(path: &Path, contig: &str, seq: &str) {
+    use std::io::Write as _;
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, ">{contig}").unwrap();
+    writeln!(f, "{seq}").unwrap();
+}
+
+/// Write a VCF whose header declares `extra_info` lines, so we can check they are
+/// inherited rather than dropped.
+fn write_src_vcf(path: &Path, contig: &str, len: usize, extra_info: &[&str], body: &[&str]) {
+    use std::io::Write as _;
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, "##fileformat=VCFv4.2").unwrap();
+    writeln!(f, "##contig=<ID={contig},length={len}>").unwrap();
+    writeln!(
+        f,
+        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
+    )
+    .unwrap();
+    for l in extra_info {
+        writeln!(f, "{l}").unwrap();
+    }
+    writeln!(
+        f,
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE"
+    )
+    .unwrap();
+    for l in body {
+        writeln!(f, "{l}").unwrap();
+    }
+}
+
+/// Both compare-vcfs artifacts must be well formed — every INFO tag their records
+/// carry declared, contigs declared, columns consistent.
+#[test]
+fn compare_vcfs_artifacts_are_well_formed() {
+    let (_dir, work) = fresh_workdir();
+    let contig = "chr1";
+    let seq: String = std::iter::repeat('A').take(2000).collect();
+    let fa = work.join("ref.fa");
+    write_fasta(&fa, contig, &seq);
+
+    // Golden carries DP; called carries a caller-specific TLOD. Neither could be
+    // enumerated in a fixed header, and they must land in different artifacts.
+    let golden = work.join("golden.vcf");
+    write_src_vcf(
+        &golden,
+        contig,
+        2000,
+        &[
+            "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"depth\">",
+            "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"type\">",
+            "##INFO=<ID=END,Number=1,Type=Integer,Description=\"end\">",
+            "##ALT=<ID=DEL,Description=\"Deletion\">",
+        ],
+        &[
+            "chr1\t100\t.\tA\tG\t50\tPASS\tDP=30\tGT\t0/1",
+            "chr1\t200\t.\tA\tT\t50\tPASS\tDP=25\tGT\t0/1",
+            // Symbolic SV: exercises ##ALT / SVTYPE / END inheritance, the case a
+            // real cancer truth VCF hits.
+            "chr1\t500\t.\tA\t<DEL>\t50\tPASS\tSVTYPE=DEL;END=600\tGT\t0/1",
+        ],
+    );
+    let called = work.join("called.vcf");
+    write_src_vcf(
+        &called,
+        contig,
+        2000,
+        &["##INFO=<ID=TLOD,Number=1,Type=Float,Description=\"mutect\">"],
+        &["chr1\t900\t.\tA\tC\t50\tPASS\tTLOD=12.5\tGT\t0/1"],
+    );
+
+    let out = work.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let yaml = work.join("cfg.yml");
+    std::fs::write(
+        &yaml,
+        format!(
+            "golden_vcf: {}\ncalled_vcf: {}\nreference: {}\noutput_dir: {}\n\
+             overwrite_output: true\nwrite_fp_vcf: true\n",
+            golden.display(),
+            called.display(),
+            fa.display(),
+            out.display(),
+        ),
+    )
+    .unwrap();
+
+    eidolon()
+        .args(["compare-vcfs", "-c"])
+        .arg(&yaml)
+        .assert()
+        .success();
+
+    let reference = load_reference(&fa);
+    for name in ["FN_with_reasons.vcf", "FP.vcf"] {
+        let path = out.join(name);
+        assert!(path.is_file(), "{name} was not written");
+        let parsed = parse_vcf(&path);
+        assert!(
+            !parsed.records.is_empty(),
+            "{name} has no records — validating an empty file proves nothing"
+        );
+        let mut problems = Vec::new();
+        problems.extend(report(
+            &format!("{name} INFO declared"),
+            check_info_declared(&parsed),
+        ));
+        problems.extend(report(
+            &format!("{name} REF"),
+            check_ref(&parsed, &reference),
+        ));
+        problems.extend(report(&format!("{name} sorted"), check_sorted(&parsed)));
+        problems.extend(report(&format!("{name} columns"), check_columns(&parsed)));
+        // No check_alt_declared here: compare-vcfs deliberately excludes symbolic
+        // ALTs before comparison (runner.rs skips them so nothing calls
+        // .as_literal() on a <DEL>) and reports the count it dropped, so these
+        // artifacts never carry one. Asserting it would pass vacuously — the
+        // golden-VCF tests above cover ALT declarations where they can occur.
+        problems.extend(report(&format!("{name} contigs"), check_contigs(&parsed)));
+        assert!(
+            problems.is_empty(),
+            "{name} is not well formed ({} problem(s)); first: {}",
+            problems.len(),
+            problems[0]
+        );
+    }
+
+    // The golden's symbolic <DEL> must be excluded cleanly, not crash and not leak
+    // into the artifact — compare-vcfs is an SNV/indel comparator by design.
+    let fn_body = std::fs::read_to_string(out.join("FN_with_reasons.vcf")).unwrap();
+    assert!(
+        !fn_body.contains("<DEL>"),
+        "symbolic ALT leaked into FN artifact:\n{fn_body}"
+    );
+    assert_eq!(
+        fn_body.lines().filter(|l| !l.starts_with('#')).count(),
+        2,
+        "expected exactly the 2 literal FNs (symbolic excluded):\n{fn_body}"
+    );
+
+    // Each artifact inherited from ITS OWN source, not a shared fixed header.
+    let fp_body = std::fs::read_to_string(out.join("FP.vcf")).unwrap();
+    assert!(
+        fn_body.contains("##INFO=<ID=DP,"),
+        "FN lost golden's DP decl"
+    );
+    assert!(
+        fp_body.contains("##INFO=<ID=TLOD,"),
+        "FP lost the caller's TLOD decl"
+    );
+}


### PR DESCRIPTION
Fixes #444. First item in the **v3.0.1** measurement-integrity milestone.

## The defect

`FN_with_reasons.vcf` and `FP.vcf` pass each record's INFO column through **verbatim** but emitted a fixed minimal header, so the artifacts carried tags their own header never declared. bcftools tolerates that streaming VCF→VCF but **hard-fails on BCF translation** — which `bcftools concat | sort` does internally — so it surfaced far downstream as an opaque failure rather than at the point of writing.

The old module doc justified the omission:

> *"We do not preserve the source VCF's `##contig=` lines because that would require re-reading the input header; downstream tools that need it can re-create from the reference FASTA."*

That reasoning doesn't hold. It addresses only `##contig`, not the consequential `##INFO` case — and no downstream tool can invent a declaration for a tag it has never seen.

## Why a fixed declaration set can't work either

The two artifacts have **different provenance**:

| artifact | records come from | inherits |
|---|---|---|
| `FN_with_reasons.vcf` | the **golden** VCF | golden's declarations |
| `FP.vcf` | the **called** VCF | the *caller's* declarations — Mutect2 `TLOD`/`MBQ`, Strelka `SomaticEVS`, … |

An FP's INFO is whatever the caller emitted, which can't be enumerated ahead of time. So each writer now takes the path of the VCF its records came from and inherits its `##INFO` / `##FILTER` / `##FORMAT` / `##ALT` / `##contig` lines, plus:

- a **backfilled ID-only `##contig`** for any record contig the source itself failed to declare (length is optional in VCF 4.2), so the artifact is self-describing even when the source header was incomplete — a third-party truth VCF need not declare contigs;
- `GT` added **only** when the source didn't declare it, so no duplicate.

## Verified end to end

```
--- FN_with_reasons.vcf ---
    ##INFO=<ID=DP,...>              <- inherited from golden
    ##INFO=<ID=EIDOLON_REASON,...>
    BCF translation: OK
--- FP.vcf ---
    ##INFO=<ID=TLOD,...>            <- inherited from the CALLER, and no DP
    BCF translation: OK
```

## Tests

The reason this shipped is the same gap that let four BND defects through: every existing test asserted expected content was *present*, none asserted the artifact was *well formed*.

- **Three unit tests**, each verified to fail against the old behaviour with `INFO key 'DP' used but not declared (declared: {"EIDOLON_REASON"})` — covering INFO inheritance, FILTER + contig inheritance with backfill and no duplicate GT, and that FP inherits from the *called* VCF.
- **An end-to-end test in `vcf_validation.rs`** that runs `compare-vcfs` and validates both artifacts with the same whole-file checks applied to the golden VCF. Also verified non-vacuous.

## A note on scope, and a vacuous check I caught in my own test

The e2e fixture includes a symbolic `<DEL>`, and I initially asserted `check_alt_declared` on the artifacts. **That check passed even with `##ALT=` removed from the inherited set** — i.e. it was vacuous.

The reason turned out to be correct behaviour: `compare-vcfs` is an SNV/indel comparator **by design** — `runner.rs` skips symbolic ALTs before anything calls `.as_literal()` on a `<DEL>`, and `report.rs` *counts and reports* how many it dropped (`Symbolic / structural ALT: N / M`). So these artifacts can never carry a symbolic ALT and the check could never fail.

Rather than leave a check that always passes, I removed it, documented why in the test, and replaced it with assertions that do bite: the `<DEL>` is excluded **cleanly** (exactly 2 literal FNs, no `<DEL>` in the artifact) rather than crashing or leaking through. Verified load-bearing by breaking the expected count.

Worth noting the code was already doing the right thing here — logging what it dropped is exactly the discipline the harness audit found missing elsewhere.

## Testing

Full workspace suite green (28 groups, 0 failures); `cargo fmt --all --check` clean. No Delta run needed — this is entirely locally verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
