### PR TITLE
docs: test-adequacy standard; fold v3.0.1 into v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 **Breaking for anyone benchmarking against the BND truth**, though no emitted format
 changes. What changes is what a BND *is* in the output.
 
+Also carries everything staged as v3.0.1 below, which was never tagged separately.
+
 ### The truth VCF described a rearrangement the reads did not carry
 
 The chimeric read generator dispatches on `bnd_join_after` / `bnd_mate_extends_right`,
@@ -54,7 +56,13 @@ the emitted ALT with the same parser the input path uses and asserts the flags a
 (verified to fail before the fix), and `bnd_pieces_reverse_complement_exactly_the_spec_
 cases` pins all four VCF 4.2 forms and which piece is reverse-complemented.
 
-## eidolon v3.0.1 — measurement integrity
+## eidolon v3.0.1 — measurement integrity (never tagged; shipped inside v3.1.0)
+
+Staged as its own patch release and then folded in, because the result that would have
+justified tagging it — the #450 subclonal-VAF confirmation from Delta job 20675479 — ran
+*before* the last three measurement fixes merged. A tag cut afterwards would not have
+been the code that produced the number, so there was nothing to cite it for. The
+validation campaign runs on v3.1.0 instead, and everything below ships there.
 
 **Fixes only; no feature work and no change to simulated output.** Every item here is a
 defect in something that *measures* eidolon, not in eidolon's simulation. They are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,40 @@ the negative case has to be built deliberately:
 A feature demonstrated only by "it emitted something plausible" has not been validated,
 it has been exercised.
 
+### Test adequacy (not test presence)
+
+**New code ships with tests that would catch it being wrong. There is no exemption for
+"small", "obvious", or "hard to test".** If it is hard to test, that is usually a signal
+the seam is in the wrong place — narrow the function's inputs until it is testable
+(`get_bnd_pieces` took a whole `ContigContext` but used only contig lengths; taking the
+reference map instead made it unit-testable with no behaviour change).
+
+Every rule below was earned by a defect that shipped green:
+
+- **Test the path that can break, not the path that works.** `bnd_fastq.rs` "covered"
+  BND read generation by driving the *input-VCF* path — where the parser sets the
+  geometry flags correctly — while the *de novo* path shipped a truth VCF that
+  contradicted its own reads for a year. Ask which path the test actually exercises.
+- **Assert content, not existence.** That same test asserted only that some read was
+  *named* `EIDOLON_chimeric`. Names, counts, non-emptiness, and exit 0 are not content.
+  If a wrong value would still pass, the test is decoration.
+- **A function that makes a decision needs a test of that decision.** `get_bnd_pieces`
+  chooses which piece of a junction is reverse-complemented — the entire semantics of a
+  breakend — and had zero tests.
+- **Invariants that span two components need their own test.** The defect was neither
+  side being wrong: `sv_model.rs` emitted a correct ALT and `runner.rs` honoured its
+  flags correctly. They simply disagreed, and nothing asserted they must agree. Where
+  two components must stay in step, assert it directly, and use the *same* helper both
+  sides use so they cannot drift.
+- **Prove non-vacuity by mutation.** Before believing a new test, break the code it
+  covers and watch it fail. If it still passes, it is not a test. This is cheap for a
+  fix (revert it) and must be done deliberately for a feature. It is how an `##ALT`
+  assertion was found that could never fail.
+
+When auditing, mutation is the method: change the production code to something plausibly
+wrong, run the tests, and record what happened. A coverage claim with no mutation
+experiment behind it is an opinion.
+
 ### Status vocabulary
 **Nothing is "done" until there is evidence it works as intended. Until then it is
 in progress.** This governs how work is reported, not just how it is tested:


### PR DESCRIPTION
Two documentation changes.

## CLAUDE.md — "Test adequacy (not test presence)"

Every rule in the new section was earned by a defect that shipped green this cycle:

- **Test the path that can break, not the path that works.** `bnd_fastq.rs` "covered" BND read generation by driving the *input-VCF* path — where the parser sets the geometry flags correctly — while the de novo path shipped a truth VCF contradicting its own reads for a year.
- **Assert content, not existence.** That test asserted only that some read was *named* `EIDOLON_chimeric`.
- **A function that makes a decision needs a test of that decision.** `get_bnd_pieces` chooses which piece of a junction is reverse-complemented and had zero tests.
- **Invariants spanning two components need their own test.** The BND defect was neither side being wrong — `sv_model.rs` emitted a correct ALT, `runner.rs` honoured its flags correctly. They disagreed, and nothing asserted they must agree.
- **Prove non-vacuity by mutation.** Break the code a test covers and watch it fail; if it still passes it is not a test.

Plus the point that testability is a design signal: `get_bnd_pieces` took a whole `ContigContext` and used only contig lengths, so narrowing the parameter made it unit-testable with no behaviour change.

## CHANGELOG — v3.0.1 folded into v3.1.0

v3.0.1 was never tagged, and on inspection should not be. The result that would have justified tagging it — the #450 subclonal-VAF confirmation from Delta job 20675479 — finished at **19:20**, while the last three measurement fixes merged at **20:39, 21:03 and 21:16**. A tag cut afterwards would not be the code that produced the number, so there was nothing to cite it for.

Everything staged as v3.0.1 ships in v3.1.0, which is also what the validation campaign will run on — one version cited throughout the report, one release, one Bioconda bump.