### PR TITLE
test(delta): automated tests for the BND geometry harness; stratify BND recall by geometry

### DIFF
--- a/.github/workflows/eidolon-tests.yml
+++ b/.github/workflows/eidolon-tests.yml
@@ -50,3 +50,26 @@ jobs:
         RUSTFLAGS: "-D warnings"
     - name: Run tests
       run: cargo test --verbose --workspace
+
+  # The Delta harness scripts determine numbers the ACCESS report cites and were
+  # covered by nothing automatic (#466). They are bash, so cargo test cannot reach
+  # them; this job runs their own suite and then proves that suite is non-vacuous by
+  # mutating the production code and requiring every mutation to be caught.
+  delta-harness:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install bcftools
+      run: sudo apt-get update -qq && sudo apt-get install -y -qq bcftools
+    - name: Shell syntax check
+      run: |
+        for f in scripts/delta/*.sh scripts/delta/*.sbatch scripts/delta/tests/*.sh; do
+          [ -e "$f" ] || continue
+          bash -n "$f" || exit 1
+        done
+    - name: BND geometry harness tests
+      run: scripts/delta/tests/test_bnd_geometry.sh
+    - name: Prove the harness tests are non-vacuous
+      run: scripts/delta/tests/test_bnd_geometry.sh --mutate

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -632,6 +632,96 @@ print(f'    reported {tp}/$base={tp/$base:.3f}  ->  over the full truth {tp}/$n_
     return 1
 }
 
+# ── BND geometry: does the truth describe all four adjacencies, reciprocally? ──
+# Before v3.1.0 every emitted junction was head-to-head (t]p]). A caller therefore only
+# ever saw inversion-like adjacencies, and "BND recall=1.000" was a measurement of one
+# quarter of the problem that read like the whole of it. Geometry is now sampled across
+# all four VCF 4.2 §5.4 forms, so this asserts two things the old harness never did:
+#
+#   1. COVERAGE OF ITS OWN INPUT — every ALT parses into one of the four forms, and the
+#      per-form counts are reported. A geometry distribution over an unknown denominator
+#      is not a result; if a form is missing, that must be visible rather than inferred
+#      from a recall number that moved.
+#   2. RECIPROCITY — each junction's two records form a spec-valid pair. This is the
+#      #451 defect stated as an assertion: the truth described a rearrangement the reads
+#      did not carry, and nothing checked the two sides agreed, so it looked like a
+#      caller failure for two months (v1.13.1 2026-06-02 -> v3.1.0 2026-08-01).
+#
+# Pairings are the spec's own worked examples: t[p[ <-> ]p]t (direct), t]p] <-> t]p]
+# (head-to-head), [p[t <-> [p[t (tail-to-tail).
+check_bnd_geometry() {  # <bnd_truth.vcf.gz>
+    local src="$1"
+    [[ -f "$src" ]] || { echo "  ERROR: BND geometry: no BND truth at $src" >&2; return 1; }
+    bcftools query -f '%CHROM\t%POS\t%ALT\n' "$src" 2>/dev/null \
+      | awk -F'\t' '
+          # Which of the four forms is this ALT? "" means unparsable, which is a defect
+          # and is counted separately rather than being silently dropped.
+          function form(a) {
+              if (a ~ /^[ACGTNacgtn]+\[/) return "t[p["   # case 1  DeletionLike
+              if (a ~ /^[ACGTNacgtn]+\]/) return "t]p]"   # case 2  HeadToHead
+              if (a ~ /^\[/)              return "[p[t"   # case 3  TailToTail
+              if (a ~ /^\]/)              return "]p]t"   # case 4  DuplicationLike
+              return ""
+          }
+          function mate(a,   b,n,p,i) {
+              b=a; gsub(/[][]/,"|",b); n=split(b,p,"|")
+              for (i=1;i<=n;i++) if (p[i] ~ /:/) return p[i]
+              return ""
+          }
+          # The spec pairing. Note it is NOT "same form": a direct junction is described
+          # by two DIFFERENT forms, which is exactly the case a naive check would miss.
+          function mates_ok(a,b) {
+              if (a=="t[p[") return b=="]p]t"
+              if (a=="]p]t") return b=="t[p["
+              if (a=="t]p]") return b=="t]p]"
+              if (a=="[p[t") return b=="[p[t"
+              return 0
+          }
+          { n++
+            f=form($3); m=mate($3)
+            if (f=="" || m=="") { bad++; badex=(badex==""?$3:badex); next }
+            cnt[f]++; parsed++
+            self=$1":"$2; g[self]=f; tgt[self]=m; ord[++k]=self }
+          END{
+            printf("  BND geometry: %d record(s), %d parsed into a form, %d unparsable\n",
+                   n+0, parsed+0, bad+0)
+            split("t[p[ t]p] [p[t ]p]t", forms, " ")
+            split("direct/deletion-like head-to-head tail-to-tail direct/duplication-like",
+                  names, " ")
+            for (i=1;i<=4;i++)
+                printf("    %-5s %-22s %d\n", forms[i], names[i], cnt[forms[i]]+0)
+            # A truth that is entirely one form is internally CONSISTENT, so every check
+            # below passes on it — that is exactly what pre-v3.1.0 output looked like.
+            # Flagged, not failed: fitted weights may legitimately be skewed, so a hard
+            # threshold here would be a flaky assertion about a random draw. The point is
+            # that a silent regression to one geometry must not be invisible.
+            nd=0; for (i=1;i<=4;i++) if (cnt[forms[i]]>0) nd++
+            if (nd==1 && parsed>=24)
+                printf("    NOTE: all %d junction record(s) share ONE geometry. That is the\n"\
+                       "      pre-v3.1.0 hardcoded behaviour; under uniform weights it is\n"\
+                       "      vanishingly unlikely at this count. Check bnd_geometry_weights\n"\
+                       "      in the model before reading any BND number below.\n",
+                       parsed+0)
+            # Reciprocity, checked per record against the record its ALT points at.
+            for (i=1;i<=k;i++) {
+                s=ord[i]; t=tgt[s]
+                if (!(t in g)) { unpaired++
+                    if (uex=="") uex=s" -> "t" (no record there)"
+                    continue }
+                if (!mates_ok(g[s], g[t])) { mismatch++
+                    if (mex=="") mex=s" "g[s]" <-> "t" "g[t] }
+            }
+            printf("    reciprocity: %d unpaired, %d mispaired\n", unpaired+0, mismatch+0)
+            if (bad)      printf("    first unparsable ALT: %s\n", badex)
+            if (unpaired) printf("    first unpaired:       %s\n", uex)
+            if (mismatch) printf("    first mispaired:      %s\n", mex)
+            # A record whose mate is absent or contradicts it describes a rearrangement
+            # the reads cannot carry. That is not a caller result to be interpreted, it
+            # is our artifact being wrong, so it is a hard failure.
+            exit (bad+unpaired+mismatch > 0) ? 1 : 0
+          }'
+}
+
 # ── BND junction spans: a comparable representation ──────────────────────
 # A BND pair at (A,B) and a caller's <DUP:TANDEM>/<DEL>/<INV> spanning A..B describe the
 # SAME event, but truvari matches variants as INTERVALS and these are not
@@ -912,6 +1002,16 @@ BND_SPAN_RC=0
 # from a displaced one at this scale — see the probe for why that is not tunable.
 BNDSPAN_VALID=1
 if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
+    # Runs BEFORE the spans are derived: if the junctions are not reciprocal, every
+    # number downstream describes our own broken artifact rather than any caller.
+    # `|| rc=$?` and not `$(cmd; echo $?)` — the latter loses the status under set -e.
+    BND_GEOM_RC=0
+    check_bnd_geometry "$OUTDIR/truth_sv_BND.vcf.gz" || BND_GEOM_RC=$?
+    if [[ "$BND_GEOM_RC" -ne 0 ]]; then
+        echo "ERROR: the BND truth is not internally consistent (see above). Scoring it" >&2
+        echo "  would measure our emission defect and report it as caller performance." >&2
+        CAL_FAIL=1
+    fi
     build_bnd_spans "$OUTDIR/truth_sv_BND.vcf.gz" "$OUTDIR/truth_sv_BNDspan.vcf.gz" \
         || BND_SPAN_RC=$?
     case "$BND_SPAN_RC" in

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -429,22 +429,26 @@ if [[ -f "$MANTA_SV" ]]; then
     case "$conv_rc" in
         0)  MANTA_SV="$MANTA_SV_CONV"     # score against the normalised calls
             # A residual the raw/converted split CANNOT remove, stated here so the INV
-            # precision figure is not misread. eidolon emits every BND junction as
-            # head-to-head (`t]p]` <-> `t]p]`), which IS the inversion signature, so
-            # convertInversion.py converts the caller's breakend pairs for OUR junctions
-            # into <INV> records too. Those then score as INV false positives against a
-            # truth that never contained them.
+            # precision figure is not misread. An INVERSION-ORIENTED junction (t]p] or
+            # [p[t) has the same shape as an inversion, so convertInversion.py turns the
+            # caller's breakend pair for OUR junction into an <INV> record, which then
+            # scores as an INV false positive against a truth that never contained it.
             #
-            # In job 20699004 that was 7 of the 11 INV FPs. It is a simulator limitation
-            # (#458 item 2: only one geometry is ever sampled), not a caller error and
-            # not something scoring can undo — until eidolon emits direct and
-            # tail-to-tail junctions, a BND junction and an inversion are the same shape.
-            n_bnd_truth=$(bcftools view -H "$OUTDIR/truth_sv_BND.vcf.gz" 2>/dev/null | wc -l)
-            if [[ "${n_bnd_truth:-0}" -gt 0 ]]; then
-                echo "    NOTE: the truth's $((n_bnd_truth / 2)) BND junction(s) are head-to-head, which is"
-                echo "      the inversion signature — a caller's breakends for them convert to <INV>"
-                echo "      too and count as INV false positives. Expect INV precision to be"
-                echo "      depressed by up to that many; it is #458 item 2, not a caller result."
+            # This used to assert that ALL our junctions were head-to-head and print
+            # n_records/2 as the count. That was hardcoded from when geometry was
+            # hardcoded, and v3.1.0 falsified it: job 20719077 measured 226 direct /
+            # 128 head-to-head / 112 tail-to-tail across 466 junctions. The number is
+            # now MEASURED, because a printed claim nobody checks is how the harness
+            # ends up lying in exactly the way it exists to prevent.
+            n_inv_or=$(bcftools query -f '%ALT\n' "$OUTDIR/truth_sv_BND.vcf.gz" 2>/dev/null \
+                | grep -cE '^([ACGTNacgtn]+\]|\[)' || true)
+            if [[ "${n_inv_or:-0}" -gt 0 ]]; then
+                echo "    NOTE: $((n_inv_or / 2)) of the truth's junction(s) are inversion-oriented"
+                echo "      (t]p] or [p[t) — a caller's breakends for those convert to <INV> and"
+                echo "      count as INV false positives. Expect INV precision to be depressed by"
+                echo "      up to that many; it is our representation, not a caller result."
+                echo "      Direct junctions (t[p[ / ]p]t) do NOT convert; they are called"
+                echo "      <DEL>/<DUP:TANDEM>, which is the BND-recall ceiling noted in stage 5."
             fi
             ;;
         2) ;;                              # no converter: nothing to normalise
@@ -722,6 +726,62 @@ check_bnd_geometry() {  # <bnd_truth.vcf.gz>
           }'
 }
 
+# ── Split the BND truth by geometry, because only half of it is BND-scoreable ──
+# Callers bucket only INVERSION-ORIENTED adjacencies (t]p], [p[t) as BND. A direct
+# adjacency inside one contig IS a deletion or a tandem duplication, and Manta calls it
+# <DEL>/<DUP:TANDEM>. Our truth types every junction BND regardless of geometry, so
+# scoring all of it against a caller's BND records asks truvari to match records that
+# cannot match by construction.
+#
+# MEASURED, not assumed — job 20719077, 466 junctions, geometry ~uniform:
+#   tp-base:  t[p[ 0    t]p] 188  [p[t 166  ]p]t 0     -> direct=0    inv-oriented=354
+#   fn:       t[p[ 226  t]p] 68   [p[t 58   ]p]t 226   -> direct=452  inv-oriented=126
+# Every single direct-form record was a false negative and none appeared in tp-base.
+# So manta_BND recall=0.380 (354/932) was a statement about OUR SVTYPE choice; the
+# caller number is 354/480 = 0.738, and the two geometries inside that agree closely
+# (head-to-head 0.734, tail-to-tail 0.741), so there is no bias within the class.
+#
+# Reporting the aggregate alone repeats the INV precision-floor mistake one layer down:
+# a number floored by our own representation, printed as if it described the caller.
+split_bnd_by_geometry() {  # <bnd_truth.vcf.gz> <inv_out.vcf.gz> <direct_out.vcf.gz>
+    local src="$1" inv="$2" dir="$3"
+    [[ -f "$src" ]] || { echo "  ERROR: BND split: no BND truth at $src" >&2; return 1; }
+    local hdr="$OUTDIR/.bnd_split_hdr" tmp="$OUTDIR/.bnd_split_tmp.vcf"
+    bcftools view -h "$src" > "$hdr" || return 1
+
+    local kind out n_inv=0 n_dir=0
+    for kind in inv direct; do
+        [[ "$kind" == inv ]] && out="$inv" || out="$dir"
+        { cat "$hdr"
+          bcftools view -H "$src" | awk -F'\t' -v k="$kind" '
+              { a=$5
+                # direct: t[p[ (base then open-bracket) or ]p]t (leading close-bracket)
+                d = (a ~ /^[ACGTNacgtn]+\[/ || a ~ /^\]/)
+                # inversion-oriented: t]p] (base then close) or [p[t (leading open)
+                i = (a ~ /^[ACGTNacgtn]+\]/ || a ~ /^\[/)
+                if ((k=="direct" && d) || (k=="inv" && i)) print }'
+        } > "$tmp"
+        bcftools view -O z -o "$out" "$tmp" || { rm -f "$tmp" "$hdr"; return 1; }
+        bcftools index -f -t "$out" || { rm -f "$tmp" "$hdr"; return 1; }
+    done
+    n_inv=$(bcftools view -H "$inv" | wc -l)
+    n_dir=$(bcftools view -H "$dir" | wc -l)
+    rm -f "$tmp" "$hdr"
+
+    local n_src
+    n_src=$(bcftools view -H "$src" | wc -l)
+    printf "  BND truth split by geometry: %d inversion-oriented, %d direct (of %d)\n" \
+        "$n_inv" "$n_dir" "$n_src"
+    # Coverage of the split's own input. A record that lands in neither bucket would
+    # silently shrink the denominator of whatever is scored next.
+    if [[ $((n_inv + n_dir)) -ne "$n_src" ]]; then
+        echo "  ERROR: BND split lost $((n_src - n_inv - n_dir)) record(s) — every record" >&2
+        echo "    must be exactly one of direct or inversion-oriented." >&2
+        return 1
+    fi
+    return 0
+}
+
 # ── BND junction spans: a comparable representation ──────────────────────
 # A BND pair at (A,B) and a caller's <DUP:TANDEM>/<DEL>/<INV> spanning A..B describe the
 # SAME event, but truvari matches variants as INTERVALS and these are not
@@ -968,6 +1028,27 @@ score_caller() {  # <caller> <comp.vcf.gz> [raw_comp.vcf.gz]
             bcftools index -f -t "$qb" 2>/dev/null || true
             run_truvari "$OUTDIR/truth_sv_BND.vcf.gz" "${caller}_BND" "$qb" \
                 --bnddist "$BND_DIST"
+            # The aggregate above has a CEILING SET BY US, not by the caller: direct
+            # junctions are correctly called <DEL>/<DUP:TANDEM>, so they can never match
+            # a BND record. Job 20719077: every one of the 452 direct-form records was a
+            # FN and none appeared in tp-base, making the 0.380 aggregate a statement
+            # about our SVTYPE choice. BNDinv restricts the truth to the junctions a
+            # caller can actually represent as breakends, which is the caller number.
+            if [[ -f "$OUTDIR/truth_sv_BNDinv.vcf.gz" ]]; then
+                local n_inv n_dir
+                n_inv=$(bcftools view -H "$OUTDIR/truth_sv_BNDinv.vcf.gz" | wc -l)
+                n_dir=$(bcftools view -H "$OUTDIR/truth_sv_BNDdirect.vcf.gz" 2>/dev/null | wc -l)
+                if [[ "$n_inv" -gt 0 ]]; then
+                    run_truvari "$OUTDIR/truth_sv_BNDinv.vcf.gz" "${caller}_BNDinv" "$qb" \
+                        --bnddist "$BND_DIST"
+                    echo "    ^ BNDinv is the interpretable BND number: truth restricted to the"
+                    echo "      $n_inv inversion-oriented record(s) a caller CAN emit as breakends."
+                    echo "      The ${caller}_BND figure above additionally counts $n_dir direct-form"
+                    echo "      record(s) that are called <DEL>/<DUP:TANDEM> and cannot match by"
+                    echo "      construction — a ceiling of $n_inv/$((n_inv + n_dir)), set by our"
+                    echo "      representation. Quote BNDinv when describing the caller."
+                fi
+            fi
         else
             rm -f "$qb" "${qb}.tbi"
             echo "  ${caller}_BND recall=0.000  (caller emitted no BND records)"
@@ -1012,6 +1093,10 @@ if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
         echo "  would measure our emission defect and report it as caller performance." >&2
         CAL_FAIL=1
     fi
+    # Split the truth by geometry so BND recall can be reported against the junctions a
+    # caller can actually emit as breakends, separately from the direct ones it cannot.
+    split_bnd_by_geometry "$OUTDIR/truth_sv_BND.vcf.gz" \
+        "$OUTDIR/truth_sv_BNDinv.vcf.gz" "$OUTDIR/truth_sv_BNDdirect.vcf.gz" || CAL_FAIL=1
     build_bnd_spans "$OUTDIR/truth_sv_BND.vcf.gz" "$OUTDIR/truth_sv_BNDspan.vcf.gz" \
         || BND_SPAN_RC=$?
     case "$BND_SPAN_RC" in

--- a/scripts/delta/tests/test_bnd_geometry.sh
+++ b/scripts/delta/tests/test_bnd_geometry.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Automated tests for the BND geometry functions in sv_pipeline.sbatch.
+#
+# WHY THIS FILE EXISTS: scripts/delta/*.sh determine numbers the ACCESS report cites and
+# were exercised by nothing automatic (#466). Every quiet failure found in this project
+# so far has been a harness reporting a metric it never checked, so a harness with no
+# tests of its own is the least defensible thing in the repo.
+#
+# The functions are EXTRACTED VERBATIM from sv_pipeline.sbatch rather than copied here.
+# A copy would drift, and then this file would be testing something that is not what runs
+# on Delta — which is the same defect it exists to catch.
+#
+# Every fixture below has an answer computable BY HAND, independently of the code under
+# test, and every assertion is accompanied by a mutation that must break it (--mutate).
+#
+# Usage:
+#   scripts/delta/tests/test_bnd_geometry.sh            # run the suite
+#   scripts/delta/tests/test_bnd_geometry.sh --mutate   # prove the suite is non-vacuous
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PIPELINE="${PIPELINE:-$HERE/../sv_pipeline.sbatch}"   # overridden by --mutate
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── Mutation driver ────────────────────────────────────────────────────────────
+# A suite that has never been seen to fail is decoration. Each entry below breaks the
+# production code in a plausible way and names the assertion that must catch it; a
+# mutation that SURVIVES means that assertion is not testing what it claims.
+#
+# The mutation is applied to a COPY of sv_pipeline.sbatch and verified to have actually
+# changed the file before the suite runs — a silently no-op edit would otherwise be
+# reported as "caught" when nothing was ever mutated.
+if [[ "${1:-}" == "--mutate" ]]; then
+    survived=0
+    # label @ literal-to-find @ replacement
+    while IFS='@' read -r label from to; do
+        [[ -n "$label" ]] || continue
+        cp "$PIPELINE" "$WORK/mutant.sbatch"
+        FROM="$from" TO="$to" perl -0pi -e 's/\Q$ENV{FROM}\E/$ENV{TO}/' "$WORK/mutant.sbatch"
+        if cmp -s "$PIPELINE" "$WORK/mutant.sbatch"; then
+            printf '  ERROR   %-42s mutation did not apply — anchor text not found\n' "$label"
+            survived=$((survived+1)); continue
+        fi
+        if PIPELINE="$WORK/mutant.sbatch" bash "$0" >/dev/null 2>&1; then
+            printf '  SURVIVED %-41s <- nothing caught this\n' "$label"
+            survived=$((survived+1))
+        else
+            printf '  caught   %s\n' "$label"
+        fi
+    done <<'MUTATIONS'
+mates_ok accepts any pairing@function mates_ok(a,b) {@function mates_ok(a,b) { return 1;
+unpaired mates not counted@if (!(t in g)) { u@if (!(t in g)) { u0
+unparsable ALTs not counted@{ bad++; badex@{ badex
+single-geometry NOTE always fires@if (nd==1 && parsed>=24)@if (nd>=1 && parsed>=1)
+geometry check always exits 0@exit (bad+unpaired+mismatch > 0) ? 1 : 0@exit 0
+split puts records in the wrong bucket@if ((k=="direct" && d) || (k=="inv" && i)) print@if ((k=="direct" && i) || (k=="inv" && d)) print
+split stops checking for lost records@if [[ $((n_inv + n_dir)) -ne "$n_src" ]]; then@if [[ 1 -eq 0 ]]; then
+MUTATIONS
+    printf '\n──────── %d mutation(s) survived ────────\n' "$survived"
+    [[ "$survived" -eq 0 ]]
+    exit $?
+fi
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL  %s\n     expected: %s\n     actual:   %s\n' "$1" "$2" "$3"; }
+is()   { [[ "$2" == "$3" ]] && ok "$1" || bad "$1" "$2" "$3"; }
+has()  { case "$2" in *"$3"*) ok "$1";; *) bad "$1" "contains: $3" "$2";; esac; }
+hasnt(){ case "$2" in *"$3"*) bad "$1" "must NOT contain: $3" "$2";; *) ok "$1";; esac; }
+
+# Skipping is a convenience for a workstation without bcftools, never for CI. If the
+# install step ever breaks, exiting 0 here would turn "tested nothing" into a green
+# check — the false-pass shape this whole suite exists to prevent.
+if ! command -v bcftools >/dev/null; then
+    if [[ -n "${CI:-}" ]]; then
+        echo "FATAL: bcftools is not on PATH and CI is set. Refusing to report success" >&2
+        echo "  for a suite that would run zero assertions." >&2
+        exit 2
+    fi
+    echo "SKIP: bcftools not on PATH (set CI=1 to make this fatal)"
+    exit 0
+fi
+
+# ── Load the functions under test, verbatim ────────────────────────────────────
+extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
+for fn in check_bnd_geometry split_bnd_by_geometry; do
+    src="$(extract "$fn")"
+    [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
+    eval "$src"
+done
+OUTDIR="$WORK"   # split_bnd_by_geometry writes its scratch files here
+
+# ── Fixture builder ────────────────────────────────────────────────────────────
+vcf_header() {
+    printf '##fileformat=VCFv4.2\n##contig=<ID=c1,length=1000000>\n'
+    printf '##ALT=<ID=BND,Description="Breakend">\n'
+    printf '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="t">\n'
+    printf '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n'
+}
+rec() { printf 'c1\t%s\t.\t%s\t%s\t60\tPASS\tSVTYPE=BND\n' "$1" "$2" "$3"; }
+
+# KNOWN-ANSWER FIXTURE. Hand-counted, independent of the implementation:
+#   2 direct junctions      -> 2x t[p[ and 2x ]p]t
+#   3 head-to-head junctions-> 6x t]p]
+#   1 tail-to-tail junction -> 2x [p[t
+#   ------------------------------------------------
+#   12 records, 6 junctions; inversion-oriented = 6+2 = 8, direct = 2+2 = 4
+build_mixed() {
+    { vcf_header
+      rec 1000 T "T[c1:2000["   ; rec 2000 A "]c1:1000]A"    # direct #1
+      rec 3000 G "G[c1:4000["   ; rec 4000 C "]c1:3000]C"    # direct #2
+      rec 5000 T "T]c1:6000]"   ; rec 6000 A "A]c1:5000]"    # head-to-head #1
+      rec 7000 G "G]c1:8000]"   ; rec 8000 C "C]c1:7000]"    # head-to-head #2
+      rec 9000 T "T]c1:10000]"  ; rec 10000 A "A]c1:9000]"   # head-to-head #3
+      rec 11000 G "[c1:12000[G" ; rec 12000 C "[c1:11000[C"  # tail-to-tail #1
+    } > "$WORK/mixed.vcf"
+}
+
+echo "=== check_bnd_geometry: known-answer fixture (12 records, 6 junctions) ==="
+build_mixed
+out="$(check_bnd_geometry "$WORK/mixed.vcf" 2>&1)"; rc=$?
+is "accepts a well-formed truth (rc)"          "0"  "$rc"
+is "counts t[p[ (hand-count: 2)"   "2" "$(sed -n 's/.*t\[p\[ *direct\/deletion-like *\([0-9]*\).*/\1/p' <<<"$out")"
+is "counts t]p] (hand-count: 6)"   "6" "$(sed -n 's/.*t\]p\] *head-to-head *\([0-9]*\).*/\1/p' <<<"$out")"
+is "counts [p[t (hand-count: 2)"   "2" "$(sed -n 's/.*\[p\[t *tail-to-tail *\([0-9]*\).*/\1/p' <<<"$out")"
+is "counts ]p]t (hand-count: 2)"   "2" "$(sed -n 's/.*\]p\]t *direct\/duplication-like *\([0-9]*\).*/\1/p' <<<"$out")"
+has "reports full reciprocity"     "$out" "0 unpaired, 0 mispaired"
+has "reports parse coverage"       "$out" "12 record(s), 12 parsed into a form, 0 unparsable"
+hasnt "does NOT flag a mixed truth as single-geometry" "$out" "NOTE:"
+
+echo "=== check_bnd_geometry: each way the truth can be wrong ==="
+# Direct forms pair two DIFFERENT shapes, so a mate given the same shape is invalid.
+# A naive "both sides match" check would pass this, which is why it is tested.
+sed 's/\]c1:1000\]A/A]c1:1000]/' "$WORK/mixed.vcf" > "$WORK/mispaired.vcf"
+out="$(check_bnd_geometry "$WORK/mispaired.vcf" 2>&1)"; rc=$?
+is  "rejects a mate with the wrong form (rc)" "1" "$rc"
+has "names the mispaired junction" "$out" "first mispaired:"
+
+grep -v $'\t6000\t' "$WORK/mixed.vcf" > "$WORK/unpaired.vcf"
+out="$(check_bnd_geometry "$WORK/unpaired.vcf" 2>&1)"; rc=$?
+is  "rejects a junction whose mate is absent (rc)" "1" "$rc"
+has "names the unpaired junction" "$out" "(no record there)"
+
+sed 's/\[c1:12000\[G/<BND>/' "$WORK/mixed.vcf" > "$WORK/unparsable.vcf"
+out="$(check_bnd_geometry "$WORK/unparsable.vcf" 2>&1)"; rc=$?
+is  "rejects an ALT that is not breakend notation (rc)" "1" "$rc"
+has "quotes the unparsable ALT" "$out" "first unparsable ALT: <BND>"
+
+echo "=== check_bnd_geometry: the pre-v3.1.0 shape is consistent but must be flagged ==="
+# 14 head-to-head junctions = 28 records: internally reciprocal, so every check above
+# passes. This is exactly what eidolon emitted before geometry sampling, and it must
+# not be able to regress silently.
+{ vcf_header
+  for i in $(seq 1 14); do
+      a=$((i*1000)); b=$((i*1000+500))
+      rec "$a" A "A]c1:$b]"; rec "$b" C "C]c1:$a]"
+  done | sort -k2,2n
+} > "$WORK/all_h2h.vcf"
+out="$(check_bnd_geometry "$WORK/all_h2h.vcf" 2>&1)"; rc=$?
+is  "a single-geometry truth is still internally consistent (rc)" "0" "$rc"
+has "flags the single-geometry regression" "$out" "share ONE geometry"
+
+echo "=== split_bnd_by_geometry: known-answer split (8 inv-oriented / 4 direct) ==="
+build_mixed
+bcftools view -O z -o "$WORK/mixed.vcf.gz" "$WORK/mixed.vcf" >/dev/null 2>&1
+bcftools index -f -t "$WORK/mixed.vcf.gz" >/dev/null 2>&1
+out="$(split_bnd_by_geometry "$WORK/mixed.vcf.gz" "$WORK/inv.vcf.gz" "$WORK/dir.vcf.gz" 2>&1)"; rc=$?
+is "splits a well-formed truth (rc)" "0" "$rc"
+is "inversion-oriented count (hand-count: 8)" "8" "$(bcftools view -H "$WORK/inv.vcf.gz" | wc -l | tr -d ' ')"
+is "direct count (hand-count: 4)"             "4" "$(bcftools view -H "$WORK/dir.vcf.gz" | wc -l | tr -d ' ')"
+has "reports the split" "$out" "8 inversion-oriented, 4 direct (of 12)"
+
+# Content, not counts: the right RECORDS must be in each bucket. A split that put 8
+# arbitrary records in the inv file would satisfy every count assertion above.
+is "inv bucket holds only t]p] and [p[t" "0" \
+   "$(bcftools query -f '%ALT\n' "$WORK/inv.vcf.gz" | grep -cE '^([ACGTNacgtn]+\[|\])')"
+is "direct bucket holds only t[p[ and ]p]t" "0" \
+   "$(bcftools query -f '%ALT\n' "$WORK/dir.vcf.gz" | grep -cE '^([ACGTNacgtn]+\]|\[)')"
+
+echo "=== split_bnd_by_geometry: a record in neither bucket is a hard failure ==="
+# The coverage-of-its-own-input rule. A record matching neither pattern would silently
+# shrink the denominator of whatever is scored next, which is the #450 shape exactly.
+sed 's/\[c1:12000\[G/<BND>/' "$WORK/mixed.vcf" > "$WORK/lossy.vcf"
+bcftools view -O z -o "$WORK/lossy.vcf.gz" "$WORK/lossy.vcf" >/dev/null 2>&1
+bcftools index -f -t "$WORK/lossy.vcf.gz" >/dev/null 2>&1
+out="$(split_bnd_by_geometry "$WORK/lossy.vcf.gz" "$WORK/i2.vcf.gz" "$WORK/d2.vcf.gz" 2>&1)"; rc=$?
+is  "rejects a split that loses a record (rc)" "1" "$rc"
+has "says how many were lost" "$out" "lost 1 record(s)"
+
+printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Job 20719077 (soy whole assembly, 466 junctions) verified geometry sampling end-to-end — and falsified two things the harness itself was printing.

## What the run measured

```
t[p[ 226 (24.2%)   t]p] 256 (27.5%)   [p[t 224 (24.0%)   ]p]t 226 (24.2%)
0 unpaired, 0 mispaired across 932 records
```

`t[p[` == `]p]t` == 226 **exactly** — required, not luck: every direct junction contributes one of each, so drift between those counts is a broken pair. χ² vs uniform over the three distinguishable classes ≈ 1.5, df=2, p≈0.47. Indistinguishable from the model's declared uniform weights.

## Two defects this exposed, both in our own output

**1. The harness was printing a false claim.** `"the truth's 466 BND junction(s) are head-to-head"` was hardcoded from when geometry was hardcoded. Only 128 are. Now measured from the truth instead of asserted.

**2. `manta_BND recall=0.380` is not a caller result.** Callers bucket only inversion-oriented adjacencies as BND; a direct adjacency is a deletion or tandem duplication, called `<DEL>`/`<DUP:TANDEM>`. Predicted before looking, then confirmed:

```
tp-base: t[p[ 0    t]p] 188  [p[t 166  ]p]t 0     -> direct 0,   inv-oriented 354
fn:      t[p[ 226  t]p] 68   [p[t 58   ]p]t 226   -> direct 452, inv-oriented 126
```

Every direct-form record was a false negative; none matched. The caller number is **354/480 = 0.738** (head-to-head 0.734, tail-to-tail 0.741 — no bias within the class). The 0.380 was a statement about our SVTYPE choice, floored by our own representation. That is the INV precision-floor mistake one layer down. `BNDinv` now reports the interpretable figure alongside the aggregate.

## First automated coverage these scripts have ever had

`scripts/delta/tests/` closes #466 for the SV pipeline. These scripts decide numbers the ACCESS report cites and were exercised by nothing. Functions are **extracted verbatim** from the sbatch rather than copied, so the tests cannot drift from what runs on Delta.

**24 assertions** on known-answer fixtures (hand-counted: 12 records, 6 junctions, 8 inversion-oriented / 4 direct), asserting content and not just counts — a split putting 8 arbitrary records in the inv bucket would satisfy every count assertion, so bucket membership is checked directly.

**7/7 mutations of the production code caught, 0 survived:**

| mutation | result |
|---|---|
| `mates_ok` accepts any pairing | caught |
| unpaired mates not counted | caught |
| unparsable ALTs not counted | caught |
| single-geometry NOTE always fires | caught (must-not-fire) |
| geometry check always exits 0 | caught |
| split puts records in the wrong bucket | caught |
| split stops checking for lost records | caught |

Re-verified on a fixture rebuilt to job 20719077's exact measured mix: 226/256/224/226, split 480 inv / 452 direct, reciprocity clean.

**The suite refuses to skip under CI.** If bcftools is missing it exits 2 rather than reporting success for zero assertions — otherwise a broken `apt-get` step turns "tested nothing" into a green check. Both branches verified (`CI=1` → rc=2 with FATAL; unset → rc=0 with SKIP).