### PR TITLE
test: assert de novo SV span consistency and exact IUPAC constituents

### DIFF
--- a/eidolon-core/src/file_tools/fasta_stream.rs
+++ b/eidolon-core/src/file_tools/fasta_stream.rs
@@ -491,6 +491,58 @@ mod tests {
         }
     }
 
+    /// Every IUPAC code must resolve to EXACTLY its own constituents.
+    ///
+    /// `test_resolve_iupac_all_codes_yield_only_acgtn` asserts membership in
+    /// {A,C,G,T,N}, which ANY wrong mapping satisfies — resolving Y (pyrimidine, C/T)
+    /// to purines passed it and every other test in the workspace. Only R and H had
+    /// distribution tests, leaving Y, M, K, S, W, B, V and D unconstrained.
+    #[test]
+    fn resolve_iupac_yields_exactly_each_code_constituents() {
+        // IUPAC nucleotide codes, per the IUBMB/IUPAC-IUB definition.
+        let codes: [(char, &[Nucleotide]); 10] = [
+            ('R', &[Nucleotide::A, Nucleotide::G]), // puRine
+            ('Y', &[Nucleotide::C, Nucleotide::T]), // pYrimidine
+            ('M', &[Nucleotide::A, Nucleotide::C]), // aMino
+            ('K', &[Nucleotide::G, Nucleotide::T]), // Keto
+            ('S', &[Nucleotide::C, Nucleotide::G]), // Strong (3 H-bonds)
+            ('W', &[Nucleotide::A, Nucleotide::T]), // Weak (2 H-bonds)
+            ('B', &[Nucleotide::C, Nucleotide::G, Nucleotide::T]), // not A
+            ('D', &[Nucleotide::A, Nucleotide::G, Nucleotide::T]), // not C
+            ('H', &[Nucleotide::A, Nucleotide::C, Nucleotide::T]), // not G
+            ('V', &[Nucleotide::A, Nucleotide::C, Nucleotide::G]), // not T
+        ];
+        let mut rng = NeatRng::new_from_seed(&vec!["iupac constituents".to_string()]).unwrap();
+        for (code, expected) in codes {
+            let input: String = std::iter::repeat(code).take(600).collect();
+            let (seq, count) = resolve_iupac_bases(&input, &mut rng).unwrap();
+            assert_eq!(count, 600, "{code}: wrong ambiguity count");
+
+            let mut seen: Vec<Nucleotide> = Vec::new();
+            for n in &seq {
+                if !seen.contains(n) {
+                    seen.push(*n);
+                }
+            }
+            // Nothing outside the code's constituents...
+            for n in &seen {
+                assert!(
+                    expected.contains(n),
+                    "{code} resolved to {n:?}, which is not one of its constituents \
+                     {expected:?}"
+                );
+            }
+            // ...and every constituent actually appears, so a mapping that collapses a
+            // code onto a strict subset (e.g. always picking the first base) fails too.
+            for n in expected {
+                assert!(
+                    seen.contains(n),
+                    "{code} never resolved to {n:?} in 600 draws; observed only {seen:?}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_resolve_iupac_preserves_acgtn_unchanged() {
         let mut rng = NeatRng::new_from_seed(&vec!["iupac_test".to_string()]).unwrap();

--- a/eidolon/tests/pipeline_e2e.rs
+++ b/eidolon/tests/pipeline_e2e.rs
@@ -510,6 +510,49 @@ fn gen_reads_with_trained_sv_model_emits_de_novo_symbolic_svs() {
         !symbolic_records.is_empty(),
         "expected at least one de novo symbolic SV in output; got VCF lines: {vcf_lines:#?}"
     );
+    // Presence is not enough: `contains("END=")` is satisfied by ANY value, and shifting
+    // every emitted END by +1000 passed the entire workspace. END is what downstream
+    // consumers size the event from (depth modulation, compare-vcfs, truvari), so assert
+    // it is INTERNALLY CONSISTENT with the record's own SVLEN and POS.
+    let info_int = |line: &str, key: &str| -> Option<i64> {
+        line.split('\t')
+            .nth(7)?
+            .split(';')
+            .find_map(|f| f.strip_prefix(key).and_then(|v| v.parse::<i64>().ok()))
+    };
+    for line in &symbolic_records {
+        let pos: i64 = line.split('\t').nth(1).unwrap().parse().unwrap();
+        let end = info_int(line, "END=")
+            .unwrap_or_else(|| panic!("symbolic record has no parseable INFO/END: {line}"));
+        let svlen = info_int(line, "SVLEN=")
+            .unwrap_or_else(|| panic!("symbolic record has no parseable INFO/SVLEN: {line}"));
+        assert!(end > pos, "INFO/END={end} is not after POS={pos}: {line}");
+        // The span END implies must equal |SVLEN|, using the convention `place_sv`
+        // documents: for <DEL> POS is the base BEFORE the event, so the affected range is
+        // [POS+1, END] and END-POS == |SVLEN|; for <DUP>/<CNV>/<INV> "POS is the first
+        // affected base", so the range is [POS, END] inclusive and END-POS+1 == |SVLEN|.
+        // Whether that second convention should match VCF's is issue #474; this asserts
+        // the record is self-consistent under whichever one applies, which is what a
+        // downstream consumer needs and what shifting every END by +1000 broke.
+        let svtype = line
+            .split('\t')
+            .nth(7)
+            .and_then(|i| i.split(';').find_map(|f| f.strip_prefix("SVTYPE=")))
+            .unwrap_or_else(|| panic!("symbolic record has no INFO/SVTYPE: {line}"));
+        let implied_span = if svtype == "DEL" {
+            end - pos
+        } else {
+            end - pos + 1
+        };
+        assert_eq!(
+            implied_span,
+            svlen.abs(),
+            "{svtype} record: the span INFO/END implies ({implied_span}) disagrees with \
+             |SVLEN| ({}) — a consumer sizing this event off END sees a different \
+             variant than one sizing it off SVLEN: {line}",
+            svlen.abs()
+        );
+    }
     for line in &symbolic_records {
         assert!(
             line.contains("SVTYPE="),


### PR DESCRIPTION
Two **correctness** gaps from the vacuous-test audit (as opposed to merely weak assertions), each verified by mutation.

## De novo SV `INFO/END` was checked for presence only

`line.contains("END=")` is satisfied by any value. **Shifting every emitted END by +1000 passed the entire workspace.** END is what downstream consumers size an event from — depth modulation, `compare-vcfs`, truvari — so a wrong END is a wrong variant everywhere it is read.

Now asserts the span END implies equals `|SVLEN|`, per the convention `place_sv` documents:

- `<DEL>` — POS is the base **before** the event, so `END − POS == |SVLEN|`
- `<DUP>`/`<CNV>`/`<INV>` — "POS is the first affected base", so `END − POS + 1 == |SVLEN|`

I first wrote this as a single `END − POS == |SVLEN|` rule and it failed on a DUP (`POS=44, END=133, SVLEN=90`). I took that for an internal inconsistency in the emitted VCF and said so, before reading `place_sv`'s own doc comment, which spells out both conventions. **The records are self-consistent.** Whether the DUP/CNV/INV convention should match VCF's is #474, and this test deliberately asserts self-consistency rather than picking a side.

## Eight of ten IUPAC codes had no correctness coverage

`test_resolve_iupac_all_codes_yield_only_acgtn` asserts membership in `{A,C,G,T,N}` — which **any** wrong mapping satisfies. Resolving `Y` (pyrimidine, C/T) to purines passed it and every other test in the workspace. Only `R` and `H` had distribution tests, leaving `Y, M, K, S, W, B, V, D` unconstrained.

Each code must now resolve to **exactly** its constituents: nothing outside them, and every one of them observed across 600 draws — so collapsing a code onto a subset fails too, not just mapping it to the wrong bases.

## Verified non-vacuous

| mutation | result |
|---|---|
| every emitted END shifted +1000 | **FAILS** — `DUP record: the span INFO/END implies (1090) disagrees with \|SVLEN\| (90)` |
| `Y` resolved to purines | **FAILS** — `Y resolved to G, which is not one of its constituents [C, T]` |
| `B` (not-A) collapsed onto one base | **FAILS** — `B never resolved to G in 600 draws; observed only [C]` |
| `S` (C/G) and `W` (A/T) swapped | **FAILS** — `S resolved to T, which is not one of its constituents [C, G]` |

## Note

Inserting the IUPAC test above an existing one **silently stole its `#[test]` attribute a second time today**, making the new test run twice. rustc's `duplicated attribute` warning caught it — the same warning the CI gate in #477 turns into a hard error. That gate has now justified itself on a real recurrence rather than a hypothetical one.

Workspace **731 passed, 0 failed**, fmt clean, zero rustc warnings.

## Remaining from the audit (all weak assertions, none report-facing)

- `all_qualities_are_valid_phred33` is a tautology — the parser already rejects bytes outside 33..=126, so `q = b - 33` is `<= 93` by construction and a Phred+64 offset bug passes.
- The N-tract test has no positive control, so "zero variants anywhere" satisfies it.
- One `compare-vcfs` attribution test asserts a header emitted unconditionally.