### PR TITLE
fix(test): restore a silently disabled test; close the BND coverage gaps it hid

### DIFF
--- a/.github/workflows/eidolon-tests.yml
+++ b/.github/workflows/eidolon-tests.yml
@@ -38,5 +38,15 @@ jobs:
           ubuntu-latest-cargo-
     - name: Build
       run: cargo build
+    # Deny rustc warnings across ALL targets, tests included. A stray duplicated
+    # `#[test]` attribute silently DISABLED `denovo_bnd_emits_a_cross_linked_mate_pair`
+    # — the #451 regression guard — while making another test run twice, which reads as
+    # a passing "2 passed". rustc said `duplicated attribute` and `function is never
+    # used` the whole time and nothing was listening. The tree is at zero rustc warnings,
+    # so this costs nothing to hold.
+    - name: Deny warnings (a disabled test is a silent warning)
+      run: cargo build --workspace --all-targets
+      env:
+        RUSTFLAGS: "-D warnings"
     - name: Run tests
       run: cargo test --verbose --workspace

--- a/eidolon-core/src/structs/sv_model.rs
+++ b/eidolon-core/src/structs/sv_model.rs
@@ -618,6 +618,19 @@ impl SvModel {
                 // time. The match is exhaustive for the compiler.
                 _ => continue,
             };
+            // VCF 4.2 §5.4: a breakend is a POINT. END must equal POS and there is no
+            // SVLEN, whatever length the model happened to sample. An anchor reporting
+            // END = POS + length claims a multi-kb span for a 1bp event, and tools that
+            // size records off END (truvari, bcftools) act on it — while the record's own
+            // mate correctly carries END = POS, so one junction would ship two
+            // conventions. `fit_from_observations` pins BND length to 1, so a trained
+            // model never exposed this; `SvModel` is plain serde JSON and hand-edited or
+            // grafted models are not covered by that.
+            let sv_end_1based = if sv_type == SvType::Bnd {
+                anchor_0based + 1
+            } else {
+                sv_end_1based
+            };
             let mut sv_data = SvData::new(raw_alt, sv_type);
             sv_data.end = Some(sv_end_1based);
             sv_data.svlen = if sv_type != SvType::Bnd {
@@ -1431,60 +1444,6 @@ mod tests {
     /// tool, and `sample_variants_emits_all_supported_types` passed anyway because
     /// it only asserts the BND *type appears*.
     #[test]
-    /// The chimeric read generator dispatches on `bnd_join_after` /
-    /// `bnd_mate_extends_right` — NOT on the ALT string. Those flags are assigned only
-    /// by the input-VCF parser (`variants.rs`), so a de novo BND leaves them at their
-    /// `SvData::new` defaults of false/false, which is case 4 (`]p]t`): a DIRECT join
-    /// with no reverse complement. Meanwhile the ALT written to the truth VCF is
-    /// `t]p]` — case 2, head-to-head, reverse-complemented.
-    ///
-    /// So the truth VCF describes a different rearrangement than the reads encode. On
-    /// Delta this showed up as Manta placing DEL/DUP candidates within 1-2bp of all 7
-    /// planted junctions while emitting no breakend there at all, and BND recall being
-    /// reported as 0.000 for a caller that had in fact found every junction.
-    #[test]
-    fn denovo_bnd_read_geometry_matches_the_alt_it_declares() {
-        let mut m = SvModel::default();
-        m.per_base_rate = 5e-3;
-        m.homozygous_frequency = 0.5;
-        m.type_probabilities.clear();
-        m.type_probabilities.insert(SvType::Bnd, 1.0);
-        m.length_log_normal.insert(SvType::Bnd, (7.0, 0.3));
-        let seq = acgt_sequence(50_000);
-        let mut rng = deterministic_rng();
-        let out = m.sample_variants("chr1", 50_000, &[], &seq, 2, 1.0, 0.25, &mut rng);
-
-        let mut checked = 0;
-        for v in &out {
-            let Some(sv) = v.alternate.as_symbolic() else {
-                continue;
-            };
-            if sv.sv_type != SvType::Bnd {
-                continue;
-            }
-            // The same parser the input-VCF path uses, so the two cannot drift apart.
-            let (_mc, _mp, j_after, m_right) = parse_bnd_alt(&sv.raw_alt);
-            assert_eq!(
-                sv.bnd_join_after, j_after,
-                "ALT {} declares join_after={j_after}, but the read generator will use \
-                 bnd_join_after={} — the reads would encode a different junction than \
-                 the truth VCF describes",
-                sv.raw_alt, sv.bnd_join_after
-            );
-            assert_eq!(
-                sv.bnd_mate_extends_right, m_right,
-                "ALT {} declares mate_extends_right={m_right}, but the read generator \
-                 will use bnd_mate_extends_right={}",
-                sv.raw_alt, sv.bnd_mate_extends_right
-            );
-            checked += 1;
-        }
-        assert!(
-            checked > 0,
-            "no de novo BND was produced — test proves nothing"
-        );
-    }
-
     fn denovo_bnd_emits_a_cross_linked_mate_pair() {
         let mut m = SvModel::default();
         m.per_base_rate = 5e-3;
@@ -1558,6 +1517,60 @@ mod tests {
                 "mate_pos must point at the mate record's location"
             );
         }
+    }
+
+    /// The chimeric read generator dispatches on `bnd_join_after` /
+    /// `bnd_mate_extends_right` — NOT on the ALT string. Those flags are assigned only
+    /// by the input-VCF parser (`variants.rs`), so a de novo BND leaves them at their
+    /// `SvData::new` defaults of false/false, which is case 4 (`]p]t`): a DIRECT join
+    /// with no reverse complement. Meanwhile the ALT written to the truth VCF is
+    /// `t]p]` — case 2, head-to-head, reverse-complemented.
+    ///
+    /// So the truth VCF describes a different rearrangement than the reads encode. On
+    /// Delta this showed up as Manta placing DEL/DUP candidates within 1-2bp of all 7
+    /// planted junctions while emitting no breakend there at all, and BND recall being
+    /// reported as 0.000 for a caller that had in fact found every junction.
+    #[test]
+    fn denovo_bnd_read_geometry_matches_the_alt_it_declares() {
+        let mut m = SvModel::default();
+        m.per_base_rate = 5e-3;
+        m.homozygous_frequency = 0.5;
+        m.type_probabilities.clear();
+        m.type_probabilities.insert(SvType::Bnd, 1.0);
+        m.length_log_normal.insert(SvType::Bnd, (7.0, 0.3));
+        let seq = acgt_sequence(50_000);
+        let mut rng = deterministic_rng();
+        let out = m.sample_variants("chr1", 50_000, &[], &seq, 2, 1.0, 0.25, &mut rng);
+
+        let mut checked = 0;
+        for v in &out {
+            let Some(sv) = v.alternate.as_symbolic() else {
+                continue;
+            };
+            if sv.sv_type != SvType::Bnd {
+                continue;
+            }
+            // The same parser the input-VCF path uses, so the two cannot drift apart.
+            let (_mc, _mp, j_after, m_right) = parse_bnd_alt(&sv.raw_alt);
+            assert_eq!(
+                sv.bnd_join_after, j_after,
+                "ALT {} declares join_after={j_after}, but the read generator will use \
+                 bnd_join_after={} — the reads would encode a different junction than \
+                 the truth VCF describes",
+                sv.raw_alt, sv.bnd_join_after
+            );
+            assert_eq!(
+                sv.bnd_mate_extends_right, m_right,
+                "ALT {} declares mate_extends_right={m_right}, but the read generator \
+                 will use bnd_mate_extends_right={}",
+                sv.raw_alt, sv.bnd_mate_extends_right
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 0,
+            "no de novo BND was produced — test proves nothing"
+        );
     }
 
     /// The sampling loop is gated on placed *events*, not emitted records — a BND
@@ -1855,13 +1868,138 @@ mod tests {
         for v in &out {
             let sv = v.alternate.as_symbolic().expect("must be symbolic");
             assert_eq!(sv.sv_type, SvType::Bnd);
-            assert!(sv.raw_alt.contains("chr1:"));
+            // Parse the ALT we emitted and compare the WHOLE tuple against the struct
+            // the read generator will consume. `contains("chr1:")` and
+            // `mate_pos.is_some()` are existence checks: shifting the ALT's mate
+            // coordinate by 137bp — so the truth text points somewhere the reads do not
+            // — satisfied both of them.
+            assert_eq!(
+                parse_bnd_alt(&sv.raw_alt),
+                (
+                    Some("chr1".to_string()),
+                    sv.mate_pos,
+                    sv.bnd_join_after,
+                    sv.bnd_mate_extends_right
+                ),
+                "ALT {} disagrees with the fields the read generator uses",
+                sv.raw_alt
+            );
             assert_eq!(sv.mate_contig.as_deref(), Some("chr1"));
-            assert!(sv.mate_pos.is_some());
             let end = sv.end.expect("END must be populated");
             // For BND, length = 1, so end = location + 1.
             assert_eq!(end, v.location + 1);
         }
+    }
+
+    /// Sample BNDs with a NON-degenerate length distribution. `model_with_single_type`
+    /// special-cases BND to `(0.0, 0.0)`, so every existing BND test runs at length 1 and
+    /// cannot see a length-dependent bug.
+    fn bnd_model_with_real_lengths() -> SvModel {
+        let mut m = SvModel::default();
+        m.per_base_rate = 5e-3;
+        m.homozygous_frequency = 0.5;
+        m.type_probabilities.clear();
+        m.type_probabilities.insert(SvType::Bnd, 1.0);
+        m.length_log_normal.insert(SvType::Bnd, (7.0, 0.3));
+        m
+    }
+
+    /// VCF 4.2 §5.4: a breakend is a point — END == POS, no SVLEN — whatever length the
+    /// model sampled. The anchor used to carry `END = POS + length` while its own mate
+    /// carried `END = POS`, so one junction shipped two conventions and tools that size
+    /// records off END (truvari, bcftools) would read a multi-kb span for a 1bp event.
+    /// Invisible to every other test because `fit_from_observations` pins BND length to
+    /// 1 — but `SvModel` is plain serde JSON, and grafted or hand-edited models are not.
+    #[test]
+    fn bnd_end_equals_pos_regardless_of_length_distribution() {
+        let m = bnd_model_with_real_lengths();
+        let seq = acgt_sequence(100_000);
+        let mut rng = deterministic_rng();
+        let out = m.sample_variants("chr1", 100_000, &[], &seq, 2, 1.0, 0.25, &mut rng);
+        let mut checked = 0;
+        for v in &out {
+            let Some(sv) = v.alternate.as_symbolic() else {
+                continue;
+            };
+            if sv.sv_type != SvType::Bnd {
+                continue;
+            }
+            let pos_1based = v.location + 1;
+            assert_eq!(
+                sv.end,
+                Some(pos_1based),
+                "BND at {pos_1based} has END={:?}; a breakend is a point, END must equal POS",
+                sv.end
+            );
+            assert_eq!(sv.svlen, None, "a breakend has no SVLEN");
+            let info = v.info.as_deref().unwrap_or("");
+            assert!(
+                info.contains(&format!("END={pos_1based}")),
+                "INFO {info} must carry END={pos_1based}"
+            );
+            assert!(!info.contains("SVLEN="), "INFO {info} must not carry SVLEN");
+            checked += 1;
+        }
+        assert!(checked > 0, "no de novo BND produced — test proves nothing");
+    }
+
+    /// The two records of a junction must describe the SAME rearrangement. Checking each
+    /// record's flags against its own ALT is not enough: a mate emitted as case 1
+    /// (`t[p[`) against an anchor at case 2 (`t]p]`) is internally consistent on both
+    /// sides and still describes two different events. That is the defect that shipped,
+    /// one level up.
+    #[test]
+    fn denovo_bnd_mate_pair_declares_one_junction() {
+        let m = bnd_model_with_real_lengths();
+        let seq = acgt_sequence(100_000);
+        let mut rng = deterministic_rng();
+        let out = m.sample_variants("chr1", 100_000, &[], &seq, 2, 1.0, 0.25, &mut rng);
+
+        let by_id: std::collections::HashMap<&str, &Variant> = out
+            .iter()
+            .filter(|v| {
+                v.alternate
+                    .as_symbolic()
+                    .map(|s| s.sv_type == SvType::Bnd)
+                    .unwrap_or(false)
+            })
+            .map(|v| (v.id.as_deref().expect("BND must carry an ID"), v))
+            .collect();
+        assert!(!by_id.is_empty(), "no de novo BND produced");
+
+        let mut pairs = 0;
+        for v in by_id.values() {
+            let sv = v.alternate.as_symbolic().unwrap();
+            let mateid = v
+                .info
+                .as_deref()
+                .unwrap_or("")
+                .split(';')
+                .find_map(|f| f.strip_prefix("MATEID="))
+                .expect("BND must carry MATEID");
+            let mate = by_id.get(mateid).expect("MATEID must resolve");
+            let mate_sv = mate.alternate.as_symbolic().unwrap();
+
+            let (_, _, ja, mr) = parse_bnd_alt(&sv.raw_alt);
+            let (_, _, ja_m, mr_m) = parse_bnd_alt(&mate_sv.raw_alt);
+            assert_eq!(
+                (ja, mr),
+                (ja_m, mr_m),
+                "junction described two ways: {} then {} — a reciprocal pair must share \
+                 one geometry (VCF 4.2 §5.4's worked example is `t]p]` <-> `t]p]`)",
+                sv.raw_alt,
+                mate_sv.raw_alt
+            );
+            // ...and the flags the read generator uses must agree on both sides too,
+            // or the two halves of one junction stitch different sequences.
+            assert_eq!(
+                (sv.bnd_join_after, sv.bnd_mate_extends_right),
+                (mate_sv.bnd_join_after, mate_sv.bnd_mate_extends_right),
+                "mate records carry different read-generation geometry"
+            );
+            pairs += 1;
+        }
+        assert!(pairs > 0, "no pair checked — test proves nothing");
     }
 
     #[test]

--- a/eidolon-core/src/structs/variants.rs
+++ b/eidolon-core/src/structs/variants.rs
@@ -1097,6 +1097,66 @@ mod tests {
         }
     }
 
+    /// The BND payload must actually REACH `SvData`. `parse_bnd_alt_extracts_mate_info`
+    /// tests the helper in isolation and
+    /// `parse_alternate_breakend_alt_classifies_as_bnd` throws the `AlternateType` away
+    /// (`let (vt, _, _)`) to assert only the type tag — so deleting the two flag
+    /// assignments, or shifting the mate coordinate, left the whole suite green while
+    /// every parsed breakend silently became a direct join.
+    ///
+    /// This is the input-VCF side of the defect that shipped on the de novo side: the
+    /// ALT said one rearrangement and the reads carried another.
+    #[test]
+    fn parsing_a_bnd_record_carries_geometry_and_mate_into_svdata() {
+        // ref, ALT, mate contig, mate pos, join_after, mate_extends_right, form
+        let cases = [
+            (
+                "G",
+                "G]17:198982]",
+                "17",
+                198982usize,
+                true,
+                false,
+                "case 2 t]p]",
+            ),
+            ("G", "G[17:198982[", "17", 198982, true, true, "case 1 t[p["),
+            (
+                "A",
+                "]13:123456]A",
+                "13",
+                123456,
+                false,
+                false,
+                "case 4 ]p]t",
+            ),
+            (
+                "A",
+                "[13:123456[A",
+                "13",
+                123456,
+                false,
+                true,
+                "case 3 [p[t",
+            ),
+        ];
+        for (ref_base, alt, contig, pos, join_after, mate_right, form) in cases {
+            let (_vt, alternate, _r) = parse_alt_payload(100, ".", ref_base, alt).expect(form);
+            let sv = alternate
+                .as_symbolic()
+                .unwrap_or_else(|| panic!("{form}: expected a symbolic BND"));
+            assert_eq!(
+                (
+                    sv.mate_contig.as_deref(),
+                    sv.mate_pos,
+                    sv.bnd_join_after,
+                    sv.bnd_mate_extends_right
+                ),
+                (Some(contig), Some(pos), join_after, mate_right),
+                "{form}: ALT {alt} did not reach SvData as the junction it declares"
+            );
+        }
+    }
+
     #[test]
     fn parse_alternate_unrecognized_nonliteral_alt_is_invalid_vcf() {
         // A non-IUPAC ALT that's neither symbolic nor breakend should still


### PR DESCRIPTION
Found by mutation-auditing the tests I wrote earlier today. **The top finding is a bug I introduced an hour ago.**

## A test stopped running and I read the evidence as success

Inserting `denovo_bnd_read_geometry_matches_the_alt_it_declares` immediately before `denovo_bnd_emits_a_cross_linked_mate_pair` placed it between that test's doc comment and its function, stealing its `#[test]` attribute. The #451 regression guard — pairing, unique IDs, reciprocal MATEID, ALT-embeds-own-REF-base — **stopped running**, while my test carried two attributes and ran twice:

```
running 2 tests
test ... denovo_bnd_read_geometry_matches_the_alt_it_declares ... ok
test ... denovo_bnd_read_geometry_matches_the_alt_it_declares ... ok
```

Same name, twice. I read "2 passed" as success. rustc was emitting `duplicated attribute` and `function ... is never used` the entire time.

**What it cost:** with the mate-record emission guarded by `&& false` — a full regression to the pre-#451 lone-breakend shape that made BND unmatchable by any comparison tool — `cargo test -p eidolon-core --lib structs::sv_model` reported **42 passed, 0 failed**.

CI now denies rustc warnings across all targets. The tree is at zero, so it costs nothing to hold, and reintroducing the duplicated attribute now gives `error: duplicated attribute`.

## Coverage gaps that test was hiding

Every new assertion was verified to **fail** against a specific plausible defect. Mutation, command, and result for each:

| new test | mutation applied | before | after |
|---|---|---|---|
| `denovo_bnd_mate_pair_declares_one_junction` | mate emitted as case 1 (`t[p[`) while anchor stays case 2 (`t]p]`) | 42 passed | **FAILS** |
| `bnd_end_equals_pos_regardless_of_length_distribution` | END fix reverted | passed | **FAILS** — `BND at 65105 has END=Some(66845)` |
| `parsing_a_bnd_record_carries_geometry_and_mate_into_svdata` | both flag assignments deleted → every parsed BND becomes a direct join | **367 passed, 0 failed** | **FAILS** (369 passed, 1 failed — only this test) |
| same | mate coordinate shifted +50bp | 367 passed | **FAILS** |
| `sampled_bnds_have_fixed_1bp_length` (strengthened) | ALT mate coordinate shifted 137bp from the one the reads use | passed | **FAILS** |

### The input-VCF side was wide open

This is the same defect class as #470, on the other side. `parse_bnd_alt_extracts_mate_info` tests the helper in isolation; `parse_alternate_breakend_alt_classifies_as_bnd` discards the `AlternateType` (`let (vt, _, _)`) to assert only the type tag. Nothing checked the payload **reached** `SvData`. Deleting both flag assignments — silently turning every parsed breakend into a direct join — passed the entire suite.

### One code fix rides along

A BND anchor carried `END = POS + length` while its own mate carried `END = POS`, so a single junction shipped two conventions and tools that size records off `END` (truvari, bcftools) would read a multi-kb span for a 1 bp event. Invisible everywhere because `model_with_single_type` pins BND length to 0 and `fit_from_observations` pins it to 1 — but `SvModel` is plain serde JSON, and grafted or hand-edited models are covered by neither.

**Confirmed absent from the real Delta truth** — all 14 BND records in job 20675480 have `END == POS` — so this is latent, not active.

## Status

Workspace **730 passed, 0 failed**, fmt clean, zero rustc warnings.

This unblocks the `sv_pipeline.sbatch` re-run: the BND paths #470 changed now have tests that bite, on both the de novo and input-VCF sides.