### PR TITLE
fix(delta): BNDspan cannot measure junction recall — disable it on probe failure

### DIFF
--- a/scripts/delta/probe_bndspan.sh
+++ b/scripts/delta/probe_bndspan.sh
@@ -151,9 +151,21 @@ if [[ "$tp_near" -ne 1 ]]; then
     rc=1
 fi
 if [[ "$tp_far" -ne 0 ]]; then
-    echo "FAIL: truvari matched a <DUP> ${FAR_OFFSET}bp away from the junction. The" >&2
-    echo "  configuration is matching on position far more loosely than intended, so a" >&2
-    echo "  BNDspan 'match' does not mean the caller found this junction." >&2
+    span=$((P_END - P_POS))
+    ovl=$(awk -v s="$span" -v o="$FAR_OFFSET" 'BEGIN{printf "%.4f", (s-o)/s}')
+    echo "FAIL: truvari matched a <DUP> ${FAR_OFFSET}bp away from the junction, so a BNDspan" >&2
+    echo "  'match' does not mean the caller found this junction." >&2
+    echo "" >&2
+    echo "  This is not a tuning problem. truvari gates position by PADDED INTERVAL OVERLAP," >&2
+    echo "  not endpoint proximity: this span is ${span}bp, so a ${FAR_OFFSET}bp displacement still" >&2
+    echo "  leaves reciprocal overlap at $ovl. Overlap is scale-relative, so on a span this" >&2
+    echo "  large NO overlap threshold can detect a breakpoint error of this size, and" >&2
+    echo "  --refdist does not constrain endpoints once the intervals overlap at all." >&2
+    echo "" >&2
+    echo "  Collapsing a junction (two precise points) into a span (one huge interval)" >&2
+    echo "  discards the precision the measurement depends on. Junction recall needs" >&2
+    echo "  endpoint proximity — truvari --bnddist for a caller that emits breakends, or an" >&2
+    echo "  explicit two-breakpoint check for one that re-represents them." >&2
     rc=1
 fi
 [[ "$rc" -eq 0 ]] && echo "  BNDspan bridge: PASS (matches the same junction, rejects a distant one)"

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -735,10 +735,12 @@ score_caller() {  # <caller> <comp.vcf.gz>
     # have used any type for the junction, so it cannot be narrowed by type. That makes
     # recall the measurement and FP/precision uninterpretable (every unrelated call is
     # an unmatched comp record), so say so rather than let the number be quoted.
-    if [[ -f "$OUTDIR/truth_sv_BNDspan.vcf.gz" ]]; then
+    if [[ -f "$OUTDIR/truth_sv_BNDspan.vcf.gz" && "$BNDSPAN_VALID" -eq 1 ]]; then
         run_truvari "$OUTDIR/truth_sv_BNDspan.vcf.gz" "${caller}_BNDspan" "$comp" -t
         echo "    ^ BNDspan: recall is the measurement; precision/FP/f1 are NOT — the query"
         echo "      is intentionally unfiltered because the caller may use any SVTYPE here."
+    elif [[ -f "$OUTDIR/truth_sv_BNDspan.vcf.gz" ]]; then
+        echo "  ${caller}_BNDspan: not scored (representation bridge failed calibration)"
     fi
 }
 
@@ -757,6 +759,9 @@ CAL_FAIL=0
 SCORE_COVERAGE_FAIL=0
 
 BND_SPAN_RC=0
+# Set to 0 by probe_bndspan.sh when truvari cannot distinguish a correct junction call
+# from a displaced one at this scale — see the probe for why that is not tunable.
+BNDSPAN_VALID=1
 if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
     build_bnd_spans "$OUTDIR/truth_sv_BND.vcf.gz" "$OUTDIR/truth_sv_BNDspan.vcf.gz" \
         || BND_SPAN_RC=$?
@@ -787,7 +792,14 @@ if [[ -f "$OUTDIR/truth_sv_BNDspan.vcf.gz" ]]; then
     # exact error this line of work began with. Known-answer, both directions.
     "$REPO_ROOT/scripts/delta/probe_bndspan.sh" \
         --spans "$OUTDIR/truth_sv_BNDspan.vcf.gz" \
-        --reference "$REFERENCE" --work "$OUTDIR/.bndspan_probe" || CAL_FAIL=1
+        --reference "$REFERENCE" --work "$OUTDIR/.bndspan_probe" || BNDSPAN_VALID=0
+    # A failed bridge disables BNDspan ONLY. It says nothing about DEL/DUP/INV scoring,
+    # so failing the whole calibration here would throw away sound measurements.
+    if [[ "$BNDSPAN_VALID" -eq 0 ]]; then
+        echo "  BNDspan scoring DISABLED — the probe above shows this configuration cannot" >&2
+        echo "  tell a correct junction call from a displaced one, so any recall it produced" >&2
+        echo "  would not be a measurement. DEL/DUP/INV and BND-to-BND are unaffected." >&2
+    fi
 fi
 # Skip scoring rather than exit: the calibration artifacts and the truth VCFs are worth
 # archiving precisely BECAUSE the scorer misbehaved, and the exit below runs after


### PR DESCRIPTION
Recovers commit `280e6af`, which was pushed to #468 after review and **missed the merge** (`git merge-base --is-ancestor` confirms the other four landed and this one did not — the exact late-push failure `CLAUDE.md` documents). Without it `develop` still scores BNDspan and reports a meaningless recall.

## What the probe found on real data

Run against job 20675480's artifacts:

```
probe junction: CM000851.4:20592138-49516423  (span 28924285 bp, of 7 derived)
  positive control: <DUP> at +1bp      -> TP=1  (must be 1)
  negative control: <DUP> at +50000bp  -> TP=1  (must be 0)
```

A `<DUP>` displaced **50 kb** from the junction matched the derived `<BND_SPAN>` just as readily as one 1 bp away.

## Why this is structural, not a setting

truvari gates position by **padded interval overlap**, not endpoint proximity. That junction spans 28,924,285 bp, so a 50 kb displacement still leaves reciprocal overlap at **0.9983**. Overlap is scale-relative — on a span that large, *no* overlap threshold can detect a breakpoint error of that size. The probe ran with truvari's default `--refdist 500` and matched anyway, which is direct evidence that `refdist` does not constrain endpoints once intervals overlap.

Collapsing a junction (two precise points) into a span (one huge interval) discards exactly the precision the measurement depends on. BNDspan recall would have credited any caller record loosely overlapping a multi-Mb region with having found the junction.

## Change

BNDspan is skipped when the probe fails, and the run says so. Scoped deliberately to BNDspan — a failed bridge says nothing about DEL/DUP/INV or BND-to-BND, and failing the whole calibration would discard sound measurements. The probe's failure output now explains the scale-relative reason and prints the reciprocal overlap, so the finding does not have to be re-derived.

## Note

I added this mechanism two commits earlier believing it would recover junction calls. It would have produced a plausible non-zero recall that meant nothing. It was caught only because the probe asserts the case where it **must not** fire — the positive control alone passes.

Separately, and not part of this diff: `manta_BND recall=0.000` is now confirmed as a **genuine caller result**. Nearest-neighbour distances between the 14 truth breakends and Manta's 14 breakends are 1.08 Mb at closest, 0 within 500 bp — Manta called different junctions entirely.