### PR TITLE
fix(delta): measure observed VAF without a genotype call (#450)

### DIFF
--- a/scripts/delta/run_scn_af_validation.sh
+++ b/scripts/delta/run_scn_af_validation.sh
@@ -79,6 +79,9 @@ mkdir -p "$OUTDIR"
 # stage_scn.sh emits AD (mpileup -a FORMAT/AD); VCFs staged before that fix lack it, so fall
 # back to re-deriving AD from the BAM at just the SNV sites (fast, -R restricted). POOL_AF is
 # BOTH the gen-reads input and the truth, so the comparison stays self-consistent either way.
+# mpileup max per-site depth; its default of 250 would silently downsample a
+# deep pool. Explicit so any cap is deliberate.
+MPILEUP_MAX_DEPTH="${MPILEUP_MAX_DEPTH:-2000}"
 POOL_AF="$OUTDIR/pool.af.vcf.gz"
 if bcftools view -h "$POOL_VCF" | grep -q '##FORMAT=<ID=AD,'; then
     echo "pool VCF carries FORMAT/AD — using AD-based fraction directly"
@@ -88,9 +91,14 @@ elif [[ -s "$BAM" ]]; then
     SITES="$OUTDIR/snv_sites.vcf.gz"
     bcftools view -v snps "$POOL_VCF" -Oz -o "$SITES"
     bcftools index -t "$SITES"
-    bcftools mpileup -a FORMAT/AD -f "$REF" -R "$SITES" "$BAM" 2>/dev/null \
-      | bcftools call -m -Oz 2>/dev/null \
-      | bcftools view -v snps -Oz -o "$POOL_AF"
+    # No `bcftools call` here (#450). `call -m` makes a diploid ML genotype call and a
+    # hom-ref call discards the uncalled allele TOGETHER WITH ITS READ COUNT, so the
+    # low-AF end of a pool spectrum — the part this harness exists to validate — was
+    # being destroyed before the comparison saw it. Worse than the subclonal case,
+    # which at least passed -C alleles. Measuring a fraction needs no genotype call;
+    # scn_af_compare.py reads the per-allele AD directly.
+    bcftools mpileup -a FORMAT/AD -d "$MPILEUP_MAX_DEPTH" -f "$REF" -R "$SITES" \
+        "$BAM" -Oz -o "$POOL_AF" 2>/dev/null
 else
     echo "ABORT: $POOL_VCF has no FORMAT/AD and no BAM at $BAM to re-derive it." >&2
     echo "       Re-stage with the current stage_scn.sh (emits FORMAT/AD), or set INPUT_BAM." >&2

--- a/scripts/delta/run_subclonal_vaf_validation.sh
+++ b/scripts/delta/run_subclonal_vaf_validation.sh
@@ -72,6 +72,9 @@ PURITY="${PURITY:-0.7}"
 COV="${COV:-150}"                              # total (merged) depth; high so low-CCF sites
                                                # don't drop out and per-site VAF noise is tight
 MIN_DEPTH="${MIN_DEPTH:-25}"                   # gate low-depth sites in the comparison
+# mpileup's max per-site depth. Its default of 250 would silently downsample a
+# 200x+ run; set explicitly so any cap is deliberate and visible.
+MPILEUP_MAX_DEPTH="${MPILEUP_MAX_DEPTH:-2000}"
 # PASS is gated on FIDELITY metrics that hold for a discrete subclonal architecture:
 #   |mean(observed-intended)| = bias (systematic composition error) and MAE (per-site
 #   accuracy vs the binomial noise floor). Pearson r is ADVISORY only — for tight,
@@ -173,10 +176,6 @@ echo "EIDOLON_VAF spread (should span deciles for a subclonal architecture):"
 bcftools query -f '%INFO/AF\n' "$SITES" \
   | awk '{b=int($1*10); if(b>9)b=9; c[b]++} END{for(i=0;i<10;i++)printf "  [%.1f,%.1f) %d\n",i/10,(i+1)/10,c[i]+0}'
 
-# Tab-delimited allele list for forced genotyping (-C alleles): CHROM POS REF,ALT.
-ALLELES="$OUTDIR/alleles.tsv.gz"
-bcftools query -f '%CHROM\t%POS\t%REF,%ALT\n' "$SITES" | bgzip > "$ALLELES"
-tabix -s1 -b2 -e2 "$ALLELES"
 
 # ── Step 3: align the MERGED (mixed) reads — the sample a caller sees ─────────
 if [[ ! -s "${REF}.bwt.2bit.64" ]]; then
@@ -203,18 +202,42 @@ if ! bwa-mem2 mem -t "$THREADS" -R '@RG\tID:subvaf\tSM:merged\tPL:ILLUMINA' "$RE
 fi
 samtools index "$MERGED_BAM"
 
-# ── Step 4: OBSERVED VAF at the somatic sites (forced genotyping) ─────────────
-# -C alleles -T $ALLELES forces the KNOWN alt allele so AD is measured even for
-# low-VAF subclonal sites that a de-novo caller's LoD would drop — exactly the
-# sites #405 is about. FORMAT/AD then carries the observed alt fraction.
+# ── Step 4: OBSERVED VAF at the somatic sites (mpileup AD, no genotype call) ──
+# Read FORMAT/AD straight from mpileup. NO `bcftools call` (#450).
+#
+# The previous version piped mpileup into `bcftools call -m -C alleles`, on the
+# reasoning that -C alleles "forces the KNOWN alt allele so AD is measured even for
+# low-VAF subclonal sites that a de-novo caller's LoD would drop". -C alleles does
+# constrain which alleles are considered, but `call -m` still makes a diploid ML
+# GENOTYPE call — and a hom-ref call discards the uncalled allele together with its
+# read count. Measured in isolation at 7% VAF:
+#
+#   mpileup alone          REF=G ALT=T,<*>   AD=93,7,0     <- 7/100 = 0.07, correct
+#   mpileup | call -m      REF=G ALT=.       AD=93         <- allele and count gone
+#
+# Coverage cannot rescue it: identical at 100x, 300x and 600x, because the decision
+# is driven by the allele FRACTION against a diploid model — no diploid genotype
+# predicts 7%. So the step meant to preserve low-VAF sites was destroying exactly
+# them, and 160 of 567 planted sites (the entire lowest CCF cluster) never reached
+# the comparison. Measuring an allele fraction needs no genotype call at all.
+#
+# scn_af_compare.py selects this allele's own AD element from the ALT list, so
+# mpileup's `<*>` non-ref placeholder beside the real base is handled.
 SIM="$OUTDIR/observed.vcf.gz"
-echo "=== mpileup + forced-allele genotyping at the somatic sites ==="
-bcftools mpileup -a FORMAT/AD -f "$REF" -R "$SITES" "$MERGED_BAM" -Ou 2>/dev/null \
-  | bcftools call -m -C alleles -T "$ALLELES" -Oz -o "$SIM" 2>/dev/null
+echo "=== mpileup at the somatic sites (AD only, no genotype calling) ==="
+# -d: mpileup's default max depth is 250, which would silently downsample a 200x+
+# run. Set it explicitly so the cap is visible and generous.
+bcftools mpileup -a FORMAT/AD -d "$MPILEUP_MAX_DEPTH" -f "$REF" -R "$SITES" \
+    "$MERGED_BAM" -Oz -o "$SIM" 2>/dev/null
 bcftools index -t "$SIM"
 nsim=$(bcftools view -H "$SIM" | wc -l)
-echo "sites genotyped in merged BAM: $nsim"
-[[ "$nsim" -gt 0 ]] || { echo "ABORT: 0 sites genotyped — check alignment / -C alleles." >&2; exit 1; }
+echo "sites piled up in merged BAM: $nsim"
+[[ "$nsim" -gt 0 ]] || { echo "ABORT: 0 sites piled up — check alignment / -R sites." >&2; exit 1; }
+# Read-the-artifact guard: a site with coverage must carry a per-allele AD. If AD is
+# absent the comparison would silently find nothing to join.
+nad=$(bcftools query -f '%CHROM\t%POS\t[%AD]\n' "$SIM" 2>/dev/null | awk -F'\t' '$3!="" && $3!="."' | wc -l)
+echo "sites carrying FORMAT/AD: $nad"
+[[ "$nad" -gt 0 ]] || { echo "ABORT: no site carries FORMAT/AD — mpileup -a FORMAT/AD failed." >&2; exit 1; }
 
 # ── Step 5: compare intended EIDOLON_VAF (truth) vs observed merged-BAM VAF ──────
 echo

--- a/scripts/delta/scn_af_compare.py
+++ b/scripts/delta/scn_af_compare.py
@@ -35,44 +35,64 @@ def _field_index(fmt, key):
     return parts.index(key) if key in parts else None
 
 
-def _af_from_record(info, fmt, sample):
-    """Extract an alt fraction from one VCF record's INFO/FORMAT/SAMPLE.
+def _pick_per_allele(raw, alt_idx, n_alts, kind):
+    """Select one allele's value from a per-allele VCF field.
 
-    Order: FORMAT/AF, then INFO/AF, then FORMAT/AD (sum alt / total). Returns
-    (af, depth) — depth is total AD when available (for min-depth gating), else
-    None. Returns (None, None) when no fraction can be derived.
+    `kind` is "A" (one value per ALT, e.g. AF) or "R" (ref first, then one per ALT,
+    e.g. AD). Returns None unless the field's arity actually matches the ALT count:
+    a field of the wrong length cannot be indexed safely, and guessing would
+    silently attribute one allele's number to another. The previous code took
+    `[0]` unconditionally, which reported the FIRST allele's fraction for every
+    allele of a multi-allelic record.
     """
-    # FORMAT/AF
+    parts = raw.split(",")
+    want = n_alts if kind == "A" else n_alts + 1
+    if len(parts) != want:
+        return None
+    try:
+        return float(parts[alt_idx if kind == "A" else alt_idx + 1])
+    except ValueError:
+        return None
+
+
+def _af_for_allele(info, fmt, sample, alt_idx, n_alts):
+    """Alt fraction for the ALT at 0-based `alt_idx`, and the site's total depth.
+
+    Order: FORMAT/AF, INFO/AF, then FORMAT/AD. Returns (None, depth) when no
+    fraction can be derived for this allele.
+    """
+    depth = _depth_from_ad(fmt, sample)
     if fmt and sample:
         af_i = _field_index(fmt, "AF")
         if af_i is not None:
             vals = sample.split(":")
             if af_i < len(vals):
-                try:
-                    return float(vals[af_i].split(",")[0]), _depth_from_ad(fmt, sample)
-                except ValueError:
-                    pass
-    # INFO/AF
+                v = _pick_per_allele(vals[af_i], alt_idx, n_alts, "A")
+                if v is not None:
+                    return v, depth
     for kv in info.split(";"):
         if kv.startswith("AF="):
-            try:
-                return float(kv[3:].split(",")[0]), _depth_from_ad(fmt, sample)
-            except ValueError:
-                pass
-    # FORMAT/AD
+            v = _pick_per_allele(kv[3:], alt_idx, n_alts, "A")
+            if v is not None:
+                return v, depth
+    # FORMAT/AD (Number=R). This is the path #450 depends on: reading the observed
+    # side straight from `bcftools mpileup` means AD carries one count per allele,
+    # so this allele's own count divided by the site total is its observed fraction.
     if fmt and sample:
         ad_i = _field_index(fmt, "AD")
         if ad_i is not None:
             vals = sample.split(":")
             if ad_i < len(vals):
-                try:
-                    counts = [float(x) for x in vals[ad_i].split(",")]
+                parts = vals[ad_i].split(",")
+                if len(parts) == n_alts + 1:
+                    try:
+                        counts = [float(x) for x in parts]
+                    except ValueError:
+                        return None, depth
                     total = sum(counts)
-                    if len(counts) >= 2 and total > 0:
-                        return sum(counts[1:]) / total, total
-                except ValueError:
-                    pass
-    return None, None
+                    if total > 0:
+                        return counts[alt_idx + 1] / total, total
+    return None, depth
 
 
 def _depth_from_ad(fmt, sample):
@@ -91,8 +111,22 @@ def _depth_from_ad(fmt, sample):
 
 
 def load_af(path):
-    """Map (chrom, pos, ref, alt) -> (af, depth) for every usable record."""
-    out = OrderedDict()
+    """Return (alleles, sites) from a VCF.
+
+    `alleles` maps (chrom, pos, ref, alt) -> (af, depth), with **multi-allelic
+    records expanded one entry per literal ALT**. That expansion is what makes the
+    mpileup-derived observed side joinable (#450): `bcftools mpileup` reports
+    `ALT=T,<*>` with `AD=93,7,0`, so the truth's single ALT `T` has to be matched
+    against the ALT *list* and its own AD element selected. Keying on the whole ALT
+    string could never match, and skipping any record containing a symbolic
+    alternative discarded the real base sitting beside `<*>`.
+
+    `sites` maps (chrom, pos, ref) -> total depth, for every record with coverage.
+    The caller uses it to score a truth ALT the observed side never listed as
+    **0.0 observed** rather than as a missing site — see main().
+    """
+    alleles = OrderedDict()
+    sites = {}
     with _open(path) as fh:
         for line in fh:
             if line.startswith("#"):
@@ -100,16 +134,24 @@ def load_af(path):
             f = line.rstrip("\n").split("\t")
             if len(f) < 5:
                 continue
-            chrom, pos, ref, alt = f[0], f[1], f[3], f[4]
-            if alt.startswith("<") or "[" in alt or "]" in alt:
-                continue  # symbolic / breakend — not a literal-fraction site
+            chrom, pos, ref, alt_field = f[0], f[1], f[3], f[4]
             info = f[7] if len(f) > 7 else "."
             fmt = f[8] if len(f) > 8 else ""
             sample = f[9] if len(f) > 9 else ""
-            af, depth = _af_from_record(info, fmt, sample)
-            if af is not None:
-                out[(chrom, pos, ref, alt)] = (af, depth)
-    return out
+            alts = alt_field.split(",")
+            depth = _depth_from_ad(fmt, sample)
+            if depth is not None:
+                sites[(chrom, pos, ref)] = depth
+            for i, alt in enumerate(alts):
+                # Skip symbolic / breakend ALTERNATIVES but keep literal ones from
+                # the same record: mpileup's `<*>` non-ref placeholder sits beside a
+                # real base, and dropping the whole record over it was the bug.
+                if alt.startswith("<") or "[" in alt or "]" in alt or alt == ".":
+                    continue
+                af, dp = _af_for_allele(info, fmt, sample, i, len(alts))
+                if af is not None:
+                    alleles[(chrom, pos, ref, alt)] = (af, dp)
+    return alleles, sites
 
 
 def pearson(xs, ys):
@@ -154,8 +196,26 @@ def main():
                     help="skip sites whose total AD is below this on either side (default 0)")
     args = ap.parse_args()
 
-    a, b = load_af(args.truth), load_af(args.sim)
-    shared = [k for k in a if k in b]
+    a, _a_sites = load_af(args.truth)
+    b, b_sites = load_af(args.sim)
+
+    # A truth ALT the observed side never listed, at a position it DID cover, means
+    # zero reads carried that allele — an observed fraction of 0.0, which is a
+    # measurement. Dropping those would recreate exactly the VAF-dependent exclusion
+    # this fixes (#450), just at a lower threshold: the sites most likely to have no
+    # alt reads at all are the lowest-VAF ones, so excluding them biases the result
+    # optimistically. Fill them in and report how many.
+    shared, zero_filled = [], 0
+    for k in a:
+        if k in b:
+            shared.append(k)
+            continue
+        chrom, pos, ref, _alt = k
+        dp = b_sites.get((chrom, pos, ref))
+        if dp is not None and dp > 0:
+            b[k] = (0.0, dp)
+            shared.append(k)
+            zero_filled += 1
     only_a = len(a) - len(shared)
     only_b = len(b) - len(shared)
 
@@ -173,6 +233,13 @@ def main():
 
     print(f"truth sites={len(a)}  sim sites={len(b)}  shared={len(shared)}"
           f"  (only-truth={only_a}, only-sim={only_b})")
+    if zero_filled:
+        print(f"  {zero_filled} truth allele(s) had coverage but zero observed reads "
+              "-> scored as observed AF 0.0 (not dropped)")
+    if only_a:
+        print(f"  WARNING: {only_a} truth allele(s) had NO coverage on the observed "
+              "side and are excluded — if this is a large fraction, the comparison "
+              "does not cover the full planted set.", file=sys.stderr)
     if args.min_depth > 0:
         print(f"min-depth {args.min_depth:g}: {gated} shared sites gated, {len(xs)} compared")
     if len(xs) < 2:


### PR DESCRIPTION
Fixes #450. Third and final code item in the **v3.0.1** measurement-integrity milestone.

## The defect

The subclonal-VAF harness silently excluded the low-VAF sites it exists to validate — 160 of 567 planted sites, including an entire CCF cluster. The reported bias/MAE were conditional on the survivors, and because the exclusion is **VAF-dependent**, the estimate was optimistic in the direction that flattered the result.

Root cause: `bcftools mpileup | bcftools call -m -C alleles`. `-C alleles` does constrain which alleles are considered, but `call -m` still makes a diploid ML **genotype** call — and a hom-ref call discards the uncalled allele **together with its read count**.

Measured on a synthetic 200× BAM with three sites at 35% / 17.5% / 7% VAF, mirroring the three CCF clusters:

```
OLD  mpileup | call -m -C alleles
  POS=331  ALT=T       AD=130,70      <- 0.350, kept
  POS=631  ALT=.       AD=165         <- allele and count destroyed
  POS=931  ALT=.       AD=186         <- allele and count destroyed

NEW  mpileup only
  POS=331  ALT=T,<*>   AD=130,70,0    <- 70/200 = 0.350
  POS=631  ALT=C,<*>   AD=165,35,0    <- 35/200 = 0.175
  POS=931  ALT=C,<*>   AD=186,14,0    <- 14/200 = 0.070
```

**Two of three clusters were being destroyed, not just the lowest** — which matches the real 160-site loss exactly (115 low + 31 middle + 14 top). Coverage cannot rescue it: identical at 100×/300×/600×, because the decision is driven by the allele *fraction* against a diploid model, and no diploid genotype predicts 7%.

## Changes

- **Both harnesses read `FORMAT/AD` straight from mpileup**, no `bcftools call`. This also fixes `run_scn_af_validation.sh` (#398's pool-AF validation), which shared the defect and was **worse** — it passed no `-C alleles` at all, so sites the caller declined to call vanished entirely. Its whole purpose is validating a pool's AF *spectrum*, whose low end was being removed.
- **`scn_af_compare.py` expands multi-allelic records** one entry per literal ALT, so the truth's single ALT is matched against mpileup's ALT *list* (`T,<*>`) and that allele's own AD element selected. Keying on the whole ALT string could never match.
- **Per-allele fields are arity-checked** (`Number=A` vs `R`) instead of taking `[0]`, which had silently reported the *first* allele's fraction for every allele of a multi-allelic record.
- **Zero-fill instead of exclusion.** A truth ALT the observed side never listed, at a position it *did* cover, now scores as observed AF **0.0** rather than being dropped. Otherwise the VAF-dependent exclusion simply moves to a lower threshold — the sites likeliest to have zero alt reads are the lowest-VAF ones. The count is reported.
- **A large only-truth fraction warns on stderr** that the comparison doesn't cover the full planted set.
- **`mpileup -d` set explicitly** (`MPILEUP_MAX_DEPTH`, default 2000); the default of 250 would silently downsample a 200×+ run.
- **A read-the-artifact guard**: abort if no site carries `FORMAT/AD`. Verified load-bearing — a mpileup run without `-a FORMAT/AD` reports 0 and aborts.

## The most useful result

Running the **old, broken** data through the fixed comparator:

```
  2 truth allele(s) had coverage but zero observed reads -> scored as observed AF 0.0 (not dropped)
  MAE=0.0817  mean(sim-truth)=-0.0817
```

A broken measurement path is now **loudly wrong** instead of quietly optimistic. Previously that same data silently excluded those sites and reported bias −0.003, which looked excellent. That's the whole point of the zero-fill: it converts an invisible exclusion into a visible error.

The new path on the same fixture: 3/3 sites, three deciles, MAE 0.0000, bias +0.0000.

## What this unblocks

Report §3.12 can finally claim the low-VAF end. Success criterion for the Phase B Delta re-run is **three rows in the per-decile table** (currently two) with `only-truth ≈ 0`.

Rust suite unaffected (28 groups, 0 failures); `bash -n` and python syntax clean. No Delta run needed to verify the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
