### PR TITLE
fix(delta): report the binary version, and refuse a stale one

### DIFF
--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -53,8 +53,38 @@ export CARGO_TARGET_DIR
 mkdir -p "$CARGO_TARGET_DIR"
 echo "[1/4] Building eidolon release binary (artifacts → \$SCRATCH)..."
 cd "$REPO_ROOT"
+# Say what is about to be built, and refuse to build a checkout that is behind its
+# remote. A partial or interrupted `git pull` leaves the tree on older code and setup
+# happily builds it: job 20682989 ran a 3.0.1 binary against a 3.1.0 checkout, spent
+# 25 core-hours, and produced a complete set of plausible numbers that tested none of
+# the fix it was submitted to verify. Nothing in the old output could have revealed
+# that, because setup never reported what it built.
+echo "      checkout: $(git describe --tags --always --dirty 2>/dev/null || echo unknown)"
+if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}')"
+    if git fetch -q origin 2>/dev/null; then
+        behind="$(git rev-list --count "HEAD..$upstream" 2>/dev/null || echo 0)"
+        if [[ "${behind:-0}" -gt 0 ]]; then
+            echo "      ERROR: checkout is ${behind} commit(s) behind ${upstream}." >&2
+            echo "      Pull before building, or the binary will not contain the code you" >&2
+            echo "      think it does. Set ALLOW_BEHIND=1 to build anyway." >&2
+            [[ "${ALLOW_BEHIND:-0}" == "1" ]] || exit 1
+        fi
+    else
+        echo "      WARNING: could not fetch ${upstream} — cannot confirm this checkout" >&2
+        echo "      is current. If a pull failed earlier, you may be building stale code." >&2
+    fi
+fi
 cargo build --release 2>&1 | tail -5
 echo "      Binary: $CARGO_TARGET_DIR/release/eidolon"
+# Report the version actually produced. This is the line whose absence cost a run.
+built_ver="$("$CARGO_TARGET_DIR/release/eidolon" --version 2>/dev/null || echo unknown)"
+repo_ver="$(awk -F\' '/^version = /{print $2; exit}' Cargo.toml 2>/dev/null || echo unknown)"
+echo "      Built:  ${built_ver}   (Cargo.toml says ${repo_ver})"
+if [[ "$built_ver" != *"$repo_ver"* ]]; then
+    echo "      ERROR: built binary reports '${built_ver}' but Cargo.toml says ${repo_ver}." >&2
+    exit 1
+fi
 
 # ── 2. NEAT 4 conda env ─────────────────────────────────────────────────
 setup_conda   # load the conda module + bootstrap `conda` (Delta: miniforge3-python)

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -133,6 +133,22 @@ TRUTH_VCF="${PREFIX}_merged_truth.vcf.gz"
 # Refuse to score fresh caller output against a truth VCF written by a different
 # build of eidolon (see lib_report.sh::check_outdir_version).
 check_outdir_version "$EIDOLON_BIN" "$OUTDIR" || exit 1
+# Say WHICH build produced these numbers, in the log, every time. This pipeline never
+# rebuilds — it runs whatever is at $EIDOLON_BIN — and on a fresh OUTDIR there is no
+# stamp to compare against, so a stale binary runs silently and its results are
+# indistinguishable from a current one. Job 20682989 reproduced job 20675480's caller
+# numbers exactly and the log could not answer "was the fix even in this build?".
+echo "eidolon binary: $EIDOLON_BIN"
+echo "eidolon version: ${EIDOLON_VERSION:-unknown}"
+echo "repo HEAD:      $(git -C "$REPO_ROOT" describe --tags --always --dirty 2>/dev/null || echo unknown)"
+# A binary older than the checkout is almost always a forgotten rebuild.
+_repo_ver="$(awk -F\' '/^version = /{print $2; exit}' "$REPO_ROOT/Cargo.toml" 2>/dev/null)"
+if [[ -n "$_repo_ver" && "${EIDOLON_VERSION:-}" != *"$_repo_ver"* ]]; then
+    echo "ERROR: binary reports '${EIDOLON_VERSION:-unknown}' but the checkout is $_repo_ver." >&2
+    echo "  The binary is stale — rebuild before running, or the results describe code" >&2
+    echo "  that is not the code you think you are testing. Set ALLOW_STALE_BIN=1 to override." >&2
+    [[ "${ALLOW_STALE_BIN:-0}" == "1" ]] || exit 1
+fi
 
 if [[ "$FORCE_RESIM" == "0" && -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then
     echo "[1/5] Simulation outputs already present — skipping."


### PR DESCRIPTION
`sv_pipeline.sbatch` **never rebuilds** — it runs whatever sits at `$EIDOLON_BIN` — and on a **fresh** OUTDIR `check_outdir_version` finds no stamp and returns silently. So a stale binary runs with no guard and no log line, and its results are indistinguishable from a current build's.

Not hypothetical. Job 20682989 was submitted to verify the v3.1.0 BND geometry fix and reproduced job 20675480's caller numbers **exactly**:

| | 20675480 (pre-fix) | 20682989 (post-fix) |
|---|---|---|
| Manta somatic / candidates | 46 / 285 | 46 / 285 |
| `manta_DEL` | TP=11 FN=0 FP=5 | TP=11 FN=0 FP=5 |
| `manta_DUP` | TP=4 FN=3 FP=9 | TP=4 FN=3 FP=9 |
| `delly_overall` | TP=17 FN=7 FP=16 | TP=17 FN=7 FP=16 |
| Delly UniqueDiscordantPairs | 385 | 385 |
| CNV recovery | 4/9 | 4/9 |

The log cannot answer whether the fix was in that build, because the version was recorded only in the archived `run_manifest.tsv` and never printed. That is the gap this closes — separately from whatever the answer turns out to be.

## Change

Every run now echoes the binary path, its version, and the repo HEAD. A binary whose version differs from the checkout's `Cargo.toml` **aborts the job**, with `ALLOW_STALE_BIN=1` as the override.

A forgotten rebuild should not be able to produce a full set of plausible numbers.