### PR TITLE
feat(delta): gate emitted artifacts through `eidolon validate`

### DIFF
--- a/eidolon/src/validate/mod.rs
+++ b/eidolon/src/validate/mod.rs
@@ -87,7 +87,10 @@ pub fn validate_file(path: &Path, format: Option<Format>) -> Result<Vec<Finding>
 /// warnings are reported but do not fail, since by definition nothing downstream
 /// rejects them.
 pub fn run(paths: &[std::path::PathBuf], format: Option<Format>) -> Result<(), ValidateError> {
-    let mut any_error = false;
+    // Only the files that actually failed. Listing every path checked — including ones
+    // that passed — would misattribute the failure, which is the opposite of what this
+    // subcommand is for.
+    let mut failed: Vec<String> = Vec::new();
     for path in paths {
         let findings = validate_file(path, format)?;
         let errors = findings
@@ -111,17 +114,11 @@ pub fn run(paths: &[std::path::PathBuf], format: Option<Format>) -> Result<(), V
             path.display()
         );
         if errors > 0 {
-            any_error = true;
+            failed.push(path.display().to_string());
         }
     }
-    if any_error {
-        return Err(ValidateError::Invalid(
-            paths
-                .iter()
-                .map(|p| p.display().to_string())
-                .collect::<Vec<_>>()
-                .join(", "),
-        ));
+    if !failed.is_empty() {
+        return Err(ValidateError::Invalid(failed.join(", ")));
     }
     Ok(())
 }

--- a/scripts/delta/lib_report.sh
+++ b/scripts/delta/lib_report.sh
@@ -208,6 +208,53 @@ check_outdir_version() {
     return 0
 }
 
+# Gate emitted artifacts through `eidolon validate` before anything consumes them.
+#
+# This replaces accreting more ad-hoc greps. The reason it exists: the malformed
+# `AF=AF=0.3000` INFO value sailed past an `nsom > 0` guard because that guard counted
+# RECORDS, not content — and bcftools would never have complained either, since it
+# silently converts a type-mismatched value to `.`. A record count cannot see that; a
+# validator that knows the declared type can.
+#
+# ERROR findings are fatal: producing numbers from an artifact a downstream tool will
+# reject, or has silently emptied, is precisely the failure this whole harness keeps
+# hitting. WARNINGs are printed and do not stop the run, because by construction nothing
+# downstream rejects them.
+#
+# Skips (loudly) if the binary predates the subcommand, so an older checkout still runs.
+validate_artifacts() {  # <eidolon-bin> <label> <file>...
+    local bin="$1" label="$2"; shift 2
+    [[ $# -gt 0 ]] || return 0
+    if [[ ! -x "$bin" ]]; then
+        echo "  WARNING: $bin is not executable — skipping $label validation." >&2
+        return 0
+    fi
+    if ! "$bin" validate --help >/dev/null 2>&1; then
+        echo "  WARNING: this eidolon build has no \`validate\` subcommand — skipping" >&2
+        echo "    $label validation. Rebuild to enable the artifact gate." >&2
+        return 0
+    fi
+    local present=()
+    local f
+    for f in "$@"; do
+        [[ -f "$f" ]] && present+=("$f")
+    done
+    if [[ ${#present[@]} -eq 0 ]]; then
+        echo "  WARNING: none of the $label artifacts exist yet — nothing validated." >&2
+        return 0
+    fi
+    echo "  Validating $label (${#present[@]} artifact(s))..."
+    local rc=0
+    "$bin" validate "${present[@]}" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        echo "ERROR: $label failed validation (see the findings above). Each one names the" >&2
+        echo "  tool and operation that will reject it. Refusing to compute results from an" >&2
+        echo "  artifact a consumer will not accept." >&2
+        return 1
+    fi
+    return 0
+}
+
 stamp_outdir_version() {
     printf '%s\n' "$EIDOLON_VERSION" > "$1/.eidolon_version"
 }

--- a/scripts/delta/run_subclonal_vaf_validation.sh
+++ b/scripts/delta/run_subclonal_vaf_validation.sh
@@ -171,6 +171,11 @@ bcftools index -t "$SITES"
 nsom=$(bcftools view -H "$SITES" | wc -l)
 echo "somatic sites carrying EIDOLON_VAF: $nsom"
 [[ "$nsom" -gt 0 ]] || { echo "ABORT: 0 somatic EIDOLON_VAF sites — is this build >= #405?" >&2; exit 1; }
+# The record count above is necessary but not sufficient, and this is the exact site
+# where that bit: it passed while every value was the malformed string `AF=AF=0.3000`,
+# because counting records says nothing about their content. bcftools would not have
+# complained either — it silently converts a type-mismatched value to `.`.
+validate_artifacts "$EIDOLON_BIN" "somatic sites" "$SITES" || exit 1
 # Read-the-artifact guard: EIDOLON_VAF must span a spectrum, not pile at one value.
 echo "EIDOLON_VAF spread (should span deciles for a subclonal architecture):"
 bcftools query -f '%INFO/AF\n' "$SITES" \

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -172,6 +172,12 @@ else
     stamp_outdir_version "$OUTDIR"
 fi
 
+# Gate the truth BEFORE stage 3b inspects it or any caller is scored against it. The
+# truth VCF is the denominator of every number this pipeline reports, so a malformed one
+# does not produce an error — it produces a plausible wrong answer.
+validate_artifacts "$EIDOLON_BIN" "simulated truth" \
+    "$TRUTH_VCF" "${PREFIX}_normal.vcf.gz" "${PREFIX}_tumor.vcf.gz" || exit 1
+
 # ── Stage 2 & 3: Index reference, align ──────────────────────────────────
 NORMAL_BAM="$OUTDIR/normal.bam"
 TUMOR_BAM="$OUTDIR/tumor.bam"
@@ -204,6 +210,10 @@ echo "[2/5] Aligning normal reads..."
 index_and_align "$NORMAL_R1" "$NORMAL_BAM" "NORMAL"
 echo "[3/5] Aligning tumor (merged) reads..."
 index_and_align "${PREFIX}_merged_r1.fastq.gz" "$TUMOR_BAM" "TUMOR"
+
+# The aligned BAMs are what Manta, Delly and GATK read. `samtools quickcheck` would
+# catch a truncated one; nothing in this pipeline was running it.
+validate_artifacts "$EIDOLON_BIN" "aligned BAMs" "$NORMAL_BAM" "$TUMOR_BAM" || exit 1
 
 # ── Stage 3b: PRE-FLIGHT — inspect + extract the somatic SV truth ────────
 # eidolon's SVs are symbolic records (ALT like <DEL>/<DUP>/<INV>, INFO SVTYPE/


### PR DESCRIPTION
Follow-up to #483, now that it is merged. One shared gate in `lib_report.sh` rather than more ad-hoc greps — which was the point of building the subcommand.

## Where, and why there

| script | artifact | why this point |
|---|---|---|
| `sv_pipeline` | simulated truth VCFs | Before stage 3b inspects them or any caller is scored. The truth is the **denominator of every number** this pipeline reports, so a malformed one produces a plausible wrong answer, not an error. |
| `sv_pipeline` | aligned BAMs | Before Manta/Delly/GATK read them. `samtools quickcheck` would catch a truncated one and nothing here was running it. |
| `subvaf` | somatic sites VCF | Immediately after the `nsom > 0` guard — **the exact site where a record count proved insufficient.** It passed while every value was the malformed string `AF=AF=0.3000`, and bcftools would not have complained either, since it silently converts a type-mismatched value to `.`. |

## Severity policy

**ERROR is fatal.** Computing results from an artifact a consumer will reject — or has silently emptied — is the failure mode this harness keeps hitting. **WARNING prints and continues**, because by construction nothing downstream rejects it.

## Degrades rather than breaking

A binary predating the subcommand, a missing binary, and artifacts that do not exist yet each warn loudly and continue, so an older checkout still runs. All six paths verified:

| case | result |
|---|---|
| well-formed artifact | rc=0, `OK` |
| malformed artifact | **rc=1**, names `tabix -p vcf` and its message |
| binary without the subcommand | rc=0, warns to rebuild |
| binary missing entirely | rc=0, warns |
| no artifacts present | rc=0, warns |
| mixed batch (one good, one bad) | **rc=1** |

## A flaw the mixed-batch case found

`validate` was reporting **every path it had been handed** as invalid, including ones that passed:

```
Error: Validate(Invalid("good.vcf, unsorted.vcf"))   <- good.vcf was fine
Error: Validate(Invalid("unsorted.vcf"))             <- fixed
```

Misattributing a failure is the opposite of what this subcommand is for.

Workspace **749 passed, 0 failed**, fmt clean, zero rustc warnings, shell syntax clean.