### PR TITLE
fix(delta): score the canonical SVTYPE list, not a glob of the truth directory

### DIFF
--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -272,7 +272,19 @@ fi
 # Pre-generate per-type truth subsets NOW, while bcftools (bioinf) is active, so
 # the truvari scoring stage needs only truvari on its PATH (no bcftools in that
 # env). Empty types are removed so the scoring loop skips them.
-for svt in DEL DUP INV INS BND CNV; do
+# The canonical SVTYPE list, declared ONCE. The scoring loop iterates this same array
+# rather than globbing truth_sv_*.vcf.gz, so a derived artifact can never be mistaken
+# for an SVTYPE — see SV_TYPES_SCORED_IN_LOOP below.
+SV_TYPES=(DEL DUP INV INS BND CNV)
+# Types the generic scoring loop handles. BND is scored by breakpoint proximity and CNV
+# by the stage-4c direction check, so both are excluded here and handled explicitly.
+# Derived from SV_TYPES so a newly added type is scored rather than silently dropped.
+SV_TYPES_SCORED_IN_LOOP=()
+for svt in "${SV_TYPES[@]}"; do
+    case "$svt" in BND|CNV) continue ;; esac
+    SV_TYPES_SCORED_IN_LOOP+=("$svt")
+done
+for svt in "${SV_TYPES[@]}"; do
     typed="$OUTDIR/truth_sv_${svt}.vcf.gz"
     bcftools view -i "INFO/SVTYPE=\"$svt\"" -O z -o "$typed" "$TRUTH_SV" 2>/dev/null || continue
     bcftools index -f -t "$typed" 2>/dev/null || true
@@ -996,12 +1008,22 @@ score_caller() {  # <caller> <comp.vcf.gz> [raw_comp.vcf.gz]
         echo "  ($caller: no truvari-scoreable truth types — aggregate skipped)"
     fi
 
-    for typed in "$OUTDIR"/truth_sv_*.vcf.gz; do
+    # Iterate the CANONICAL type list, never a glob of whatever files happen to exist.
+    #
+    # This used to be `for typed in "$OUTDIR"/truth_sv_*.vcf.gz` with a hand-maintained
+    # exclusion list, which meant any newly derived truth artifact was silently promoted
+    # to an SVTYPE. Adding truth_sv_BNDinv.vcf.gz did exactly that in job 20745149:
+    #     manta_BNDinv recall=0.000  (caller emitted no BNDinv records)
+    #     manta_BNDinv       recall=0.738 ... TP=354  FN=126
+    # Two contradictory lines for one label, and for Delly only the false one appeared.
+    # The bug was not the missing exclusion, it was that the loop's input was the
+    # directory contents; adding to an exclusion list would leave the next artifact to
+    # find the same trap. SV_TYPES_SCORED_IN_LOOP is derived from SV_TYPES so a new type
+    # is picked up automatically while a new derived FILE cannot inject a fake one.
+    local svt
+    for svt in "${SV_TYPES_SCORED_IN_LOOP[@]}"; do
+        local typed="$OUTDIR/truth_sv_${svt}.vcf.gz"
         [[ -f "$typed" ]] || continue
-        local svt; svt=$(basename "$typed" .vcf.gz); svt=${svt#truth_sv_}
-        case "$svt" in
-            BND|BNDspan|CNV|scoreable) continue ;;   # handled separately below / 4c
-        esac
         local q="$OUTDIR/${caller}_calls_${svt}.vcf.gz"
         bcftools view -i "INFO/SVTYPE=\"$svt\"" -O z -o "$q" "$comp" 2>/dev/null || true
         if [[ -f "$q" ]] && [[ "$(bcftools view -H "$q" 2>/dev/null | wc -l)" -gt 0 ]]; then

--- a/scripts/delta/tests/test_bnd_geometry.sh
+++ b/scripts/delta/tests/test_bnd_geometry.sh
@@ -56,6 +56,8 @@ single-geometry NOTE always fires@if (nd==1 && parsed>=24)@if (nd>=1 && parsed>=
 geometry check always exits 0@exit (bad+unpaired+mismatch > 0) ? 1 : 0@exit 0
 split puts records in the wrong bucket@if ((k=="direct" && d) || (k=="inv" && i)) print@if ((k=="direct" && i) || (k=="inv" && d)) print
 split stops checking for lost records@if [[ $((n_inv + n_dir)) -ne "$n_src" ]]; then@if [[ 1 -eq 0 ]]; then
+scoring loop goes back to globbing@for svt in "${SV_TYPES_SCORED_IN_LOOP[@]}"; do@for typed in "$OUTDIR"/truth_sv_*.vcf.gz; do
+a derived artifact stops being scored separately@BND|CNV) continue ;;@BND) continue ;;
 MUTATIONS
     printf '\n──────── %d mutation(s) survived ────────\n' "$survived"
     [[ "$survived" -eq 0 ]]
@@ -187,6 +189,40 @@ bcftools index -f -t "$WORK/lossy.vcf.gz" >/dev/null 2>&1
 out="$(split_bnd_by_geometry "$WORK/lossy.vcf.gz" "$WORK/i2.vcf.gz" "$WORK/d2.vcf.gz" 2>&1)"; rc=$?
 is  "rejects a split that loses a record (rc)" "1" "$rc"
 has "says how many were lost" "$out" "lost 1 record(s)"
+
+echo "=== cross-component: a derived truth artifact must not become an SVTYPE ==="
+# REGRESSION GUARD, job 20745149. The scoring loop globbed truth_sv_*.vcf.gz and relied
+# on a hand-maintained exclusion list, so writing truth_sv_BNDinv.vcf.gz silently
+# promoted it to an SVTYPE. The harness then printed, for the same label:
+#     manta_BNDinv recall=0.000  (caller emitted no BNDinv records)
+#     manta_BNDinv       recall=0.738 ... TP=354  FN=126
+# Neither split_bnd_by_geometry nor the scoring loop is wrong on its own — they simply
+# disagreed about what a truth_sv_* file means. That is an invariant BETWEEN two
+# components, and it needs its own assertion or it is nobody's test.
+# Anchored to non-comment lines: the fix's own comment quotes the old glob verbatim,
+# and a check that cannot tell code from a comment would fail on the correct code.
+is "scoring loop does not glob the truth directory" "0" \
+   "$(grep -cE '^[^#]*for +typed +in .*truth_sv_\*' "$PIPELINE")"
+is "scoring loop iterates the canonical type list" "1" \
+   "$(grep -cF 'for svt in "${SV_TYPES_SCORED_IN_LOOP[@]}"' "$PIPELINE")"
+
+# The loop must cover exactly the types not handled separately. Hardcoded here on
+# purpose: if someone edits SV_TYPES, this must be reviewed rather than silently follow.
+SV_TYPES=(); SV_TYPES_SCORED_IN_LOOP=()
+eval "$(awk '/^SV_TYPES=\(/,/^done$/' "$PIPELINE")"
+is "canonical SVTYPEs"            "DEL DUP INV INS BND CNV" "${SV_TYPES[*]}"
+is "types scored by the generic loop" "DEL DUP INV INS"     "${SV_TYPES_SCORED_IN_LOOP[*]}"
+
+# Every truth_sv_<X> file the script writes must be a canonical SVTYPE or a KNOWN
+# derived artifact. A new artifact that is neither shows up here, not on Delta.
+KNOWN_DERIVED=" BNDspan BNDinv BNDdirect scoreable "
+unclassified=""
+for nm in $(grep -oE 'truth_sv_[A-Za-z]+' "$PIPELINE" | sed 's/^truth_sv_//' | sort -u); do
+    case " ${SV_TYPES[*]} " in *" $nm "*) continue ;; esac
+    case "$KNOWN_DERIVED"     in *" $nm "*) continue ;; esac
+    unclassified="$unclassified $nm"
+done
+is "no unclassified truth_sv_* artifact" "" "$unclassified"
 
 printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Job 20745149 confirmed every prediction for #489's geometry split — and exposed a defect the split itself introduced.

## Confirmed

A re-score of job 20719077's artifacts: same truth, same calls, only the scoring code changed, so any difference is attributable.

| | predicted | actual |
|---|---|---|
| NOTE | 240 inversion-oriented junctions | 240 ✓ |
| geometry | 226/256/224/226, 0 unpaired, 0 mispaired | identical ✓ |
| split | 480 inversion-oriented, 452 direct (of 932) | identical ✓ |
| `manta_BND` | unchanged 0.380 | `0.380 TP=354 FN=578 FP=518` ✓ |
| `manta_BNDinv` | **TP exactly 354**, FN=126 | `0.738 TP=354 FN=126 FP=518` ✓ |
| precision | unchanged 0.406 | `0.406` ✓ |

TP was exactly 354 and precision moved not at all, as predicted: the 452 direct records matched nothing, so removing them freed no comp record and no new pairing could form.

## The defect

`score_caller` globbed `"$OUTDIR"/truth_sv_*.vcf.gz` and filtered it through a hand-maintained exclusion list. Writing `truth_sv_BNDinv.vcf.gz` therefore silently promoted it to an SVTYPE, and the harness printed, for the same label:

```
manta_BNDinv recall=0.000  (caller emitted no BNDinv records)
manta_BNDinv       recall=0.738 ... TP=354  FN=126
```

Two contradictory numbers. Delly, which emits no breakends, showed only the false one.

**Adding `BNDinv|BNDdirect` to the exclusion list would fix the symptom and leave the trap for the next artifact.** The bug is that the loop's input was the directory contents. It now iterates `SV_TYPES_SCORED_IN_LOOP`, derived from a single canonical `SV_TYPES` declaration: a new SVTYPE is scored automatically, while a new derived *file* cannot inject a fake one.

Neither component was wrong alone — `split_bnd_by_geometry` wrote a correct file and the loop scored files correctly. They disagreed about what `truth_sv_*` **means**. That is why the tests added in #489 could not catch it: an invariant between two components is nobody's test until it is written down.

## Verified

29 assertions pass; **9/9 mutations caught, 0 survived**, including the two new ones:

| mutation | result |
|---|---|
| scoring loop goes back to globbing | caught |
| a derived artifact stops being scored separately | caught |

The glob assertion is anchored to non-comment lines — the fix's own comment quotes the old glob verbatim, and the first version of the check failed on *correct* code because it could not tell code from a comment.