### PR TITLE
docs(CLAUDE.md): language policy — no new Python, and vet what exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,28 @@ contributed the *fragility* (see the footguns below), not the blind spots.
   moment a token is renamed. Anchor on the token (`sub(/^EIDOLON_VAF=/,"",v)`) or use
   `PREFIX.len()`.
 
+## Languages: Rust, bash, and (reluctantly) Python
+- **The shipped artifact is pure Rust** and must stay that way: the binary invokes no
+  interpreter, `Cargo.lock` has no `pyo3`/`cpython`, and `conda-recipe/meta.yaml`
+  declares **no runtime requirements** (build-only). Verify before adding anything that
+  would change that.
+- **Do not introduce new Python.** Product logic is Rust; harness orchestration is bash.
+  Python is acceptable only where an **external tool forces it** — truvari and
+  SigProfiler are Python packages, so parsing their output in their own env is fine.
+- **Vet what exists** (all validation/prep only, none shipped):
+  `scripts/delta/{scn_af_compare,sbs96_compare}.py` are per-validation measurement
+  helpers — they determine numbers the ACCESS report cites and are **not covered by CI**
+  (#466). `tools/{build_pcawg_sv_vcf,normalize_pcawg_sv_model,graft_sv_model}.py` are
+  offline corpus prep. `tools/inject_cancer_sv_model.py` is **dead** — deprecated in
+  v1.14.0, no live caller, safe to delete.
+- Before writing a helper that works *around* a third-party tool, **check that tool's
+  actual capabilities and version.** A `bnd_proximity.py` was written on the inherited
+  belief that "truvari cannot benchmark breakends" — true of truvari v4, and explicitly
+  reversed by v5.0.0 ("BNDs which were always filtered are now analyzed"). The deployed
+  version was v5.4.0 with `--bnddist`. The helper was redundant; reading the changelog
+  was the whole job. The claim still sits uncorrected in
+  `docs/access_report_draft.md` §3.7.
+
 ## Delta / HPC (`scripts/delta/`)
 - Real-data validation runs on **NCSA Delta** (SLURM, account `bhrd-delta-cpu`). The
   cluster filesystem is **not reachable from this workstation** — the user runs jobs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,38 @@ Hand-written guidance below; the GitNexus block that follows is auto-generated
   `git merge-base --is-ancestor <sha> origin/develop`; recover a missed commit with
   `git cherry-pick`.
 
+## Vetting standard for new work (standing requirement)
+"It ran and produced output" is not evidence of correctness, and it is the bar this repo
+keeps accidentally settling for. Before calling anything done:
+
+1. **Assert on content, not existence.** A file existing, a non-zero record count, or
+   exit 0 proves nothing. The `nsom -gt 0` guard passed while every value was the
+   malformed string `AF=AF=0.3000`; `truth $svt: N` counted records while two of three
+   VAF clusters were being discarded downstream.
+2. **Prove the test fails without the fix.** Every check added this cycle was verified
+   non-vacuous by reverting the fix and watching it fail. That is what exposed an
+   `##ALT` assertion of mine that could never fail, because `compare-vcfs` excludes
+   symbolic ALTs by design.
+3. **Vet the premise, not just the implementation.** `bnd_proximity.py` was correct
+   code that should not have existed: it was built on an inherited claim that "truvari
+   cannot benchmark breakends", true of truvari v4 and explicitly reversed in v5.0.0.
+   Check a third-party tool's actual version and capabilities before writing anything
+   that works around its supposed limits.
+4. **Check coverage of the inputs, not just the metric.** Report `n_scored` vs
+   `n_planted` per stratum. A metric over an unknown denominator is not a result — #450
+   reported a clean bias while silently excluding the sites it existed to test.
+5. **Chase the evidence past the first plausible story.** `BND recall=0.000` got three
+   confident explanations in sequence (unpaired truth, then truvari's inability, then
+   ALT orientation) before the actual cause: the truth was fine, the reads were fine,
+   truvari was fine — Manta had not called those junctions. Each wrong answer was
+   plausible enough to stop at.
+6. **Say what was NOT verified.** If something was checked by hand rather than by CI,
+   or on a fixture rather than real data, state it. `scripts/delta/*.py` determine
+   numbers the ACCESS report cites and are exercised by nothing automatic (#466).
+
+Applies to features as much as fixes: a new capability needs correctness evidence, not
+a demonstration that it emits something.
+
 ## Don't trust a green result — read the artifact
 - Harness "overall: PASS" / summary lines can be **false passes** — e.g. a run that
   found no inputs still printed PASS over an empty `summary.tsv` (job 19887446). Open

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,25 @@ keeps accidentally settling for. Before calling anything done:
    or on a fixture rather than real data, state it. `scripts/delta/*.py` determine
    numbers the ACCESS report cites and are exercised by nothing automatic (#466).
 
-Applies to features as much as fixes: a new capability needs correctness evidence, not
-a demonstration that it emits something.
+**The bar is HIGHER for new features than for fixes**, because a fix has a
+known-bad baseline and a feature has none. With a fix you can revert it and watch the
+test fail — non-vacuity is free. With a feature, "it works" has no counterfactual, so
+the negative case has to be built deliberately:
+
+- **State the correctness criterion before implementing it**, and how it will be
+  falsified. If that cannot be written down, the feature is not ready to build.
+- **Include a known-answer fixture** — inputs whose correct output is computable
+  independently of the code under test. A 7-alt-in-100-reads BAM has an observed VAF of
+  exactly 0.070 whatever the implementation thinks.
+- **Include a case where it must NOT fire.** Most defects this cycle were things
+  matching or counting when they should not have, or vice versa.
+- **Verify the whole chain, not the unit.** #405's subclonal VAF passed its unit tests
+  and shipped; the harness validating it was itself excluding the sites it existed to
+  test, so the end-to-end claim was wrong for a year. BND junction reads were correct
+  the whole time and nobody had confirmed it until it was checked by hand.
+
+A feature demonstrated only by "it emitted something plausible" has not been validated,
+it has been exercised.
 
 ## Don't trust a green result — read the artifact
 - Harness "overall: PASS" / summary lines can be **false passes** — e.g. a run that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,20 @@ the negative case has to be built deliberately:
 A feature demonstrated only by "it emitted something plausible" has not been validated,
 it has been exercised.
 
+### Status vocabulary
+**Nothing is "done" until there is evidence it works as intended. Until then it is
+in progress.** This governs how work is reported, not just how it is tested:
+
+- Do not write "done", "complete", "verified" or a green check for work whose evidence
+  is "it ran", "tests pass" in isolation, or "the code looks right".
+- Say what level of evidence exists and what is still missing — e.g. *"locally vetted on
+  a known-answer fixture; not yet run against real data"*. That is an honest in-progress
+  status, and it is more useful than a checkmark.
+- A merged PR is not evidence. A tagged release is not evidence. Passing CI is evidence
+  about the tests, which is only as good as the tests.
+- This applies to milestones too: a release whose fixes have not been observed working
+  on real data is in progress, however many PRs are merged.
+
 ## Don't trust a green result — read the artifact
 - Harness "overall: PASS" / summary lines can be **false passes** — e.g. a run that
   found no inputs still printed PASS over an empty `summary.tsv` (job 19887446). Open


### PR DESCRIPTION
Records the preference stated on review of #462, with the inventory needed to act on it.

**The shipped artifact is already pure Rust** — verified before writing it down, since the distinction that matters is *does Python reach a user*, not *is Python present*: the binary invokes no interpreter, `Cargo.lock` has no `pyo3`/`cpython`, and `conda-recipe/meta.yaml` declares **no runtime requirements at all** (build-only). Every `.py` is validation harness or offline corpus prep; none is installed.

**Policy:** product logic is Rust, harness orchestration is bash, Python only where an external tool forces it — truvari and SigProfiler *are* Python packages, so parsing their output inside their own env is fine.

**Inventory, with status**, so "vet what we have" is actionable:
- `scripts/delta/{scn_af_compare,sbs96_compare}.py` — per-validation measurement helpers; they determine numbers the ACCESS report cites and are **not covered by CI** (#466)
- `tools/{build_pcawg_sv_vcf,normalize_pcawg_sv_model,graft_sv_model}.py` — offline corpus prep
- `tools/inject_cancer_sv_model.py` — **dead**: deprecated in v1.14.0, no live caller, safe to delete

**Also records the generalizable lesson:** check a third-party tool's actual capabilities and version before writing a helper around a claimed limitation. `bnd_proximity.py` was written on the inherited belief that *"truvari cannot benchmark breakends"* — true of truvari v4, explicitly reversed by v5.0.0 (*"BNDs which were always filtered are now analyzed"*), and the deployed version is **v5.4.0 with `--bnddist`**. Reading the changelog was the whole job. That claim originates in `docs/access_report_draft.md` §3.7 and is still uncorrected there.

Docs only.