### PR TITLE
test: close the last three vacuous assertions from the audit

### DIFF
--- a/eidolon/tests/compare_vcfs_attribution.rs
+++ b/eidolon/tests/compare_vcfs_attribution.rs
@@ -464,9 +464,32 @@ fn txt_report_renders_attribution_and_warnings() {
         .assert()
         .success();
     let txt = std::fs::read_to_string(out.join("comparison_summary.txt")).unwrap();
+    // `contains("FN attribution")` cannot fail: report.rs pushes that header
+    // UNCONDITIONALLY, outside any branch, so it is present for every run including one
+    // with no false negatives at all. Making attribute_fn return Reason::Unknown for
+    // everything — every FN mis-attributed — passed it. Assert the rendered ROW instead.
     assert!(
         txt.contains("FN attribution"),
         "TXT missing FN attribution section:\n{txt}"
+    );
+    let attribution_line = txt
+        .lines()
+        .skip_while(|l| !l.contains("FN attribution"))
+        .find(|l| l.contains("outside_mutation_bed"))
+        .unwrap_or_else(|| {
+            panic!("FN attribution section has no outside_mutation_bed row:\n{txt}")
+        });
+    // The single golden variant is at chr1:500 and the BED names a contig that does not
+    // exist, so exactly one FN must be attributed there — the count, not just the label.
+    let count: usize = attribution_line
+        .split_whitespace()
+        .last()
+        .and_then(|t| t.parse().ok())
+        .unwrap_or_else(|| panic!("no count on attribution row {attribution_line:?}"));
+    assert_eq!(
+        count, 1,
+        "expected exactly 1 FN attributed to outside_mutation_bed, got {count} \
+         (row: {attribution_line:?})"
     );
     assert!(
         txt.contains("Warnings"),

--- a/eidolon/tests/fastq_validation.rs
+++ b/eidolon/tests/fastq_validation.rs
@@ -185,10 +185,36 @@ fn all_qualities_are_valid_phred33() {
     ))
     .expect("FASTQ failed strict parse");
 
+    // `q <= 93` cannot fail: parse_fastq_strict already rejects any byte outside
+    // 33..=126, so `b - 33` is <= 93 BY CONSTRUCTION. The assertion was unfalsifiable
+    // given its own precondition — switching the encoder to Phred+64, the classic
+    // offset bug, passed it. Assert on the DISTRIBUTION instead, which is what actually
+    // pins the offset: the same bytes decode to a mean near 65 under Phred+64.
+    let mut sum = 0u64;
+    let mut n = 0u64;
+    let mut above_45 = 0u64;
     for r in &records {
         for &b in r.quality.as_bytes() {
-            let q = b.saturating_sub(33);
-            assert!(q <= 93, "quality byte {b} maps to invalid Phred score {q}");
+            let q = b.saturating_sub(33) as u64;
+            sum += q;
+            n += 1;
+            if q > 45 {
+                above_45 += 1;
+            }
         }
     }
+    assert!(n > 0, "no quality bytes to check");
+    let mean = sum as f64 / n as f64;
+    assert!(
+        (25.0..=42.0).contains(&mean),
+        "mean decoded quality {mean:.1} is outside the plausible Phred+33 range \
+         [25, 42] — check the encoding offset (Phred+64 would land near 65)"
+    );
+    // Phred+33 tops out at 41-42 for real instruments; a systematic excess above 45
+    // means the offset is wrong even if the mean happens to land in range.
+    let pct_above = 100.0 * above_45 as f64 / n as f64;
+    assert!(
+        pct_above <= 1.0,
+        "{pct_above:.1}% of bases decode above Phred 45 — implausible for Phred+33"
+    );
 }

--- a/eidolon/tests/pipeline_e2e.rs
+++ b/eidolon/tests/pipeline_e2e.rs
@@ -392,9 +392,28 @@ fn gen_reads_treats_n_tract_as_gap_no_variants_inside() {
                 .unwrap_or(false)
         })
         .collect();
+    // POSITIVE CONTROL FIRST. Without it, "zero variants anywhere" satisfies this test:
+    // making non_n_regions return an empty vec whenever the sequence contains any N —
+    // the natural over-broad form of the fix this guards — passed the whole
+    // pipeline_e2e suite. A denominator is required before an exclusion means anything.
+    let variants_in_flanks = vcf_lines
+        .iter()
+        .filter(|l| !l.starts_with('#'))
+        .filter_map(|l| l.split('\t').nth(1).and_then(|p| p.parse::<usize>().ok()))
+        .filter(|p| (1..=240).contains(p) || (481..=720).contains(p))
+        .count();
+    assert!(
+        variants_in_flanks >= 10,
+        "only {variants_in_flanks} variant(s) placed in the non-N flanks [1,240] and \
+         [481,720] — too few for the N-tract exclusion below to mean anything. Either \
+         mutation placement is broken or the gap exclusion is over-broad."
+    );
+
     assert!(
         variants_in_gap.is_empty(),
-        "variants were placed inside the N tract [241, 480]; N regions must be excluded: {variants_in_gap:?}"
+        "variants were placed inside the N tract [241, 480] ({} in the flanks, so \
+         placement is working); N regions must be excluded: {variants_in_gap:?}",
+        variants_in_flanks
     );
 }
 


### PR DESCRIPTION
The final three findings from the suite-wide vacuous-test audit. Each replaced an assertion that **could not fail**, and each is verified by mutation.

## 1. `all_qualities_are_valid_phred33` was a tautology

`parse_fastq_strict` already rejects any byte outside `33..=126`, so `q = b - 33` is `<= 93` **by construction**. The assertion was unfalsifiable given its own precondition — switching the encoder to **Phred+64**, the classic offset bug, passed it.

Now asserts the **distribution**, which is what actually pins the offset: mean decoded quality in `[25, 42]`, and at most 1% of bases above Phred 45. The same bytes decode to a mean near 65 under Phred+64.

**FAILS** under `(score + 33)` → `(score + 64)`.

## 2. The N-tract test had no positive control

"Zero variants anywhere" satisfied it, so an over-broad gap exclusion — the natural failure mode of the fix it guards — would pass.

Now requires **≥10 variants in the non-N flanks** `[1,240]` and `[481,720]` *before* asserting the gap is empty, and reports the flank count in the failure message so the two failure modes are distinguishable.

**FAILS** under a forced-zero mutation rate:
```
only 0 variant(s) placed in the non-N flanks [1,240] and [481,720] — too few for
the N-tract exclusion below to mean anything. Either mutation placement is broken
or the gap exclusion is over-broad.
```

## 3. `txt_report_renders_attribution_and_warnings` asserted an unconditional header

`report.rs:272` pushes `"FN attribution"` **outside any branch**, so it is present for every run — including one with no false negatives at all.

Now parses the rendered **row** and asserts the **count**: exactly one FN attributed to `outside_mutation_bed`, since the fixture has one golden variant and a BED naming a contig that does not exist.

**FAILS** when `attribute_fn` mis-attributes (`OutsideMutationBed` → `Unknown`).

## A note on method

Three of my first mutation attempts here **did not compile** and printed no `test result` line — which reads exactly like a pass if you are grepping for failures. The harness now checks for a build error before believing a result. A mutation that does not build proves nothing, and silently counting it as evidence is the same failure this audit exists to find.

Workspace **739 passed, 0 failed**, fmt clean.

With this, every finding from all three audits is either fixed or explicitly withdrawn.