### PR TITLE
fix!: POS now means the same thing for every symbolic SV type (VCF 4.2)

### DIFF
--- a/eidolon-core/src/structs/sv_model.rs
+++ b/eidolon-core/src/structs/sv_model.rs
@@ -900,11 +900,14 @@ fn weighted_pick_with<'a, T>(
 /// anchor_0based, sv_end_1based)` or `None` if the contig is too small
 /// for the chosen length.
 ///
-/// For `<DEL>`, the anchor (1-based POS) is the base immediately before
-/// the deletion and is NOT itself deleted — the affected range is
-/// `[POS+1, END]` 1-based inclusive, i.e. `[anchor_0based + 1,
-/// anchor_0based + 1 + length)` 0-based half-open. For `<DUP>` / `<CNV>`
-/// POS is the first affected base.
+/// INVARIANT, for every symbolic SPAN type: `anchor_0based` is the base
+/// immediately BEFORE the event and is NOT itself affected. The affected range
+/// is always `[anchor_0based + 1, anchor_0based + 1 + length)` 0-based
+/// half-open, i.e. 1-based `[POS+1, END]`, so `END - POS == |SVLEN|` holds
+/// uniformly (VCF 4.2 symbolic-allele convention).
+///
+/// `<INS>` and `<BND>` are point events, not spans: nothing in the reference is
+/// consumed, POS marks the position, and END == POS.
 fn place_sv(
     sv_type: SvType,
     length: usize,
@@ -925,28 +928,48 @@ fn place_sv(
         return None;
     }
     let anchor = rng.range_i64(0, max_anchor_inclusive as i64).ok()?.max(0) as usize;
-    let (start, end, sv_end_1based) = match sv_type {
+    let (start, end, vcf_anchor_0based, sv_end_1based) = match sv_type {
         SvType::Del => {
             let s = anchor + 1;
             let e = s + length;
             // 1-based END for SvData: span includes the anchor + deleted
             // bases, so END_1based = anchor_1based + length = anchor + 1 + length.
-            (s, e, anchor + 1 + length)
+            (s, e, anchor, anchor + 1 + length)
         }
         SvType::Ins => {
-            // Insertions are point events in the reference.
+            // Insertions are point events in the reference: POS carries the base
+            // before the inserted sequence and END == POS.
             let s = anchor;
             let e = s + 1;
-            (s, e, anchor + 1)
+            (s, e, anchor, anchor + 1)
+        }
+        SvType::Bnd => {
+            // A breakend is a point and POS IS the breakend base — the
+            // anchor-before convention does not apply, and END is forced to POS
+            // by the caller (VCF 4.2 5.4).
+            let s = anchor;
+            let e = s + 1;
+            (s, e, anchor, anchor + 1)
         }
         _ => {
+            // DUP/CNV/INV. `anchor` is the FIRST AFFECTED base, but VCF 4.2 puts
+            // POS on the base BEFORE a symbolic event, so the record's anchor is
+            // `anchor - 1` while the affected range stays [anchor, anchor+length).
+            // Emitting `anchor` directly is what made POS mean "last unaffected"
+            // for DEL and "first affected" for everything else, so END-POS equalled
+            // |SVLEN| for DEL and |SVLEN|-1 for the rest in the same file. It also
+            // put the first duplicated base in REF, where the preceding base belongs.
+            // There is no base before position 0.
+            if anchor == 0 {
+                return None;
+            }
             let s = anchor;
             let e = s + length;
-            // 1-based END = POS_1based + length - 1 = (anchor + 1) + length - 1 = anchor + length.
-            (s, e, anchor + length)
+            // 1-based END = last affected base = anchor + length.
+            (s, e, anchor - 1, anchor + length)
         }
     };
-    Some((start, end, anchor, sv_end_1based))
+    Some((start, end, vcf_anchor_0based, sv_end_1based))
 }
 
 /// Compute the 0-based half-open affected range of an existing symbolic
@@ -963,8 +986,13 @@ fn affected_range_for_existing(v: &Variant, block_end: usize) -> Option<(usize, 
     }
     let raw_end = v.location.saturating_add(span).min(block_end);
     let start = match sv.sv_type {
-        SvType::Del => v.location.saturating_add(1).min(block_end),
-        _ => v.location.min(block_end),
+        // Point events consume no reference bases, so the anchor itself marks the
+        // position for overlap purposes — there is no POS+1..END to speak of.
+        SvType::Ins | SvType::Bnd => v.location.min(block_end),
+        // Span events: POS is the base BEFORE the event (VCF 4.2), so the affected
+        // range starts at POS+1. This used to be DEL-only, which is what let a DUP
+        // and a DEL in the same file mean different things by POS.
+        _ => v.location.saturating_add(1).min(block_end),
     };
     if start >= raw_end {
         return None;
@@ -2000,6 +2028,49 @@ mod tests {
             pairs += 1;
         }
         assert!(pairs > 0, "no pair checked — test proves nothing");
+    }
+
+    /// VCF 4.2 puts POS on the base BEFORE a symbolic event, so `END - POS` must
+    /// equal `|SVLEN|` for every span type — one rule, not one per type.
+    ///
+    /// `place_sv` used to return the FIRST AFFECTED base as the anchor for
+    /// DUP/CNV/INV while returning the preceding base for DEL, so a single output
+    /// file carried two meanings of POS: `END-POS == |SVLEN|` for DEL and
+    /// `|SVLEN|-1` for the rest. It also put the first duplicated base in REF where
+    /// the preceding base belongs.
+    #[test]
+    fn denovo_symbolic_svs_put_pos_on_the_base_before_the_event() {
+        for sv_type in [SvType::Del, SvType::Dup, SvType::Cnv, SvType::Inv] {
+            let m = model_with_single_type(sv_type, 5e-3);
+            let seq = acgt_sequence(100_000);
+            let mut rng = deterministic_rng();
+            let out = m.sample_variants("chr1", 100_000, &[], &seq, 2, 1.0, 0.25, &mut rng);
+            let mut checked = 0;
+            for v in &out {
+                let Some(sv) = v.alternate.as_symbolic() else {
+                    continue;
+                };
+                if sv.sv_type != sv_type {
+                    continue;
+                }
+                let pos = (v.location + 1) as i64; // 1-based POS
+                let end = sv.end.expect("symbolic SV must carry END") as i64;
+                let svlen = sv.svlen.expect("span SV must carry SVLEN");
+                assert_eq!(
+                    end - pos,
+                    svlen.abs(),
+                    "{sv_type:?} at POS {pos}: END-POS ({}) != |SVLEN| ({}) — POS is \
+                     not on the base before the event",
+                    end - pos,
+                    svlen.abs()
+                );
+                checked += 1;
+            }
+            assert!(
+                checked > 0,
+                "{sv_type:?}: nothing sampled — test proves nothing"
+            );
+        }
     }
 
     #[test]

--- a/eidolon/src/gen_reads/utils/runner.rs
+++ b/eidolon/src/gen_reads/utils/runner.rs
@@ -2278,8 +2278,9 @@ fn get_dup_pieces(
     // pre-dup context — see fn doc for the implication).
     let e1 = end.min(c_len);
     let s1 = e1.saturating_sub(len1);
-    // Right piece: first len2 bases of the duplicated region.
-    let s2 = location;
+    // Right piece: first len2 bases of the duplicated region. POS is the base
+    // BEFORE the event (VCF 4.2), so the region begins at location+1.
+    let s2 = location + 1;
     let e2 = (s2 + len2).min(c_len);
     Ok((
         (contig.to_string(), s1, e1, false),
@@ -2305,21 +2306,22 @@ fn get_inv_pieces(
         ))
     })?;
     Ok(if junction == 1 {
-        // Junction 1: REF[..POS-1] | RC(REF[POS..END])
-        // Left piece ends at index location-1. Right piece starts at RC(index end-1).
-        let e1 = location;
+        // Junction 1: REF[..POS] | RC(REF[POS+1..END])
+        // POS is the base BEFORE the inverted block (VCF 4.2), so the block begins
+        // at location+1 and the left piece ends there.
+        let e1 = location + 1;
         let s1 = e1.saturating_sub(len1);
 
         let e2 = end.min(c_len);
-        let s2 = e2.saturating_sub(len2).max(location);
+        let s2 = e2.saturating_sub(len2).max(location + 1);
         (
             (contig.to_string(), s1, e1, false),
             (contig.to_string(), s2, e2, true),
         )
     } else {
-        // Junction 2: RC(REF[POS..END]) | REF[END+1..]
-        // Left piece ends at RC(index location). Right piece starts at index end.
-        let s1 = location;
+        // Junction 2: RC(REF[POS+1..END]) | REF[END+1..]
+        // Same convention as junction 1: the inverted block begins at location+1.
+        let s1 = location + 1;
         let e1 = (s1 + len1).min(end).min(c_len);
 
         let s2 = end.min(c_len);
@@ -2820,15 +2822,15 @@ fn build_coverage_multipliers(
 /// modulates coverage, given the variant's 0-based stored `location` (= VCF
 /// POS − 1) and the `span_bases` reported by [`SvData::span`].
 ///
-/// VCF convention for `<DEL>`: POS is the anchor base immediately *before*
-/// the deletion (still present in the reference), and the deleted bases run
-/// from POS+1 to END (1-based, inclusive). So a DEL modulates `[POS, END)`
-/// in 0-based half-open coords, which is `[location + 1, location + span)`.
+/// One convention for every symbolic type (VCF 4.2): POS is the anchor base
+/// immediately *before* the event and is not itself affected, so the affected
+/// bases run from POS+1 to END (1-based, inclusive) and the modulated range is
+/// `[location + 1, location + span)` in 0-based half-open coords.
 ///
-/// `<DUP>`, `<CNV>`, `<INV>`: POS is conventionally *inside* the affected
-/// region (the duplicated / inverted block starts at POS itself). Those
-/// modulate `[POS − 1, END)` in 0-based half-open coords, i.e.
-/// `[location, location + span)`.
+/// This used to differ by type — DUP/CNV/INV modulated `[location, location + span)`
+/// on the basis that "POS is conventionally *inside* the affected region". That is
+/// not the VCF convention, and it meant an input `<DUP>` was modulated one base
+/// early while a `<DEL>` in the same file was not.
 fn sv_modulation_range(
     location_0based: usize,
     sv_type: SvType,
@@ -2838,8 +2840,12 @@ fn sv_modulation_range(
     let raw_end = location_0based.saturating_add(span_bases);
     let end = raw_end.min(block_end);
     let start = match sv_type {
-        SvType::Del => location_0based.saturating_add(1).min(block_end),
-        _ => location_0based.min(block_end),
+        // Point events never modulate coverage today (their multiplier is 1.0, so
+        // build_coverage_multipliers skips them before reaching here), but they have
+        // no POS+1..END range, so don't let a future multiplier change silently shift
+        // them by one.
+        SvType::Ins | SvType::Bnd => location_0based.min(block_end),
+        _ => location_0based.saturating_add(1).min(block_end),
     };
     (start, end)
 }
@@ -3451,19 +3457,30 @@ mod tests {
     }
 
     #[test]
-    fn test_sv_modulation_range_dup_cnv_inv_include_anchor() {
-        // For DUP / CNV / INV, POS is conventionally inside the affected
-        // region — range starts at the anchor.
-        assert_eq!(sv_modulation_range(100, SvType::Dup, 100, 1000), (100, 200));
-        assert_eq!(sv_modulation_range(100, SvType::Cnv, 100, 1000), (100, 200));
-        assert_eq!(sv_modulation_range(100, SvType::Inv, 100, 1000), (100, 200));
+    fn test_sv_modulation_range_excludes_the_anchor_for_every_type() {
+        // location=100 -> POS=101 (1-based); span=100 -> END = 101+100-1 = 200.
+        // VCF 4.2: the anchor at POS is NOT affected, so the affected bases are
+        // 1-based 102..200, i.e. 0-based [101, 200) — identical to DEL.
+        //
+        // These used to be (100, 200): DUP/CNV/INV modulated one base early, so an
+        // input <DUP> and an input <DEL> in the same file used different conventions.
+        assert_eq!(sv_modulation_range(100, SvType::Dup, 100, 1000), (101, 200));
+        assert_eq!(sv_modulation_range(100, SvType::Cnv, 100, 1000), (101, 200));
+        assert_eq!(sv_modulation_range(100, SvType::Inv, 100, 1000), (101, 200));
+        // Same input, same answer as DEL — that equality is the property that was
+        // missing, not an incidental detail.
+        assert_eq!(
+            sv_modulation_range(100, SvType::Dup, 100, 1000),
+            sv_modulation_range(100, SvType::Del, 100, 1000)
+        );
     }
 
     #[test]
     fn test_sv_modulation_range_clipped_to_block_end() {
         // SV running past block_end gets clipped on both ends.
         assert_eq!(sv_modulation_range(95, SvType::Del, 100, 110), (96, 110));
-        assert_eq!(sv_modulation_range(95, SvType::Dup, 100, 110), (95, 110));
+        // Was (95, 110): DUP now excludes its anchor like every other type.
+        assert_eq!(sv_modulation_range(95, SvType::Dup, 100, 110), (96, 110));
         // Start clipped above block_end → empty range.
         let (s, e) = sv_modulation_range(150, SvType::Del, 50, 100);
         assert!(s >= e);
@@ -3567,9 +3584,11 @@ mod tests {
             Genotype::Heterozygous,
             None,
         )];
-        // span = 149 - 51 + 1 = 99; range = [50, 50 + 99) = [50, 149).
+        // POS = 51 (1-based); span = 149 - 51 + 1 = 99. The anchor at POS is not
+        // duplicated, so the affected range is [51, 50 + 99) = [51, 149).
+        // Was [50, 149) — one base early.
         let segs = build_coverage_multipliers(&svs, 2, 300);
-        assert_eq!(segs, vec![(0, 50, 1.0), (50, 149, 1.5), (149, 300, 1.0)]);
+        assert_eq!(segs, vec![(0, 51, 1.0), (51, 149, 1.5), (149, 300, 1.0)]);
     }
 
     #[test]
@@ -3582,9 +3601,10 @@ mod tests {
             Genotype::Homozygous,
             Some(4),
         )];
-        // span = 99 - 1 + 1 = 99; range = [0, 99).
+        // POS = 1 (1-based); span = 99 - 1 + 1 = 99. Anchor excluded, so the
+        // affected range is [1, 0 + 99) = [1, 99). Was [0, 99).
         let segs = build_coverage_multipliers(&svs, 2, 200);
-        assert_eq!(segs, vec![(0, 99, 2.0), (99, 200, 1.0)]);
+        assert_eq!(segs, vec![(0, 1, 1.0), (1, 99, 2.0), (99, 200, 1.0)]);
     }
 
     #[test]

--- a/eidolon/tests/chimeric_sequence_content.rs
+++ b/eidolon/tests/chimeric_sequence_content.rs
@@ -88,6 +88,14 @@ fn derived_haplotype(reference: &[u8], sv: &Sv) -> Vec<u8> {
             out.extend_from_slice(&reference[..*pos]);
             out.extend_from_slice(&reference[*end..]);
         }
+        // Tandem <DUP>: POS is the base BEFORE the event, so the duplicated bases
+        // are 1-based [POS+1, END] = 0-based [pos, end), and the derived haplotype
+        // carries that block twice. The novel junction is at offset `end`.
+        Sv::Dup { pos, end } => {
+            out.extend_from_slice(&reference[..*end]);
+            out.extend_from_slice(&reference[*pos..*end]);
+            out.extend_from_slice(&reference[*end..]);
+        }
         // VCF 4.2 case 2, `t]p]`: REF[..=pos] + revcomp(MATE[..=mate_pos]).
         Sv::BndCase2 { pos, mate_pos } => {
             out.extend_from_slice(&reference[..*pos]);
@@ -105,6 +113,7 @@ fn derived_haplotype(reference: &[u8], sv: &Sv) -> Vec<u8> {
 
 enum Sv {
     Del { pos: usize, end: usize },
+    Dup { pos: usize, end: usize },
     BndCase2 { pos: usize, mate_pos: usize },
     BndCase3 { pos: usize, mate_pos: usize },
 }
@@ -378,5 +387,32 @@ fn chimeric_mates_are_sequenced_from_opposite_strands() {
         r2_reversed * 10 >= pairs.len() * 8,
         "only {r2_reversed} of {} R2 reads reverse-complement-match the derived haplotype",
         pairs.len()
+    );
+}
+
+/// A tandem `<DUP>` must duplicate 1-based [POS+1, END], not [POS, END].
+///
+/// `get_dup_pieces` treated `location` as the FIRST AFFECTED base while
+/// `get_del_pieces` treated it as the last unaffected one, so an input <DUP> and an
+/// input <DEL> in the same file meant different things by POS and the duplicated
+/// block started one base early. Nothing tested it: `dup_chimeric.rs` asserts QNAMEs,
+/// and `get_dup_pieces` had no unit tests at all.
+#[test]
+fn dup_chimeric_reads_duplicate_the_vcf_conventional_block() {
+    assert_derived(
+        "chim_dup",
+        "H1N1_HA\t600\t.\tG\t<DUP>\t60\tPASS\tSVTYPE=DUP;END=1400\tGT\t1/1",
+        Sv::Dup {
+            pos: 600,
+            end: 1400,
+        },
+        // The novel junction sits where the duplicated block is re-entered.
+        //
+        // The block is 800bp against a ~200bp fragment ON PURPOSE. At 200bp a fragment
+        // can span the WHOLE duplication, which needs a three-piece stitch (left +
+        // block + right) that get_dup_pieces cannot express — it returns two — and 4 of
+        // 30 reads then match no haplotype at all. That is a separate real defect
+        // (#474), and keeping it out of this test stops one bug from masking another.
+        1400,
     );
 }

--- a/eidolon/tests/pipeline_e2e.rs
+++ b/eidolon/tests/pipeline_e2e.rs
@@ -527,29 +527,19 @@ fn gen_reads_with_trained_sv_model_emits_de_novo_symbolic_svs() {
         let svlen = info_int(line, "SVLEN=")
             .unwrap_or_else(|| panic!("symbolic record has no parseable INFO/SVLEN: {line}"));
         assert!(end > pos, "INFO/END={end} is not after POS={pos}: {line}");
-        // The span END implies must equal |SVLEN|, using the convention `place_sv`
-        // documents: for <DEL> POS is the base BEFORE the event, so the affected range is
-        // [POS+1, END] and END-POS == |SVLEN|; for <DUP>/<CNV>/<INV> "POS is the first
-        // affected base", so the range is [POS, END] inclusive and END-POS+1 == |SVLEN|.
-        // Whether that second convention should match VCF's is issue #474; this asserts
-        // the record is self-consistent under whichever one applies, which is what a
-        // downstream consumer needs and what shifting every END by +1000 broke.
-        let svtype = line
-            .split('\t')
-            .nth(7)
-            .and_then(|i| i.split(';').find_map(|f| f.strip_prefix("SVTYPE=")))
-            .unwrap_or_else(|| panic!("symbolic record has no INFO/SVTYPE: {line}"));
-        let implied_span = if svtype == "DEL" {
-            end - pos
-        } else {
-            end - pos + 1
-        };
+        // VCF 4.2, one rule for every symbolic type: POS is the base BEFORE the
+        // event, so the affected bases are 1-based [POS+1, END] and
+        // END - POS == |SVLEN|. This used to need a per-type branch — DEL followed
+        // the convention while DUP/CNV/INV put POS on the first affected base, so
+        // the same file carried two meanings of POS. Collapsing this assertion to a
+        // single rule is the observable half of that fix.
         assert_eq!(
-            implied_span,
+            end - pos,
             svlen.abs(),
-            "{svtype} record: the span INFO/END implies ({implied_span}) disagrees with \
-             |SVLEN| ({}) — a consumer sizing this event off END sees a different \
-             variant than one sizing it off SVLEN: {line}",
+            "INFO/END - POS ({}) disagrees with |SVLEN| ({}) — a consumer sizing \
+             this event off END sees a different variant than one sizing it off \
+             SVLEN: {line}",
+            end - pos,
             svlen.abs()
         );
     }


### PR DESCRIPTION
Closes half of #474 — the anchor-convention half.

## What was wrong

`place_sv` returned the **last unaffected** base as the anchor for `<DEL>` and the **first affected** base for `<DUP>`/`<CNV>`/`<INV>`. So one output file carried two meanings of POS:

| type | `END − POS` | matches `\|SVLEN\|`? |
|---|---|---|
| `<DEL>` | `\|SVLEN\|` | ✓ |
| `<DUP>`/`<CNV>`/`<INV>` | `\|SVLEN\| − 1` | ✗ |

It also put the first *duplicated* base in REF, where VCF 4.2 wants the preceding base.

## Why nothing bridged it

**Nothing knew there was a gap.** `anchor_0based` flows straight into `Variant.location` → VCF POS, and each read generator was written against whatever `place_sv` handed *its* type. Both halves agreed per type, so everything worked, and no test compared the types to each other.

Three places encoded the split independently — `place_sv`, `affected_range_for_existing`, and `sv_modulation_range`, whose doc comment says outright that for DUP/CNV/INV "POS is conventionally *inside* the affected region." Deliberate and documented, just never reconciled with the spec.

Same root cause as the BND defect: **a value whose meaning differed between producer and consumer, with nothing asserting they agreed.**

## The rule now

POS is the base **before** the event; affected bases are 1-based `[POS+1, END]`; `END − POS == |SVLEN|`. `<INS>` and `<BND>` stay point events — they consume no reference bases, so POS marks the position and `END == POS` — and are excluded explicitly rather than by falling through a `_` arm.

## Breaking, twice over

- **De novo** DUP/CNV/INV records shift POS down one and carry a different REF base. The **reads are unchanged** — the generators compensate, so the same bases are affected.
- **Input-VCF** DUP/INV reads **do** move one base. That is the correctness fix: a supplied `<DUP>` was being duplicated from POS rather than POS+1.

Folds into the unreleased v3.1.0, which already carries the BND geometry change.

## Verification

| check | result |
|---|---|
| `denovo_symbolic_svs_put_pos_on_the_base_before_the_event` (Del/Dup/Cnv/Inv) | **FAILS** on reverting `place_sv`: `Dup at POS 64912: END-POS (2030) != \|SVLEN\| (2031)` |
| `dup_chimeric_reads_duplicate_the_vcf_conventional_block` — known-answer on the **reads** | **FAILS** on reverting `get_dup_pieces` (identity 0.62) |

Measured directly on generated reads: the VCF-convention haplotype matches **27/30** chimeric reads at ≥0.98, against **19/30** for the old convention.

The two-rule `INFO/END` assertion added in #478 **collapses to one rule** — that is the observable half of this fix, not an edit made to accommodate it.

Four tests that pinned the old convention were updated with expectations **re-derived from VCF**, not from what the code now prints. One is renamed `..._dup_cnv_inv_include_anchor` → `..._excludes_the_anchor_for_every_type` and now also asserts DUP and DEL return identical ranges for identical input — the property that was missing.

## Not covered

**INV read geometry.** Reverting `get_inv_pieces`' junction-2 offset still passes the whole suite — it has no unit tests and the known-answer harness has no INV case. Tracked in #474 with the ~8% of INV chimeric reads matching no haplotype model, which is a separate real defect rather than a convention question. That is item B and is next.

Workspace **741 passed, 0 failed**, fmt clean, zero rustc warnings.