### PR TITLE
fix(delta): fail the signature check below the SNV floor instead of warning

### DIFF
--- a/scripts/delta/signature_check.sh
+++ b/scripts/delta/signature_check.sh
@@ -30,6 +30,10 @@ TRUTH_VCF="${TRUTH_VCF:?set TRUTH_VCF to an eidolon truth VCF (INFO/EIDOLON_ORIG
 OUTDIR="${OUTDIR:-$SCRATCH/sigcheck_$(basename "$(dirname "$TRUTH_VCF")")}"
 GENOME="${GENOME:-GRCh38}"
 SIGPROFILER_ENV="${SIGPROFILER_ENV:-sigprofiler}"
+# Minimum somatic SNVs before a signature fit is meaningful. Keeps the historical 50
+# so this change enforces the existing bar rather than silently moving it — but note
+# SBS-96 has 96 contexts, so 50 is a hard floor and not a sufficiency threshold.
+MIN_SNVS="${MIN_SNVS:-50}"
 
 setup_conda
 mkdir -p "$OUTDIR/vcf"
@@ -40,7 +44,27 @@ bcftools view -v snps -i 'INFO/EIDOLON_ORIGIN="somatic"' \
     -O v -o "$OUTDIR/vcf/eidolon_somatic_snvs.vcf" "$TRUTH_VCF"
 n=$(grep -vc '^#' "$OUTDIR/vcf/eidolon_somatic_snvs.vcf" || true)
 echo "Somatic SNVs for signature fitting: $n"
-[[ "$n" -ge 50 ]] || echo "WARNING: few SNVs ($n) — fit will be noisy; use a larger/higher-coverage run." >&2
+# Fatal, not a warning. This harness produces exactly one thing — a signature fit —
+# so too few SNVs is not a degraded result, it is not a result: SBS-96 has 96
+# trinucleotide contexts, and a spectrum built from fewer mutations than contexts
+# cannot populate them. SigProfiler will still return an assignment, and that
+# assignment would be reported as though it measured something. The report's own
+# signature analysis (§3.9) used 6,225 SNVs; MIN_SNVS is a floor, not a target.
+if [[ "$n" -lt "$MIN_SNVS" ]]; then
+    echo "ERROR: only $n somatic SNV(s) — below MIN_SNVS=$MIN_SNVS." >&2
+    echo "  A COSMIC SBS fit needs to populate 96 trinucleotide contexts; below that" >&2
+    echo "  floor the assignment is noise that would be reported as a measurement." >&2
+    if [[ "$n" -eq 0 ]]; then
+        echo "  0 SNVs usually means the truth VCF has no somatic SNVs at all — raise" >&2
+        echo "  TUMOR_MUTATION_RATE or coverage. (A pre-v3.0.0 truth VCF uses" >&2
+        echo "  NEAT_ORIGIN and would have failed the filter above instead; convert it" >&2
+        echo "  with tools/migrate_legacy_tokens.sh.)" >&2
+    else
+        echo "  Use a larger / higher-coverage run, or set MIN_SNVS to accept the" >&2
+        echo "  noise deliberately." >&2
+    fi
+    exit 1
+fi
 
 # 2. SigProfiler: install the reference genome once (no-op if present), then fit.
 conda_activate "$SIGPROFILER_ENV"


### PR DESCRIPTION
Last item in the **v3.0.1** measurement-integrity milestone — the final `WARNING`-on-an-unusable-measurement site from the harness audit.

## The defect

`signature_check.sh` counted somatic SNVs, printed `WARNING: few SNVs — fit will be noisy` below 50, and fitted anyway.

This harness produces exactly one thing: a COSMIC SBS assignment. So too few SNVs isn't a degraded result — it isn't a result. **SBS-96 has 96 trinucleotide contexts**, and a spectrum built from fewer mutations than contexts cannot populate them. SigProfiler still returns an assignment, and that assignment was being reported as though it measured something.

## Change

Fatal below `MIN_SNVS`, default **50** — deliberately the historical bar, so this enforces the existing threshold rather than silently moving it. The message is explicit that 50 is a *hard floor, not a sufficiency threshold*: the report's own signature analysis (§3.9) used **6,225** SNVs. `MIN_SNVS` is overridable to accept the noise deliberately.

The **0-SNV case gets its own branch**, because it means something different — no somatic SNVs in the truth at all (raise `TUMOR_MUTATION_RATE` or coverage) rather than a thin run. It also notes that a pre-v3.0.0 truth VCF would have failed the `EIDOLON_ORIGIN` filter earlier instead, and points at `tools/migrate_legacy_tokens.sh`, matching the messages the other three harnesses now give.

## Verified

Each branch and its **exit status**:

| n | exit | branch |
|---|---|---|
| 0 | 1 | 0-SNV |
| 12 | 1 | too-few |
| 49 | 1 | too-few (boundary) |
| 50 | 0 | proceeds (inclusive) |
| 6225 | 0 | proceeds |
| 12 with `MIN_SNVS=10` | 0 | override honored |

Worth noting: my first pass at that table piped the script through `sed` and read `$?`, which reported the *pipe's* status and showed `exit=0` for every case — the exact footgun documented in `CLAUDE.md`. Re-checked without the pipe.

`bash -n` clean. No Rust changes.

## v3.0.1 is now complete

| item | PR |
|---|---|
| #444 compare-vcfs headers | #461 |
| #457 SV scoring | #462 |
| #450 VAF measurement | #463 |
| signature check guard | this |

All four locally verified; **zero Delta node-hours consumed**. Ready to tag once merged, then the Phase B campaign runs against a tagged version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
