### PR TITLE
fix(delta): scorers must prove they measured what they were given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,22 @@ Three defects:
   (0.667 → 0.413). The aggregate now covers only the truvari-scoreable subset and states
   what it excluded and where each type is scored instead.
 
+#### Coverage of the planted set is now enforced, not warned about
+
+Fixing the cause is not enough, because the harness had no way to *notice* the problem:
+it reported bias and MAE over whatever survived and said `VERDICT: PASS`. A subset that
+drops the lowest-VAF stratum produces numbers that look **better** than an honest
+full-coverage run — on a reproduction of #450, bias `+0.0011` / MAE `0.0227` against
+`+0.0008` / `0.0240` for the complete set — so the metrics can never be the only gate.
+
+`scn_af_compare.py` now prints planted / scored / unscored per AF decile and exits
+non-zero above `--max-uncovered-frac` (default 10%). Every planted bin is printed even
+when nothing in it was scored: previously an excluded stratum simply *vanished from the
+table*, and a missing row is far harder to notice than a row reading
+`0 of 104 — NOTHING SCORED`. `run_subclonal_vaf_validation.sh` folds that status into
+its verdict ahead of bias/MAE, and captures it with `|| rc=$?` so the failure does not
+abort the run before `archive_run`.
+
 ### Harnesses now fail instead of reporting an unusable measurement
 
 `signature_check.sh` warned `few SNVs — fit will be noisy` below 50 and fitted anyway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,12 +68,16 @@ Three defects:
   `manta_BND FP=39` against `manta_overall FP=20`. A subset cannot have more false
   positives than the whole. Per-type precision/FP/f1 from this harness were meaningless;
   only per-type recall was ever sound.
-- **BND was unscoreable.** `truvari bench` matches by position *and size overlap*, and a
-  breakend has no `SVLEN` with `END == POS`, so truvari cannot match one however correct
-  the truth is. Adds `scripts/delta/bnd_proximity.py`, which scores junctions (not
-  records — a junction is one event described by two mate records, so record-counting
-  weighted BND 2× against DEL/DUP/INV) and is representation-agnostic, since callers
-  legitimately re-represent a junction as `<DUP:TANDEM>` at the correct coordinates.
+- **BND was scored with the wrong tool settings, not unscoreable.** truvari **can**
+  benchmark breakends — `-B/--bnddist` has existed since v5.0.0, and Delta runs v5.4.0.
+  The harness simply never passed it, and the resulting `recall=0.000` was misread as a
+  tool limitation. BND is now scored two ways, because callers represent a junction two
+  ways: breakend-to-breakend via `--bnddist`, and against a **derived junction span**
+  (one record per junction, `POS`=min, `END`=max) for callers that re-represent a
+  junction as `<DUP:TANDEM>`/`<DEL>`/`<INV>` — a span and a point record are not
+  interval-comparable, which no similarity threshold can bridge. Both are reported and
+  labelled. Spans are a comparison artifact only; `END` on an emitted BND still equals
+  `POS` per VCF 4.2 §5.4.
 - **The aggregate was dominated by unmatchable types.** BND + CNV were 23 of 47 truth
   records in one run, all guaranteed misses, capping the aggregate near 0.5 regardless of
   caller quality — and making v3.0.0's *correct* BND fix look like a regression
@@ -98,6 +102,17 @@ bar, enforced rather than moved; §3.9's own analysis used 6,225 SNVs). This was
   figure computed from nothing.
 - `eidolon/tests/vcf_validation.rs` gained whole-artifact validation of the
   `compare-vcfs` outputs.
+- **Recall denominators are now verified to cover the whole truth.** truvari's
+  `TP-base + FN` is a *post-filter* count; when a filter discarded truth records the
+  recall was computed over a subset and nothing said so. An audit of the archived runs
+  found 4 such cases in 152 per-type checks (a DEL reporting 0.800 where the full
+  denominator gives 0.727). Each comparison now checks that count against the truth it
+  was handed, prints the discarded records with `SVTYPE`/`SVLEN` (derived by differencing
+  the truth against truvari's own `tp-base`/`fn` output, so the attribution is exact) and
+  the corrected recall, and fails the job — after archiving, so a failure stays
+  diagnosable. This also closes a hole in the Rule 0 selftest: a filter drops a record
+  from base *and* comparison alike, so truth-vs-truth still scored a perfect 1.000 over
+  the surviving subset.
 
 Every fix in this release was reproduced and verified locally; no Delta time was spent
 diagnosing or confirming any of them.

--- a/scripts/delta/probe_bndspan.sh
+++ b/scripts/delta/probe_bndspan.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Rule 0 for the BND-span representation bridge.
+#
+# `selftest_truvari` compares the derived spans to THEMSELVES. That matches trivially and
+# proves nothing about the actual question, which is cross-representation:
+#
+#     does truvari -t match a derived <BND_SPAN> to the <DUP:TANDEM>/<DEL>/<INV>
+#     a caller emits for the same junction?
+#
+# That match is the entire premise of BNDspan scoring, it is the reason build_bnd_spans
+# exists, and nothing in the pipeline tests it. If it does not hold, BNDspan recall is 0
+# for reasons that are ours rather than the caller's — which is the mistake this whole
+# line of work started from.
+#
+# Known-answer, both directions, because a configuration loose enough to match anything
+# is as useless as one that matches nothing:
+#   * a synthetic caller record at the span's own coordinates MUST match
+#   * the same record shifted far away MUST NOT
+#
+# Standalone use against an existing run directory (seconds, no simulation):
+#   scripts/delta/probe_bndspan.sh --spans "$OUTDIR/truth_sv_BNDspan.vcf.gz"
+#
+# Exit 0 = the bridge works as assumed. Exit 1 = it does not, and any BNDspan number
+# produced with this configuration is meaningless.
+
+set -euo pipefail
+
+SPANS=""
+REFERENCE="${REFERENCE:-}"
+# Offset applied to the "must match" case. Real callers do not hit a breakpoint exactly;
+# job 20636298 had Manta 1 bp off. Non-zero on purpose — an exact-coordinate-only match
+# would pass here and still fail on real data.
+NEAR_OFFSET="${NEAR_OFFSET:-1}"
+# Distance for the negative control. Far beyond any breakpoint imprecision.
+FAR_OFFSET="${FAR_OFFSET:-50000}"
+WORK="${WORK:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --spans)     SPANS="$2"; shift 2 ;;
+        --reference) REFERENCE="$2"; shift 2 ;;
+        --work)      WORK="$2"; shift 2 ;;
+        -h|--help)   sed -n '2,30p' "$0"; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$SPANS" ]] || { echo "ERROR: --spans <truth_sv_BNDspan.vcf.gz> is required" >&2; exit 2; }
+[[ -f "$SPANS" ]] || { echo "ERROR: no such spans VCF: $SPANS" >&2; exit 2; }
+
+if [[ -z "$WORK" ]]; then
+    WORK="$(mktemp -d)"
+    trap 'rm -rf "$WORK"' EXIT
+fi
+mkdir -p "$WORK"
+
+n_spans=$(bcftools view -H "$SPANS" 2>/dev/null | wc -l)
+if [[ "$n_spans" -eq 0 ]]; then
+    echo "ERROR: $SPANS contains no records — nothing to probe." >&2
+    exit 1
+fi
+
+# One truth record, so the arithmetic is unambiguous: TP=1/FN=0 or TP=0/FN=1.
+TRUTH1="$WORK/probe_truth.vcf.gz"
+{ bcftools view -h "$SPANS"; bcftools view -H "$SPANS" | head -1; } \
+    | bcftools sort -O z -o "$TRUTH1" 2>/dev/null
+bcftools index -f -t "$TRUTH1"
+
+read -r P_CHROM P_POS P_END < <(bcftools query -f '%CHROM\t%POS\t%INFO/END\n' "$TRUTH1")
+echo "probe junction: $P_CHROM:$P_POS-$P_END  (span $((P_END - P_POS)) bp, of $n_spans derived)"
+
+# A caller's representation of that same junction: a tandem duplication over the span.
+# This is what Manta emitted in job 20636298 for a truth junction — POS 1 bp off, END
+# exactly on the mate — and what truvari refused to match as a BND.
+mk_dup() {  # <out.vcf.gz> <offset>
+    local out="$1" off="$2" hdr="$WORK/.hdr"
+    bcftools view -h "$SPANS" | grep -vE '^#CHROM' > "$hdr"
+    grep -q '^##ALT=<ID=DUP,' "$hdr" \
+        || echo '##ALT=<ID=DUP,Description="Duplication">' >> "$hdr"
+    { cat "$hdr"
+      bcftools view -h "$SPANS" | grep -E '^#CHROM'
+      awk -v c="$P_CHROM" -v p="$P_POS" -v e="$P_END" -v o="$off" 'BEGIN{OFS="\t"
+          print c, p+o, ".", "N", "<DUP>", 60, "PASS",
+                "SVTYPE=DUP;END=" (e+o) ";SVLEN=" (e-p), "GT", "0/1" }'
+    } | bcftools sort -O z -o "$out" 2>/dev/null
+    bcftools index -f -t "$out"
+}
+
+# -t (--typeignore) is the point: the caller says DUP, the truth says BND. --pctsize/
+# --pctseq 0 because a span and a duplication are the same interval but not the same
+# sequence claim. Matching the settings score_caller uses for BNDspan.
+run_probe() {  # <comp.vcf.gz> <out-dir>
+    truvari bench -b "$TRUTH1" -c "$1" -o "$2" \
+        --passonly -t --pctsize 0 --pctseq 0 --sizemax 100000000 \
+        ${REFERENCE:+-f "$REFERENCE"} >/dev/null 2>&1 || true
+    [[ -f "$2/summary.json" ]] || { echo "-1"; return; }
+    python3 -c "import json;d=json.load(open('$2/summary.json'));print(d.get('TP-base') or 0)"
+}
+
+NEAR="$WORK/comp_near.vcf.gz"; FAR="$WORK/comp_far.vcf.gz"
+mk_dup "$NEAR" "$NEAR_OFFSET"
+mk_dup "$FAR"  "$FAR_OFFSET"
+
+rm -rf "$WORK/out_near" "$WORK/out_far"
+tp_near=$(run_probe "$NEAR" "$WORK/out_near")
+tp_far=$(run_probe "$FAR"  "$WORK/out_far")
+
+rc=0
+echo "  positive control: <DUP> at +${NEAR_OFFSET}bp      -> TP=$tp_near  (must be 1)"
+echo "  negative control: <DUP> at +${FAR_OFFSET}bp  -> TP=$tp_far  (must be 0)"
+
+if [[ "$tp_near" == "-1" || "$tp_far" == "-1" ]]; then
+    echo "ERROR: truvari produced no summary.json — the probe could not run." >&2
+    exit 1
+fi
+if [[ "$tp_near" -ne 1 ]]; then
+    echo "FAIL: truvari did not match a caller's <DUP> to the derived <BND_SPAN> for the" >&2
+    echo "  SAME junction, ${NEAR_OFFSET}bp apart. The representation bridge does not hold, so" >&2
+    echo "  BNDspan recall measures our comparison rather than the caller. Do not report it." >&2
+    rc=1
+fi
+if [[ "$tp_far" -ne 0 ]]; then
+    echo "FAIL: truvari matched a <DUP> ${FAR_OFFSET}bp away from the junction. The" >&2
+    echo "  configuration is matching on position far more loosely than intended, so a" >&2
+    echo "  BNDspan 'match' does not mean the caller found this junction." >&2
+    rc=1
+fi
+[[ "$rc" -eq 0 ]] && echo "  BNDspan bridge: PASS (matches the same junction, rejects a distant one)"
+exit "$rc"

--- a/scripts/delta/probe_bndspan.sh
+++ b/scripts/delta/probe_bndspan.sh
@@ -17,8 +17,12 @@
 #   * a synthetic caller record at the span's own coordinates MUST match
 #   * the same record shifted far away MUST NOT
 #
-# Standalone use against an existing run directory (seconds, no simulation):
+# Standalone use against an existing run directory (seconds, no simulation). Either
+# point it at derived spans, or at the BND truth and let it derive them with the real
+# build_bnd_spans extracted from sv_pipeline.sbatch — which also checks that the ALT
+# parser works on actual eidolon output rather than on a fixture:
 #   scripts/delta/probe_bndspan.sh --spans "$OUTDIR/truth_sv_BNDspan.vcf.gz"
+#   scripts/delta/probe_bndspan.sh --bnd   "$OUTDIR/truth_sv_BND.vcf.gz"
 #
 # Exit 0 = the bridge works as assumed. Exit 1 = it does not, and any BNDspan number
 # produced with this configuration is meaningless.
@@ -26,6 +30,7 @@
 set -euo pipefail
 
 SPANS=""
+BND_TRUTH=""
 REFERENCE="${REFERENCE:-}"
 # Offset applied to the "must match" case. Real callers do not hit a breakpoint exactly;
 # job 20636298 had Manta 1 bp off. Non-zero on purpose — an exact-coordinate-only match
@@ -38,6 +43,7 @@ WORK="${WORK:-}"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --spans)     SPANS="$2"; shift 2 ;;
+        --bnd)       BND_TRUTH="$2"; shift 2 ;;
         --reference) REFERENCE="$2"; shift 2 ;;
         --work)      WORK="$2"; shift 2 ;;
         -h|--help)   sed -n '2,30p' "$0"; exit 0 ;;
@@ -45,14 +51,39 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-[[ -n "$SPANS" ]] || { echo "ERROR: --spans <truth_sv_BNDspan.vcf.gz> is required" >&2; exit 2; }
-[[ -f "$SPANS" ]] || { echo "ERROR: no such spans VCF: $SPANS" >&2; exit 2; }
+if [[ -z "$SPANS" && -z "$BND_TRUTH" ]]; then
+    echo "ERROR: one of --spans <truth_sv_BNDspan.vcf.gz> or --bnd <truth_sv_BND.vcf.gz>" >&2
+    exit 2
+fi
 
 if [[ -z "$WORK" ]]; then
     WORK="$(mktemp -d)"
     trap 'rm -rf "$WORK"' EXIT
 fi
 mkdir -p "$WORK"
+
+# Derive the spans here when given the BND truth, using the REAL function rather than a
+# reimplementation — so this also exercises the ALT parser against actual eidolon output.
+if [[ -z "$SPANS" ]]; then
+    [[ -f "$BND_TRUTH" ]] || { echo "ERROR: no such BND truth: $BND_TRUTH" >&2; exit 2; }
+    SBATCH="$(cd "$(dirname "$0")" && pwd)/sv_pipeline.sbatch"
+    [[ -f "$SBATCH" ]] || { echo "ERROR: cannot find $SBATCH to extract build_bnd_spans" >&2; exit 2; }
+    OUTDIR="$WORK"          # build_bnd_spans writes its temporaries under $OUTDIR
+    eval "$(awk '/^build_bnd_spans\(\) \{/,/^\}$/' "$SBATCH")"
+    SPANS="$WORK/derived_BNDspan.vcf.gz"
+    span_rc=0
+    build_bnd_spans "$BND_TRUTH" "$SPANS" || span_rc=$?
+    case "$span_rc" in
+        0) ;;
+        2) echo "No intra-contig junctions to span — the bridge is untestable here, and" >&2
+           echo "  BNDspan scoring would legitimately not run." >&2
+           exit 0 ;;
+        *) echo "ERROR: span derivation failed (rc=$span_rc) — cannot probe the bridge." >&2
+           exit 1 ;;
+    esac
+fi
+
+[[ -f "$SPANS" ]] || { echo "ERROR: no such spans VCF: $SPANS" >&2; exit 2; }
 
 n_spans=$(bcftools view -H "$SPANS" 2>/dev/null | wc -l)
 if [[ "$n_spans" -eq 0 ]]; then

--- a/scripts/delta/run_subclonal_vaf_validation.sh
+++ b/scripts/delta/run_subclonal_vaf_validation.sh
@@ -245,8 +245,14 @@ echo "════════════════════════�
 echo "#405 subclonal VAF reproduction — intended EIDOLON_VAF vs observed merged VAF"
 echo "════════════════════════════════════════════════════════════════"
 CMP="$OUTDIR/compare.txt"
+# scn_af_compare.py exits non-zero when too much of the planted set went unscored.
+# Capture that instead of letting `set -e` + pipefail abort here, which would skip both
+# the verdict and archive_run — the artifacts are most worth keeping when it fails.
+# `$(cmd; echo $?)` cannot be used for this: the inherited `set -e` kills the subshell
+# before echo runs. `|| rc=$?` is the form that works.
+CMP_RC=0
 python3 "$REPO_ROOT/scripts/delta/scn_af_compare.py" \
-    --truth "$SITES" --sim "$SIM" --min-depth "$MIN_DEPTH" | tee "$CMP"
+    --truth "$SITES" --sim "$SIM" --min-depth "$MIN_DEPTH" | tee "$CMP" || CMP_RC=$?
 echo "════════════════════════════════════════════════════════════════"
 
 # ── PASS/FAIL gate (don't trust a green run — parse the actual numbers) ───────
@@ -265,7 +271,14 @@ if [[ -n "$r" ]] && awk -v r="$r" -v rm="$R_MIN" 'BEGIN{exit !(r<rm)}'; then
   echo "        this depth; raise COV and/or widen SUBCLONES for a Pearson-meaningful run." >&2
 fi
 verdict=FAIL
-if [[ -n "$bias" && -n "$mae" ]] \
+# Coverage first: bias and MAE computed over a subset that dropped a whole VAF stratum
+# look BETTER than an honest full-coverage run, so they can never be the only gate.
+# That is #450 exactly — it reported clean numbers and PASS while excluding the sites
+# it existed to test.
+if [[ "$CMP_RC" -ne 0 ]]; then
+  echo "  coverage gate FAILED (scn_af_compare.py rc=$CMP_RC) — see the per-decile" >&2
+  echo "  planted/scored table above. bias and MAE are not usable." >&2
+elif [[ -n "$bias" && -n "$mae" ]] \
    && awk -v b="$absbias" -v bm="$BIAS_MAX" 'BEGIN{exit !(b<=bm)}' \
    && awk -v m="$mae" -v mm="$MAE_MAX" 'BEGIN{exit !(m<=mm)}'; then
   verdict=PASS

--- a/scripts/delta/scn_af_compare.py
+++ b/scripts/delta/scn_af_compare.py
@@ -20,6 +20,7 @@ Usage:
       --truth pool.af.vcf.gz --sim af_run.vcf.gz [--min-depth 20]
 """
 import argparse
+import collections
 import gzip
 import math
 import sys
@@ -194,6 +195,10 @@ def main():
     ap.add_argument("--sim", required=True, help="VCF B — simulated golden VCF")
     ap.add_argument("--min-depth", type=float, default=0.0,
                     help="skip sites whose total AD is below this on either side (default 0)")
+    ap.add_argument("--max-uncovered-frac", type=float, default=0.10,
+                    help="fail if more than this fraction of planted truth alleles go "
+                         "unscored (default 0.10). A metric over an unknown denominator "
+                         "is not a result, so this is enforced rather than warned about.")
     args = ap.parse_args()
 
     a, _a_sites = load_af(args.truth)
@@ -237,9 +242,8 @@ def main():
         print(f"  {zero_filled} truth allele(s) had coverage but zero observed reads "
               "-> scored as observed AF 0.0 (not dropped)")
     if only_a:
-        print(f"  WARNING: {only_a} truth allele(s) had NO coverage on the observed "
-              "side and are excluded — if this is a large fraction, the comparison "
-              "does not cover the full planted set.", file=sys.stderr)
+        print(f"  {only_a} truth allele(s) had NO coverage on the observed side and are "
+              f"excluded ({only_a / len(a):.1%} of the planted set).", file=sys.stderr)
     if args.min_depth > 0:
         print(f"min-depth {args.min_depth:g}: {gated} shared sites gated, {len(xs)} compared")
     if len(xs) < 2:
@@ -252,12 +256,35 @@ def main():
     print(f"MAE={mae:.4f}  RMSE={rmse:.4f}  mean(sim-truth)={sum(diffs)/len(diffs):+.4f}")
     print("  target: r>=0.95 and per-bin MAE within AF-estimation noise at that coverage")
 
-    print("per-AF-decile MAE (truth bin):")
-    for lo in [i / 10 for i in range(10)]:
-        hi = lo + 0.1
-        bd = [abs(y - x) for x, y in zip(xs, ys) if (lo <= x < hi or (hi >= 1.0 and x == 1.0))]
-        if bd:
-            print(f"  [{lo:.1f},{hi:.1f})  n={len(bd):6d}  MAE={sum(bd)/len(bd):.4f}")
+    def _bin(af):
+        return min(int(af * 10), 9)
+
+    planted = collections.Counter(_bin(af) for af, _dp in a.values())
+
+    print("per-AF-decile coverage and MAE (truth bin):")
+    print(f"  {'bin':<12} {'planted':>8} {'scored':>8} {'unscored':>9}   MAE")
+    shortfall = 0
+    for i in range(10):
+        if not planted.get(i):
+            continue
+        lo, hi = i / 10, i / 10 + 0.1
+        bd = [abs(y - x) for x, y in zip(xs, ys) if _bin(x) == i]
+        n_p, n_s = planted[i], len(bd)
+        shortfall += n_p - n_s
+        mae_s = f"{sum(bd) / len(bd):.4f}" if bd else "n/a — NOTHING SCORED"
+        flag = "" if n_p == n_s else "  <-- incomplete"
+        print(f"  [{lo:.1f},{hi:.1f})   {n_p:>8} {n_s:>8} {n_p - n_s:>9}   {mae_s}{flag}")
+    print(f"  total planted={sum(planted.values())}  scored={len(xs)}  "
+          f"unscored={shortfall} ({shortfall / sum(planted.values()):.1%})")
+
+    # Enforced, not advised: a bias/MAE computed over a subset that silently omits the
+    # lowest-VAF stratum is exactly the #450 failure, and it read as a clean PASS.
+    uncovered = (len(a) - len(xs)) / len(a)
+    if uncovered > args.max_uncovered_frac:
+        sys.exit(f"FAIL: {uncovered:.1%} of planted truth alleles went unscored "
+                 f"(limit {args.max_uncovered_frac:.1%}). The reported bias/MAE cover a "
+                 f"subset of the planted set and must not be quoted. Attribute the "
+                 f"shortfall per stratum above before believing any of it.")
 
 
 if __name__ == "__main__":

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -259,12 +259,6 @@ done
 # END==POS, and CNV is a copy-ratio call — truvari matches neither, so including
 # them made every aggregate a guaranteed partial miss (#457). They are scored
 # separately: BND by breakpoint proximity, CNV by the stage-4c direction check.
-# Derive comparable junction spans from the BND pairs (see build_bnd_spans).
-if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
-    build_bnd_spans "$OUTDIR/truth_sv_BND.vcf.gz" "$OUTDIR/truth_sv_BNDspan.vcf.gz" \
-        || echo "  (BND span derivation produced nothing — no intra-contig junctions?)"
-fi
-
 # What would --sizemax silently discard? Truvari drops oversized records BEFORE
 # comparison, so an unreported ceiling turns real events into guaranteed misses.
 n_over=$(bcftools query -f '%INFO/SVLEN\n' "$TRUTH_SV" 2>/dev/null \
@@ -512,11 +506,19 @@ print(f'    reported {tp}/$base={tp/$base:.3f}  ->  over the full truth {tp}/$n_
 # COMPARISON artifact, not an output format — END on a real BND must equal POS. Only
 # intra-contig junctions can become spans; inter-contig ones are counted and skipped.
 build_bnd_spans() {  # <bnd_truth.vcf.gz> <out.vcf.gz>
+    # Exit status is three-way on purpose, because "no spans" has two very different
+    # meanings and the caller must not treat them alike:
+    #   0 = spans written
+    #   2 = nothing to write because every junction is inter-contig (legitimate)
+    #   1 = anything else (a defect; the previous version reported this as case 2)
     local src="$1" dst="$2"
-    [[ -f "$src" ]] || return 1
-    local body="$OUTDIR/.bnd_span_body"
+    [[ -f "$src" ]] || { echo "  ERROR: BND spans: no BND truth at $src" >&2; return 1; }
+    local body="$OUTDIR/.bnd_span_body" stats="$OUTDIR/.bnd_span_stats"
+    local hdr="$OUTDIR/.bnd_span_hdr" err="$OUTDIR/.bnd_span_err"
+    rm -f "$body" "$stats" "$hdr" "$err"
+
     bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\n' "$src" \
-      | awk -F'\t' 'BEGIN{OFS="\t"}
+      | awk -F'\t' -v stats="$stats" 'BEGIN{OFS="\t"}
           { alt=$4; gsub(/[][]/, "|", alt); n=split(alt, p, "|"); loc=""
             for (i=1;i<=n;i++) if (p[i] ~ /:/) { loc=p[i]; break }
             if (loc == "") { bad++; next }
@@ -528,18 +530,66 @@ build_bnd_spans() {  # <bnd_truth.vcf.gz> <out.vcf.gz>
             seen[key]=1
             print $1, lo, ".", $3, "<BND_SPAN>", 37, "PASS", \
                   "SVTYPE=BND;END=" hi ";SVLEN=" (hi-lo), "GT", "0/1" }
-          END{ printf("  BND spans: %d junction(s) from %d record(s) "\
+          END{ print length(seen), dup+0, inter+0, bad+0 > stats
+               printf("  BND spans: %d junction(s) from %d record(s) "\
                       "(inter-contig skipped=%d, unparsable ALT=%d)\n",
                       length(seen), length(seen)+dup+inter+bad, inter+0, bad+0) > "/dev/stderr" }' \
       > "$body"
-    if [[ ! -s "$body" ]]; then rm -f "$body"; return 1; fi
-    { bcftools view -h "$src" | grep -vE '^#CHROM'
-      echo '##ALT=<ID=BND_SPAN,Description="Derived: intra-contig BND junction as a span (comparison only)">'
-      echo '##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Junction span">'
+
+    local n_junc dup inter bad
+    if ! read -r n_junc dup inter bad < "$stats" 2>/dev/null; then
+        echo "  ERROR: BND spans: derivation produced no statistics — awk did not run." >&2
+        rm -f "$body" "$stats"; return 1
+    fi
+    rm -f "$stats"
+    if [[ "$n_junc" -eq 0 ]]; then
+        rm -f "$body"
+        if [[ "$bad" -eq 0 && "$inter" -gt 0 ]]; then
+            echo "  BND spans: none derived — all $inter junction record(s) are inter-contig," >&2
+            echo "    which cannot be expressed as a span. Expected on a multi-contig reference." >&2
+            return 2
+        fi
+        echo "  ERROR: BND spans: 0 junctions derived from a non-empty BND truth" >&2
+        echo "    (unparsable ALT=$bad, inter-contig=$inter). The ALT parser or the truth is wrong." >&2
+        return 1
+    fi
+
+    # Inherit the source header, then backfill ONLY what is missing. The body writes
+    # SVTYPE/END/SVLEN and a GT column; an undeclared END is parsed as Type=String and
+    # kills bcftools outright, which the old `2>/dev/null` hid while still returning 0.
+    bcftools view -h "$src" | grep -vE '^#CHROM' > "$hdr"
+    local decl id kind
+    for decl in '##ALT=<ID=BND_SPAN,Description="Derived: intra-contig BND junction as a span (comparison only)">' \
+                '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">' \
+                '##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">' \
+                '##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">' \
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">'; do
+        id="${decl#*<ID=}"; id="${id%%,*}"
+        kind="${decl%%=*}"
+        grep -q "^${kind}=<ID=${id}," "$hdr" || echo "$decl" >> "$hdr"
+    done
+
+    local rc=0
+    { cat "$hdr"
       bcftools view -h "$src" | grep -E '^#CHROM'
-      cat "$body"; } | bcftools sort -O z -o "$dst" 2>/dev/null
+      cat "$body"; } | bcftools sort -O z -o "$dst" 2> "$err" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        echo "  ERROR: BND spans: bcftools sort failed (rc=$rc):" >&2
+        sed 's/^/      /' "$err" >&2
+        rm -f "$body" "$hdr" "$err" "$dst"; return 1
+    fi
     bcftools index -f -t "$dst" 2>/dev/null || true
-    rm -f "$body"
+
+    # Coverage of its own input: the file must hold every junction awk counted.
+    local n_written; n_written=$(bcftools view -H "$dst" 2>/dev/null | wc -l)
+    if [[ "$n_written" -ne "$n_junc" ]]; then
+        echo "  ERROR: BND spans: derived $n_junc junction(s) but wrote $n_written record(s)." >&2
+        sed 's/^/      /' "$err" >&2
+        rm -f "$body" "$hdr" "$err"; return 1
+    fi
+    echo "  BND spans: $n_written junction span(s) -> $(basename "$dst")"
+    rm -f "$body" "$hdr" "$err"
+    return 0
 }
 
 # ── Rule 0: calibrate the scorer before believing it ────────────────────
@@ -618,7 +668,26 @@ score_caller() {  # <caller> <comp.vcf.gz>
     echo "  === $caller (cSample=$(comp_sample "$comp")) ==="
 
     if [[ -f "$TRUTH_SCOREABLE" ]]; then
-        run_truvari "$TRUTH_SCOREABLE" "${caller}_overall" "$comp"
+        # The aggregate truth excludes BND and CNV, so the query must exclude them too.
+        # Otherwise every BND/CNV call the caller made is a false positive against a
+        # truth that never contained one — job 20675480 reported manta_overall FP=24
+        # from a 24-record truth, with Manta's BND calls making up the bulk. `-e`
+        # (exclude) rather than `-i`, so a record with no SVTYPE at all is kept instead
+        # of silently dropped.
+        local qs="$OUTDIR/${caller}_calls_scoreable.vcf.gz"
+        if ! bcftools view -e 'INFO/SVTYPE="BND" || INFO/SVTYPE="CNV"' \
+                -O z -o "$qs" "$comp" 2>/dev/null; then
+            echo "  ERROR: $caller: could not build the aggregate query subset —" >&2
+            echo "    skipping the aggregate rather than scoring an unfiltered query." >&2
+            SCORE_COVERAGE_FAIL=$((SCORE_COVERAGE_FAIL + 1))
+        else
+            bcftools index -f -t "$qs" 2>/dev/null || true
+            local n_all n_sub
+            n_all=$(bcftools view -H "$comp" 2>/dev/null | wc -l)
+            n_sub=$(bcftools view -H "$qs" 2>/dev/null | wc -l)
+            echo "  (aggregate query: $n_sub of $n_all $caller call(s); $((n_all - n_sub)) BND/CNV call(s) excluded, scored separately)"
+            run_truvari "$TRUTH_SCOREABLE" "${caller}_overall" "$qs"
+        fi
     else
         echo "  ($caller: no truvari-scoreable truth types — aggregate skipped)"
     fi
@@ -642,24 +711,66 @@ score_caller() {  # <caller> <comp.vcf.gz>
         fi
     done
 
-    # BND, representation 1: breakend-to-breakend.
+    # BND, representation 1: breakend-to-breakend. The query is the caller's BND
+    # records ONLY — comparing breakends to breakends. Passing the whole call set here
+    # made every non-BND call a false positive: job 20675480 reported manta_BND FP=43
+    # against manta_overall FP=24, and a subset cannot have more false positives than
+    # the whole. That was #457's defect surviving in the one run it never covered.
     if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
-        run_truvari "$OUTDIR/truth_sv_BND.vcf.gz" "${caller}_BND" "$comp" \
-            --bnddist "$BND_DIST"
+        local qb="$OUTDIR/${caller}_calls_BND.vcf.gz"
+        bcftools view -i 'INFO/SVTYPE="BND"' -O z -o "$qb" "$comp" 2>/dev/null || true
+        if [[ -f "$qb" ]] && [[ "$(bcftools view -H "$qb" 2>/dev/null | wc -l)" -gt 0 ]]; then
+            bcftools index -f -t "$qb" 2>/dev/null || true
+            run_truvari "$OUTDIR/truth_sv_BND.vcf.gz" "${caller}_BND" "$qb" \
+                --bnddist "$BND_DIST"
+        else
+            rm -f "$qb" "${qb}.tbi"
+            echo "  ${caller}_BND recall=0.000  (caller emitted no BND records)"
+        fi
     fi
     # BND, representation 2: junction spans vs whatever type the caller used. -t
     # (--typeignore) is required: the caller legitimately calls a junction a DUP.
+    #
+    # The query is deliberately UNFILTERED here — the whole point is that the caller may
+    # have used any type for the junction, so it cannot be narrowed by type. That makes
+    # recall the measurement and FP/precision uninterpretable (every unrelated call is
+    # an unmatched comp record), so say so rather than let the number be quoted.
     if [[ -f "$OUTDIR/truth_sv_BNDspan.vcf.gz" ]]; then
         run_truvari "$OUTDIR/truth_sv_BNDspan.vcf.gz" "${caller}_BNDspan" "$comp" -t
+        echo "    ^ BNDspan: recall is the measurement; precision/FP/f1 are NOT — the query"
+        echo "      is intentionally unfiltered because the caller may use any SVTYPE here."
     fi
 }
 
 # ── Rule 0: calibrate every scorer before believing any of it ────────────
-echo "[5/5] Calibrating scorers (truth-vs-truth must be perfect; decoy must be zero)..."
+# Derive comparable junction spans from the BND pairs (see build_bnd_spans). This runs
+# HERE, not in stage 3b, because bash resolves function names at call time: the call used
+# to sit ~250 lines above the definition, so it was `command not found` (127) on every
+# run and the `||` branch reported it as "no intra-contig junctions". The BNDspan scoring
+# path — the one that recovers a caller which re-represents a junction — therefore never
+# executed. Handle every status explicitly; an unexpected rc must not read as success.
+# Hoisted above the span derivation: a failed derivation is a calibration failure, and
+# the flag must exist before anything can set it (set -u).
 CAL_FAIL=0
 # Counts per-type comparisons whose recall denominator did not cover the whole truth.
 # Evaluated after ALL scoring so every discrepancy is reported, not just the first.
 SCORE_COVERAGE_FAIL=0
+
+BND_SPAN_RC=0
+if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
+    build_bnd_spans "$OUTDIR/truth_sv_BND.vcf.gz" "$OUTDIR/truth_sv_BNDspan.vcf.gz" \
+        || BND_SPAN_RC=$?
+    case "$BND_SPAN_RC" in
+        0) ;;                                   # spans written
+        2) echo "  (BNDspan scoring skipped: no intra-contig junctions to span)" ;;
+        *) echo "ERROR: BND span derivation failed (rc=$BND_SPAN_RC) — BNDspan scoring" >&2
+           echo "  cannot run, so a caller that re-represents junctions will score 0" >&2
+           echo "  recall for reasons that are ours, not the caller's." >&2
+           CAL_FAIL=1 ;;
+    esac
+fi
+
+echo "[5/5] Calibrating scorers (truth-vs-truth must be perfect; decoy must be zero)..."
 if [[ -f "$TRUTH_SCOREABLE" ]]; then
     selftest_truvari "$TRUTH_SCOREABLE" scoreable || CAL_FAIL=1
     decoy_truvari    "$TRUTH_SCOREABLE" scoreable

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -437,9 +437,66 @@ s = json.load(open(sys.argv[1])); name = sys.argv[2]
 print(f"  {name:<18} recall={(s.get('recall') or 0):.3f}  precision={(s.get('precision') or 0):.3f}  "
       f"f1={(s.get('f1') or 0):.3f}  TP={s.get('TP-base') or 0}  FN={s.get('FN') or 0}  FP={s.get('FP') or 0}")
 PY
+        check_denominator "$truth" "$out" "$label" || true
     else
         echo "  $label: truvari produced no summary.json (see $out)"
+        SCORE_COVERAGE_FAIL=$((SCORE_COVERAGE_FAIL + 1))
     fi
+}
+
+# Coverage check: truvari's TP-base+FN is its POST-filter base count. If that is less than
+# the number of records in the truth we handed it, records were discarded before comparison
+# and the reported recall was computed over a SUBSET — a wrong denominator, silently.
+#
+# This checks the OUTCOME rather than enumerating causes, so it generalises past any one
+# filter. An audit of the archived runs found 4 such cases in 152 per-type checks (a DEL in
+# job_19758751 reported 0.800 where the full denominator gives 0.727; an INV in
+# job_20636298 reported 0.800 vs 0.667) and nothing in the output said so.
+#
+# It also ATTRIBUTES the loss: every base record truvari considered lands in tp-base.vcf.gz
+# or fn.vcf.gz, so truth-minus-those is exactly the discarded set, printed with SVTYPE/SVLEN
+# so the responsible filter is obvious. eidolon's own floor is MIN_SV_LENGTH_BP=50, equal to
+# truvari's --sizemin default, so a size-driven drop here means the LARGE end (--sizemax).
+check_denominator() {  # <truth.vcf.gz> <truvari_out_dir> <label>
+    local truth="$1" out="$2" label="$3"
+    local n_truth base
+    n_truth=$(bcftools view -H "$truth" 2>/dev/null | wc -l)
+    base=$(python3 -c "import json;d=json.load(open('$out/summary.json'));print((d.get('TP-base') or 0)+(d.get('FN') or 0))" 2>/dev/null || echo 0)
+    [[ "$n_truth" -eq "$base" ]] && return 0
+
+    echo "  ERROR: $label scored only $base of $n_truth truth record(s); $((n_truth - base)) discarded" >&2
+    echo "    before comparison, so the recall above used the WRONG DENOMINATOR." >&2
+    if [[ "$base" -gt 0 ]]; then
+        python3 -c "
+import json
+d = json.load(open('$out/summary.json')); tp = d.get('TP-base') or 0
+print(f'    reported {tp}/$base={tp/$base:.3f}  ->  over the full truth {tp}/$n_truth={tp/$n_truth:.3f}')" >&2
+    fi
+
+    # Attribute it: every base record truvari considered lands in tp-base or fn, so
+    # truth-minus-those is exactly what was discarded. awk-join (not join(1)) to avoid
+    # depending on key collation matching between two independently sorted streams.
+    local considered="$OUTDIR/.considered_$label" f found=0
+    : > "$considered"
+    for f in "$out/tp-base.vcf.gz" "$out/fn.vcf.gz"; do
+        if [[ -f "$f" ]]; then
+            bcftools query -f '%CHROM\t%POS\n' "$f" >> "$considered" 2>/dev/null && found=1
+        fi
+    done
+    if [[ "$found" -eq 1 ]]; then
+        echo "    discarded records (CHROM POS SVTYPE SVLEN); --sizemax=$TRUVARI_SIZEMAX:" >&2
+        bcftools query -f '%CHROM\t%POS\t%INFO/SVTYPE\t%INFO/SVLEN\n' "$truth" 2>/dev/null \
+          | awk -F'\t' -v seen="$considered" '
+              BEGIN { while ((getline line < seen) > 0) { split(line, k, "\t"); c[k[1] "~" k[2]] = 1 } }
+              !((($1 "~" $2) in c)) { n++; if (n <= 10) printf "      %s %s %s %s\n", $1, $2, $3, $4 }
+              END { if (n > 10) printf "      ... and %d more\n", n - 10 }' >&2
+    else
+        echo "    (no tp-base/fn VCF in $out — cannot attribute; inspect it directly)" >&2
+    fi
+    rm -f "$considered"
+
+    SCORE_COVERAGE_FAIL=$((SCORE_COVERAGE_FAIL + 1))
+    return 1
 }
 
 # ── BND junction spans: a comparable representation ──────────────────────
@@ -501,7 +558,11 @@ selftest_truvari() {  # <truth.vcf.gz> <label> [extra args...]
     local r=0
     [[ -f "$out/summary.json" ]] && r=$(python3 -c "import json,sys;print(json.load(open('$out/summary.json')).get('recall') or 0)")
     if awk -v r="$r" 'BEGIN{exit !(r > 0.999)}'; then
-        echo "  selftest $label: PASS (truth vs truth recall=$r)"
+        # recall=1.000 is necessary but NOT sufficient: a filter that discards a record
+        # removes it from base AND comp alike, so the subset still matches itself
+        # perfectly. Only the denominator check sees that.
+        check_denominator "$truth" "$out" "selftest_$label" || return 1
+        echo "  selftest $label: PASS (truth vs truth recall=$r, all $(bcftools view -H "$truth" | wc -l) records scored)"
         return 0
     fi
     echo "ERROR: scorer selftest FAILED for $label — truth vs truth recall=$r, expected 1.000." >&2
@@ -596,6 +657,9 @@ score_caller() {  # <caller> <comp.vcf.gz>
 # ── Rule 0: calibrate every scorer before believing any of it ────────────
 echo "[5/5] Calibrating scorers (truth-vs-truth must be perfect; decoy must be zero)..."
 CAL_FAIL=0
+# Counts per-type comparisons whose recall denominator did not cover the whole truth.
+# Evaluated after ALL scoring so every discrepancy is reported, not just the first.
+SCORE_COVERAGE_FAIL=0
 if [[ -f "$TRUTH_SCOREABLE" ]]; then
     selftest_truvari "$TRUTH_SCOREABLE" scoreable || CAL_FAIL=1
     decoy_truvari    "$TRUTH_SCOREABLE" scoreable
@@ -606,21 +670,34 @@ fi
 if [[ -f "$OUTDIR/truth_sv_BNDspan.vcf.gz" ]]; then
     selftest_truvari "$OUTDIR/truth_sv_BNDspan.vcf.gz" BNDspan -t || CAL_FAIL=1
 fi
+# Skip scoring rather than exit: the calibration artifacts and the truth VCFs are worth
+# archiving precisely BECAUSE the scorer misbehaved, and the exit below runs after
+# archive_run. Scoring itself is pointless with a scorer that cannot score a known answer.
 if [[ "$CAL_FAIL" -ne 0 ]]; then
     echo "ERROR: at least one scorer cannot match the truth to itself — refusing to" >&2
     echo "  report caller results computed with a configuration that demonstrably" >&2
-    echo "  cannot score a perfect answer." >&2
-    exit 1
+    echo "  cannot score a perfect answer. Skipping caller scoring; see the selftest" >&2
+    echo "  output above and the archived truvari_selftest_* directories." >&2
+else
+    score_caller manta "$MANTA_SV"
+    [[ -n "$DELLY_SV" ]] && score_caller delly "$DELLY_SV"
 fi
 
-score_caller manta "$MANTA_SV"
-[[ -n "$DELLY_SV" ]] && score_caller delly "$DELLY_SV"
-
 # ── Summary ──────────────────────────────────────────────────────────────
+# Never print an unqualified "complete" over a run whose numbers are not usable — a
+# summary banner that reads as success regardless of outcome is how a bad run gets
+# believed. The detail follows in the deferred failure gate below.
+if [[ "$CAL_FAIL" -ne 0 ]]; then
+    RUN_STATUS="FAILED (scorer calibration) — no caller results"
+elif [[ "$SCORE_COVERAGE_FAIL" -gt 0 ]]; then
+    RUN_STATUS="FAILED ($SCORE_COVERAGE_FAIL comparison(s) scored a SUBSET of the truth)"
+else
+    RUN_STATUS="complete"
+fi
 cat <<EOF
 
 ════════════════════════════════════════════════════════════════
-SV validation pipeline complete — Job $SLURM_JOB_ID
+SV validation pipeline $RUN_STATUS — Job $SLURM_JOB_ID
 
 Inputs:
   Reference:    $REFERENCE
@@ -653,3 +730,23 @@ fi
 # Persist report artifacts off scratch + record provenance/resources.
 # (manta overall always exists; delly summaries remain under $OUTDIR/truvari_delly_*)
 archive_run sv "$OUTDIR" truvari_manta_overall/summary.json
+
+# ── Deferred failure gate ────────────────────────────────────────────────
+# Deliberately last. Every discrepancy is reported inline next to the comparison it
+# affects (so the scale is visible rather than just the first case), the artifacts are
+# archived (so a failure is diagnosable after the fact), and only then does the job
+# exit non-zero — because a run that published recalls over a subset of the truth, or
+# scored with an uncalibrated scorer, must not look successful to whoever reads the
+# SLURM exit status.
+if [[ "$CAL_FAIL" -ne 0 || "$SCORE_COVERAGE_FAIL" -gt 0 ]]; then
+    echo "" >&2
+    [[ "$CAL_FAIL" -ne 0 ]] && \
+        echo "FAILED: scorer calibration (Rule 0) — no caller results were produced." >&2
+    if [[ "$SCORE_COVERAGE_FAIL" -gt 0 ]]; then
+        echo "FAILED: $SCORE_COVERAGE_FAIL comparison(s) did not score the whole truth set." >&2
+        echo "  Those recalls are over a subset and must not be reported as-is. Raise" >&2
+        echo "  TRUVARI_SIZEMAX (currently $TRUVARI_SIZEMAX) or relax the size filters," >&2
+        echo "  then re-score. Artifacts are archived." >&2
+    fi
+    exit 1
+fi

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -780,6 +780,14 @@ if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
 fi
 if [[ -f "$OUTDIR/truth_sv_BNDspan.vcf.gz" ]]; then
     selftest_truvari "$OUTDIR/truth_sv_BNDspan.vcf.gz" BNDspan -t || CAL_FAIL=1
+    # The selftest above compares spans to THEMSELVES, which matches trivially. It says
+    # nothing about the premise BNDspan actually rests on: that truvari -t matches a
+    # derived <BND_SPAN> to the <DUP:TANDEM> a caller emits for the same junction. If
+    # that does not hold, BNDspan recall measures our comparison, not the caller — the
+    # exact error this line of work began with. Known-answer, both directions.
+    "$REPO_ROOT/scripts/delta/probe_bndspan.sh" \
+        --spans "$OUTDIR/truth_sv_BNDspan.vcf.gz" \
+        --reference "$REFERENCE" --work "$OUTDIR/.bndspan_probe" || CAL_FAIL=1
 fi
 # Skip scoring rather than exit: the calibration artifacts and the truth VCFs are worth
 # archiving precisely BECAUSE the scorer misbehaved, and the exit below runs after


### PR DESCRIPTION
Three defects, one shape: a scorer reported a plausible number without checking it had actually measured its input. Two were found by the `sizemax` audit and the v3.0.1 Delta runs (jobs 20675479 / 20675480).

## 1. Recall denominators were never checked against the truth

truvari's `TP-base + FN` is a **post-filter** count. When a filter discards truth records, recall is computed over a subset and nothing says so. The audit found **4 such cases in 152 per-type checks** (job_19758751 DEL reported 0.800 where the full denominator gives 0.727; job_20636298 INV 0.800 vs 0.667).

`check_denominator` compares the scorer's base count against the truth handed to it, checking the **outcome** rather than enumerating causes so it generalises past `--sizemax`. On a mismatch it prints the corrected recall and attributes the loss exactly, by differencing the truth against truvari's own `tp-base`/`fn` output.

**This also closed a hole in Rule 0.** A filter drops a record from base *and* comparison alike, so truth-vs-truth still scores a perfect **1.000** over the surviving subset — the selftest could only ever catch a *total* drop, never a partial one.

## 2. BND span derivation never ran, and reported that as a fact about the data

`build_bnd_spans` was **called at line 264 and defined at line 514**. Bash resolves function names at call time, so every run hit `command not found` (127), and the call site's `|| echo "(BND span derivation produced nothing — no intra-contig junctions?)"` turned exit 127 into a plausible statement about the data. On a single-contig reference, where every junction is necessarily intra-contig, that explanation was not merely wrong but impossible.

So the BNDspan path — the mechanism that recovers a caller which re-represents a junction, and the entire reason the derivation exists — **has never executed**. `manta_BND recall=0.000` in job 20675480 was measured with the only thing that could have matched it absent, and Manta emits inversions as breakend pairs (`manta_INV: caller emitted no INV records`), so it is the case that most needed it.

A second, independent silent failure sat underneath: the body writes `END=` but only `SVLEN` was backfilled, so an undeclared `END` parses as `Type=String` and `bcftools sort` dies — hidden by `2>/dev/null`, after which the function **returned 0 having written nothing**. It now inherits the source header and backfills only what is missing, surfaces sort's stderr, and verifies the written record count equals the junction count it derived.

Exit status is three-way, because "no spans" has two unrelated meanings: `0` written, `2` all junctions inter-contig (legitimate), `1` anything else. The caller handles each with an explicit `*)` arm.

## 3. #457's query filtering missed the two runs that needed it

Per-type runs filtered the query; the aggregate and BND runs passed the whole call set, so truvari counted every record of an excluded type as a false positive:

- job 20675480: `manta_BND FP=43` against `manta_overall FP=24`. **A subset cannot have more false positives than the whole** — the same arithmetic impossibility #457 was opened for.
- The aggregate truth excludes BND/CNV by construction, so the query now does too (via `-e`, so a record with no `SVTYPE` is kept rather than silently dropped), and logs what it set aside.
- The BND run compares breakends to breakends, so its query is now the caller's BND records only.

`BNDspan`'s query stays unfiltered **by design** — the caller may use any `SVTYPE` for a junction — which makes recall the measurement and precision/FP/f1 uninterpretable there. The output now says so rather than leaving the number to be quoted.

## 4. VAF coverage is enforced, not warned about

Job 20675479 **confirms the #450 fix on real data**: three clusters in the per-decile table where there were two, 543 of 567 planted sites scored where 407 were. But the harness still could not notice its own failure mode — `only-truth=24` was a one-line stderr warning, and localising those 24 meant differencing two tables by hand.

The metrics cannot be the coverage gate, because dropping the lowest-VAF stratum makes them look **better**:

| | bias | MAE | r | verdict |
|---|---|---|---|---|
| complete set | +0.0008 | 0.0240 | 0.9846 | PASS |
| #450 (lowest cluster excluded) | **+0.0011** | **0.0227** | **0.9803** | PASS ← |

Both pass every threshold; only the denominator separates them. `scn_af_compare.py` now prints planted/scored/unscored per decile and exits non-zero above `--max-uncovered-frac` (default 10%). Every planted bin prints even when nothing in it survived — `if bd:` meant an excluded stratum *vanished from the table*, and a missing row is far harder to spot than `0 of 104 — NOTHING SCORED`.

## Failure handling

Both pipelines previously exited **before** `archive_run`, discarding the artifacts most worth keeping. Failures are now deferred past archiving: every discrepancy is reported inline next to the comparison it affects, artifacts are archived, and only then does the job exit non-zero. The SV summary banner no longer prints an unqualified `complete` over a run whose numbers are unusable.

## Evidence

All local, driving the **real** functions extracted from the scripts rather than copies:

- Denominator check: at `--sizemax 5000000` on a 5-record truth with one 20 Mb DEL, pre-change output is `recall=1.000 TP=4` and `selftest: PASS` — **both look correct**; the check fires in both places and names the discarded record. At an adequate `sizemax` it is completely silent.
- Forward-reference failure reproduced in isolation: exit 127 swallowed by the `||` branch, script exits 0.
- `build_bnd_spans` across all three paths (intra+inter / all-inter / unparsable ALT) → `0`/`2`/`1`, writing exactly the 2 expected spans — on a fixture that does **not** declare `END`, i.e. the case that previously failed silently.
- VAF gate on fixtures reproducing job 20675479's architecture: passes at the observed 4.2% shortfall and localises it per stratum; fails with the zero row when the lowest cluster is excluded. Driving the real gate block with #450's `compare.txt` gives PASS at `rc=0` and FAIL at `rc=1` on **identical** bias/MAE.
- `set -e` interactions checked rather than assumed: a short-circuited `[[ … ]] && cmd` does not abort, and `cmd | tee || rc=$?` captures the status without aborting.

## Status

**In progress, not done.** Locally vetted; **not yet exercised against real truvari on Delta** (not installed on this workstation).

Specifically **NOT verified**: that truvari with `-t` actually matches a derived `<BND_SPAN>` to a caller's `<DUP:TANDEM>` at the same coordinates. That is the prediction the next `sv_pipeline.sbatch` run tests, and it is the one that decides whether BND recall was ever a real result.

CHANGELOG also corrected: the v3.0.1 entry asserted truvari "cannot match" a breakend and credited a `bnd_proximity.py` that was never committed. `--bnddist` has existed since truvari v5.0.0; Delta runs v5.4.0.
