### PR TITLE
fix!: de novo BND truth described a rearrangement the reads did not carry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 7/31/2026
 =========
+## eidolon v3.1.0 — de novo breakends now carry the junction they describe
+
+**Breaking for anyone benchmarking against the BND truth**, though no emitted format
+changes. What changes is what a BND *is* in the output.
+
+### The truth VCF described a rearrangement the reads did not carry
+
+The chimeric read generator dispatches on `bnd_join_after` / `bnd_mate_extends_right`,
+not on the ALT string. Those flags are assigned only by the input-VCF parser, so a de
+novo BND left them at their `SvData::new` defaults of `false/false` — VCF 4.2 **case 4,
+`]p]t`, a direct join with no reverse complement** — while the ALT written to the truth
+was **`t]p]`, case 2, head-to-head with the mate piece reverse-complemented**.
+`sv_model.rs` never set them at all.
+
+A direct intra-contig join is not a breakend. Joining A-left to B-right *is* a deletion;
+the reverse *is* a duplication. eidolon has been planting DELs and DUPs and labelling
+them BNDs since v1.13.1 (#224) — the #451 fix only replaced the literal `N` with the real
+anchor base, leaving the bracket form untouched.
+
+This is the root cause of `BND recall=0.000`, which survived five explanations across a
+year. It was never a caller failure and never a scoring artifact. On Delta job 20675480
+Manta placed DEL/DUP candidates within **1–2 bp of all seven planted junctions**, emitted
+no INV and no breakend anywhere near them, and was marked as having found none of them:
+
+| planted junction | Manta candidate | worst endpoint error |
+|---|---|---|
+| 20592138-49516423 | DUP 20592137-49516423 | 1 bp |
+| 20610778-45788036 | DEL 20610777-45788034 | 2 bp |
+| 26790171-36133098 | DEL 26790171-36133097 | 1 bp |
+| 34999235-36134214 | DUP 34999234-36134214 | 1 bp |
+| 40696874-53467765 | DUP 40696872-53467764 | 2 bp |
+| 47038466-51969855 | DUP 47038465-51969855 | 1 bp |
+| 50310249-51236091 | DEL 50310249-51236090 | 1 bp |
+
+The reads were never at fault: 7–15 discordant pairs and 3–15 split reads at each of the
+14 breakends, which is what a het somatic junction should look like at 18×. The caller
+was right, the reads were right, and the truth was wrong.
+
+`sv_model.rs` now sets both flags to match the `t]p]` ALT it emits, on the anchor and the
+mate. A reciprocal `t]p]` ↔ `t]p]` pair is the spec's own worked example, so the ALT
+stays and the reads move to match it.
+
+### Why the tests did not catch it
+
+`bnd_fastq.rs` drives the **input** path — where the parser sets the flags correctly, so
+the one path that was never broken — and asserts only that some read is named
+`EIDOLON_chimeric`. An existence check on the working case. `get_bnd_pieces` had no tests
+at all, so nothing in the suite could distinguish a direct join from a head-to-head one.
+
+Now pinned at both ends: `denovo_bnd_read_geometry_matches_the_alt_it_declares` parses
+the emitted ALT with the same parser the input path uses and asserts the flags agree
+(verified to fail before the fix), and `bnd_pieces_reverse_complement_exactly_the_spec_
+cases` pins all four VCF 4.2 forms and which piece is reverse-complemented.
+
 ## eidolon v3.0.1 — measurement integrity
 
 **Fixes only; no feature work and no change to simulated output.** Every item here is a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "eidolon"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "eidolon-core"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '3.0.1'
+version = '3.1.0'
 edition = '2024'
 authors = ["Joshua Allen", "Mikolaj Kowalik", "See coauthors of Python Neat versions"]
 description = "Toolkit for generating simulated NGS read data in fastq and vcf formats. Feature set under development."

--- a/eidolon-core/src/structs/sv_model.rs
+++ b/eidolon-core/src/structs/sv_model.rs
@@ -629,6 +629,20 @@ impl SvModel {
                 None
             };
             sv_data.copy_number = copy_number;
+            // The chimeric read generator dispatches on these flags, NOT on the ALT
+            // string, and they are otherwise only ever set by the input-VCF parser. A de
+            // novo BND left them at their false/false defaults, which is case 4 (`]p]t`)
+            // — a DIRECT join — while the ALT above says `t]p]`, case 2, head-to-head
+            // with the mate piece reverse-complemented. The truth VCF therefore described
+            // a different rearrangement than the reads carried, and a direct intra-contig
+            // join is just a deletion or duplication: on Delta, Manta placed DEL/DUP
+            // candidates within 1-2bp of all 7 planted junctions and emitted no breakend
+            // at any of them, so BND recall read 0.000 for a caller that had found every
+            // one. Keep these in step with the ALT emitted above.
+            if sv_type == SvType::Bnd {
+                sv_data.bnd_join_after = true;
+                sv_data.bnd_mate_extends_right = false;
+            }
             sv_data.mate_contig = m_contig;
             sv_data.mate_pos = m_pos;
 
@@ -698,6 +712,10 @@ impl SvModel {
                 mate_sv.end = Some(mate_1based);
                 mate_sv.svlen = None;
                 mate_sv.copy_number = None;
+                // Same form as the anchor (`t]p]`), so the same geometry — a reciprocal
+                // `t]p]` <-> `t]p]` pair is the spec's own worked example.
+                mate_sv.bnd_join_after = true;
+                mate_sv.bnd_mate_extends_right = false;
                 mate_sv.mate_contig = Some(contig_name.to_string());
                 mate_sv.mate_pos = Some(anchor_1based);
                 let mate_info = format!(
@@ -1080,7 +1098,7 @@ fn genotype_string(genotype: &Genotype, ploidy: usize) -> String {
 mod tests {
     use super::*;
     use crate::structs::nucleotides::Nucleotide;
-    use crate::structs::variants::{AlternateType, SvData, VariantType};
+    use crate::structs::variants::{AlternateType, SvData, VariantType, parse_bnd_alt};
 
     #[test]
     fn default_sv_model_is_not_usable() {
@@ -1413,6 +1431,60 @@ mod tests {
     /// tool, and `sample_variants_emits_all_supported_types` passed anyway because
     /// it only asserts the BND *type appears*.
     #[test]
+    /// The chimeric read generator dispatches on `bnd_join_after` /
+    /// `bnd_mate_extends_right` — NOT on the ALT string. Those flags are assigned only
+    /// by the input-VCF parser (`variants.rs`), so a de novo BND leaves them at their
+    /// `SvData::new` defaults of false/false, which is case 4 (`]p]t`): a DIRECT join
+    /// with no reverse complement. Meanwhile the ALT written to the truth VCF is
+    /// `t]p]` — case 2, head-to-head, reverse-complemented.
+    ///
+    /// So the truth VCF describes a different rearrangement than the reads encode. On
+    /// Delta this showed up as Manta placing DEL/DUP candidates within 1-2bp of all 7
+    /// planted junctions while emitting no breakend there at all, and BND recall being
+    /// reported as 0.000 for a caller that had in fact found every junction.
+    #[test]
+    fn denovo_bnd_read_geometry_matches_the_alt_it_declares() {
+        let mut m = SvModel::default();
+        m.per_base_rate = 5e-3;
+        m.homozygous_frequency = 0.5;
+        m.type_probabilities.clear();
+        m.type_probabilities.insert(SvType::Bnd, 1.0);
+        m.length_log_normal.insert(SvType::Bnd, (7.0, 0.3));
+        let seq = acgt_sequence(50_000);
+        let mut rng = deterministic_rng();
+        let out = m.sample_variants("chr1", 50_000, &[], &seq, 2, 1.0, 0.25, &mut rng);
+
+        let mut checked = 0;
+        for v in &out {
+            let Some(sv) = v.alternate.as_symbolic() else {
+                continue;
+            };
+            if sv.sv_type != SvType::Bnd {
+                continue;
+            }
+            // The same parser the input-VCF path uses, so the two cannot drift apart.
+            let (_mc, _mp, j_after, m_right) = parse_bnd_alt(&sv.raw_alt);
+            assert_eq!(
+                sv.bnd_join_after, j_after,
+                "ALT {} declares join_after={j_after}, but the read generator will use \
+                 bnd_join_after={} — the reads would encode a different junction than \
+                 the truth VCF describes",
+                sv.raw_alt, sv.bnd_join_after
+            );
+            assert_eq!(
+                sv.bnd_mate_extends_right, m_right,
+                "ALT {} declares mate_extends_right={m_right}, but the read generator \
+                 will use bnd_mate_extends_right={}",
+                sv.raw_alt, sv.bnd_mate_extends_right
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 0,
+            "no de novo BND was produced — test proves nothing"
+        );
+    }
+
     fn denovo_bnd_emits_a_cross_linked_mate_pair() {
         let mut m = SvModel::default();
         m.per_base_rate = 5e-3;

--- a/eidolon-core/src/structs/variants.rs
+++ b/eidolon-core/src/structs/variants.rs
@@ -766,7 +766,13 @@ fn sv_type_matches_svtype(sv_type: SvType, svtype_str: &str) -> bool {
     svtype_str.eq_ignore_ascii_case(expected)
 }
 
-fn parse_bnd_alt(alt: &str) -> (Option<String>, Option<usize>, bool, bool) {
+/// Test-only re-export: lets the read generator's tests assert that the geometry an ALT
+/// declares is the geometry the reads are built from, without duplicating the parser.
+pub fn parse_bnd_alt_for_test(alt: &str) -> (Option<String>, Option<usize>, bool, bool) {
+    parse_bnd_alt(alt)
+}
+
+pub(crate) fn parse_bnd_alt(alt: &str) -> (Option<String>, Option<usize>, bool, bool) {
     // VCF 4.2 breakend notation (Section 1.4.2)
     // 4 possible forms involving brackets:
     // 1. t[p[  2. t]p]  3. ]p]t  4. [p[t

--- a/eidolon/src/gen_reads/utils/runner.rs
+++ b/eidolon/src/gen_reads/utils/runner.rs
@@ -1850,7 +1850,7 @@ fn generate_chimeric_pair(
     // L2 = frag_len - offset
 
     let ((c1, s1, e1, rev1), (c2, s2, e2, rev2)) =
-        get_bnd_pieces(contig, pos, sv, offset, frag_len - offset, ctx)?;
+        get_bnd_pieces(contig, pos, sv, offset, frag_len - offset, &ctx.reference)?;
 
     let seq1 = get_stitched_sequence(ctx, &c1, s1, e1, rev1, &c2, s2, e2, rev2, rng)?;
 
@@ -2331,13 +2331,18 @@ fn get_inv_pieces(
     })
 }
 
+/// Split a BND into the two reference pieces a chimeric fragment is stitched from.
+///
+/// Takes the reference map rather than the whole `ContigContext` because contig lengths
+/// are all it needs — and because the geometry it selects is the thing most worth
+/// testing directly. The `bool` in each tuple is "reverse-complement this piece".
 fn get_bnd_pieces(
     contig: &str,
     pos: usize, // 0-based
     sv: &SvData,
     len1: usize,
     len2: usize,
-    ctx: &ContigContext,
+    reference: &HashMap<String, Vec<Nucleotide>>,
 ) -> Result<((String, usize, usize, bool), (String, usize, usize, bool)), GenerateReadsError> {
     let mate_contig = sv.mate_contig.as_ref().unwrap().clone();
     let mate_pos = sv.mate_pos.unwrap().saturating_sub(1);
@@ -2345,12 +2350,12 @@ fn get_bnd_pieces(
     // BNDs can legitimately point at a contig outside the reference (a real
     // VCF data quality issue). Surface that as an error rather than silently
     // producing zero-length sequences via `unwrap_or(0)`.
-    let c1_len = ctx.reference.get(contig).map(|s| s.len()).ok_or_else(|| {
+    let c1_len = reference.get(contig).map(|s| s.len()).ok_or_else(|| {
         GenerateReadsError::CliError(format!(
             "BND at {contig}:{pos} references its own contig {contig} but that contig is not in the reference"
         ))
     })?;
-    let c2_len = ctx.reference.get(&mate_contig).map(|s| s.len()).ok_or_else(|| {
+    let c2_len = reference.get(&mate_contig).map(|s| s.len()).ok_or_else(|| {
         GenerateReadsError::CliError(format!(
             "BND at {contig}:{pos} has mate on contig {mate_contig} but that contig is not in the reference"
         ))
@@ -3001,6 +3006,103 @@ mod tests {
     use eidolon_core::structs::bed_record::BedRecord;
     use eidolon_core::structs::sequence_block::{RegionType, SequenceMap};
     use eidolon_core::structs::variants::AlternateType;
+
+    /// The four VCF 4.2 §5.4 breakend forms, and specifically WHICH PIECE gets reverse-
+    /// complemented. This is the property nothing tested: `bnd_fastq.rs` drives the input
+    /// path (where the parser sets the flags) and only asserts that some read is named
+    /// "EIDOLON_chimeric", so a direct join and a head-to-head join were indistinguishable
+    /// to the whole suite.
+    ///
+    /// That gap let de novo BNDs ship a truth VCF saying `t]p]` (reverse-complemented)
+    /// while the reads were built as case 4 (a direct join) — which is simply a deletion
+    /// or duplication, and is what Manta correctly called them on Delta.
+    fn bnd_sv(join_after: bool, mate_extends_right: bool) -> SvData {
+        let mut sv = SvData::new("N]chr1:5001]", SvType::Bnd);
+        sv.mate_contig = Some("chr1".to_string());
+        sv.mate_pos = Some(5001); // 1-based, so 5000 0-based
+        sv.bnd_join_after = join_after;
+        sv.bnd_mate_extends_right = mate_extends_right;
+        sv
+    }
+
+    fn bnd_reference() -> HashMap<String, Vec<Nucleotide>> {
+        let mut r = HashMap::new();
+        r.insert("chr1".to_string(), vec![Nucleotide::A; 10_000]);
+        r
+    }
+
+    #[test]
+    fn bnd_pieces_reverse_complement_exactly_the_spec_cases() {
+        let reference = bnd_reference();
+        let (pos, len1, len2) = (1000usize, 100usize, 50usize);
+
+        // Case 1, t[p[ : REF[..=pos] + MATE[mate_pos..]. Direct, nothing reversed.
+        let (a, b) =
+            get_bnd_pieces("chr1", pos, &bnd_sv(true, true), len1, len2, &reference).unwrap();
+        assert_eq!((a.1, a.2, a.3), (901, 1001, false), "case 1 anchor piece");
+        assert_eq!(
+            (b.1, b.2, b.3),
+            (5000, 5050, false),
+            "case 1 mate piece must NOT be reversed"
+        );
+
+        // Case 2, t]p] : REF[..=pos] + revcomp(MATE[..=mate_pos]). This is the form de
+        // novo BNDs declare, so the mate piece MUST be reverse-complemented.
+        let (a, b) =
+            get_bnd_pieces("chr1", pos, &bnd_sv(true, false), len1, len2, &reference).unwrap();
+        assert_eq!((a.1, a.2, a.3), (901, 1001, false), "case 2 anchor piece");
+        assert_eq!(
+            (b.1, b.2, b.3),
+            (4951, 5001, true),
+            "case 2 mate piece MUST be reverse-complemented"
+        );
+
+        // Case 3, [p[t : revcomp(MATE[mate_pos..]) + REF[pos..]. Mate piece comes first.
+        let (a, b) =
+            get_bnd_pieces("chr1", pos, &bnd_sv(false, true), len1, len2, &reference).unwrap();
+        assert_eq!(
+            (a.1, a.2, a.3),
+            (5000, 5100, true),
+            "case 3 mate piece leads, reversed"
+        );
+        assert_eq!((b.1, b.2, b.3), (1000, 1050, false), "case 3 anchor piece");
+
+        // Case 4, ]p]t : MATE[..=mate_pos] + REF[pos..]. Direct, nothing reversed — the
+        // layout a de novo BND was silently getting from the false/false defaults.
+        let (a, b) =
+            get_bnd_pieces("chr1", pos, &bnd_sv(false, false), len1, len2, &reference).unwrap();
+        assert_eq!(
+            (a.1, a.2, a.3),
+            (4901, 5001, false),
+            "case 4 mate piece leads, NOT reversed"
+        );
+        assert_eq!((b.1, b.2, b.3), (1000, 1050, false), "case 4 anchor piece");
+    }
+
+    /// The regression proper: the geometry a de novo BND's ALT declares must be the
+    /// geometry its reads are built from. Distinct from the case table above, which pins
+    /// the generator; this pins the two ends AGREEING.
+    #[test]
+    fn denovo_bnd_alt_form_produces_a_reverse_complemented_junction() {
+        let reference = bnd_reference();
+        // `t]p]` is what sv_model.rs emits for every de novo BND.
+        let (_mc, _mp, join_after, mate_right) =
+            eidolon_core::structs::variants::parse_bnd_alt_for_test("N]chr1:5001]");
+        let (_a, b) = get_bnd_pieces(
+            "chr1",
+            1000,
+            &bnd_sv(join_after, mate_right),
+            100,
+            50,
+            &reference,
+        )
+        .unwrap();
+        assert!(
+            b.3,
+            "a `t]p]` breakend joins a REVERSE-COMPLEMENTED piece (VCF 4.2 §5.4); a \
+             direct join here is a deletion or duplication, not a breakend"
+        );
+    }
 
     #[test]
     fn test_split_contig_into_chunks_covers_contig_without_gaps_or_overlap() {


### PR DESCRIPTION
Root cause of `BND recall=0.000`. It was never a caller result, and it was never a scoring artifact — **the simulator was wrong in a way that made the caller look wrong.**

## The defect

The chimeric read generator dispatches on `bnd_join_after` / `bnd_mate_extends_right`, **not** on the ALT string. Those flags are assigned only by the input-VCF parser, so a de novo BND left them at their `SvData::new` defaults of `false/false` — VCF 4.2 **case 4, `]p]t`, a direct join with no reverse complement** — while the ALT written to the truth VCF was **`t]p]`, case 2, head-to-head with the mate piece reverse-complemented**.

`sv_model.rs` never sets those flags (grep count: 0).

So for every de novo breakend, the truth VCF described a different rearrangement than the reads encoded. And a direct intra-contig join is not a breakend at all: joining A-left to B-right **is** a deletion, and the reverse **is** a duplication. eidolon has been planting DELs and DUPs and labelling them BNDs.

`git log -L` dates the `]p]` form to **v1.13.1 (#224)**. The #451 fix only replaced the literal `N` with the real anchor base, so this is long-standing, not newly introduced.

## Evidence (Delta job 20675480)

Manta placed DEL/DUP candidates within **1–2 bp of all 7 planted junctions**:

```
junction 20592138-49516423 -> DUP 20592137-49516423 (worst endpoint error 1 bp)
junction 20610778-45788036 -> DEL 20610777-45788034 (worst endpoint error 2 bp)
junction 26790171-36133098 -> DEL 26790171-36133097 (worst endpoint error 1 bp)
junction 34999235-36134214 -> DUP 34999234-36134214 (worst endpoint error 1 bp)
junction 40696874-53467765 -> DUP 40696872-53467764 (worst endpoint error 2 bp)
junction 47038466-51969855 -> DUP 47038465-51969855 (worst endpoint error 1 bp)
junction 50310249-51236091 -> DEL 50310249-51236090 (worst endpoint error 1 bp)
```

`candidateSV` contains **zero INV records** and no breakend within 500 bp of any planted junction — because the reads carry no inversion signature to find.

The reads themselves were never the problem: **7–15 discordant pairs and 3–15 split reads at every one of the 14 breakends**, exactly what a het somatic junction should look like at 18×.

## Fix

`sv_model.rs` sets both flags to match the `t]p]` ALT it emits, on the anchor and the mate. A reciprocal `t]p]` ↔ `t]p]` pair is the spec's own worked example, so the ALT stays and the reads move to match it.

## Tests

The regression is pinned by `denovo_bnd_read_geometry_matches_the_alt_it_declares`, which parses the emitted ALT with the **same parser the input path uses** and asserts the flags agree. Verified to fail before the change:

```
ALT T]chr1:33823] declares join_after=true, but the read generator
will use bnd_join_after=false
```

`get_bnd_pieces` had **no tests at all**, so `bnd_pieces_reverse_complement_exactly_the_spec_cases` now pins all four forms and specifically which piece is reverse-complemented. Those would have passed before the fix — they close the gap that hid it rather than catching it. Together the ends compose: flags match the ALT, generator honours the flags.

**Worth naming why nothing caught this.** `bnd_fastq.rs` drives the *input* path — where the parser sets the flags correctly, i.e. the one path that was never broken — and asserts only that some read is named `EIDOLON_chimeric`. An existence check, so the entire suite could not distinguish a direct join from a head-to-head one.

`get_bnd_pieces` now takes the reference map instead of the whole `ContigContext`; contig lengths were all it used, and the narrower signature is what makes it testable. Single call site.

## Breaking

BND reads change for a given seed. Per the v3.0.0 policy exact simulated content is not public API, but this changes what a BND *is* in the output, which any consumer benchmarking against the BND truth will see.

## Status

**In progress.** Workspace 727 passed / 0 failed, `cargo fmt` clean, clippy unchanged. **Not yet observed on real data.** The prediction is that Manta now calls these junctions as breakends and BND recall becomes a caller measurement for the first time — that needs an `sv_pipeline.sbatch` run to confirm, and if it does not hold, this is not finished.