### PR TITLE
fix(core): emit adapter read-through as a soft clip, not an aligned match

### DIFF
--- a/eidolon-core/src/file_tools/bam_writer.rs
+++ b/eidolon-core/src/file_tools/bam_writer.rs
@@ -494,7 +494,6 @@ mod tests {
     /// the FASTQ side pinned `'S'` and the BAM side silently turned it into `M`, and no
     /// test spanned the two.
     fn read_bam_cigars(path: &PathBuf) -> Vec<String> {
-        use noodles::sam::alignment::record::Cigar as _;
         let file = std::fs::File::open(path).unwrap();
         let mut reader = bam::io::Reader::new(file);
         reader.read_header().unwrap();

--- a/eidolon-core/src/file_tools/bam_writer.rs
+++ b/eidolon-core/src/file_tools/bam_writer.rs
@@ -370,11 +370,33 @@ fn rle_to_cigar(char_ops: &[char]) -> Cigar {
     ops.into_iter().collect()
 }
 
+/// Map a `ReadRecord::cigar_ops` character to its SAM CIGAR operation.
+///
+/// The read pipeline emits exactly four: `M` (aligned base), `I` (insertion error),
+/// `D` (deletion error), and `S` (adapter read-through, `fastq_tools.rs:657`).
+///
+/// `S` was previously absent, so it fell through to `Match` and every adapter base was
+/// written to the BAM as aligned sequence — a soft clip does not consume reference, and
+/// claiming it does tells every downstream aligner and caller that adapter aligned to
+/// the genome. `fastq_tools` pinned the `'S'` in its own unit test and nothing checked
+/// the BAM honoured it, which is the two-components-in-agreement invariant that needs
+/// its own test (see `every_op_the_read_pipeline_emits_round_trips_through_a_bam`).
 fn char_to_cigar_kind(c: char) -> CigarKind {
     match c {
+        'M' => CigarKind::Match,
         'I' => CigarKind::Insertion,
         'D' => CigarKind::Deletion,
-        _ => CigarKind::Match,
+        'S' => CigarKind::SoftClip,
+        // `cigar_ops` is an untyped Vec<char>, so an unknown op is possible. Fall back
+        // to Match rather than panicking mid-write, but fail loudly in tests so a newly
+        // added op cannot repeat the silent-Match bug above.
+        other => {
+            debug_assert!(
+                false,
+                "unhandled CIGAR op {other:?} — add it to char_to_cigar_kind"
+            );
+            CigarKind::Match
+        }
     }
 }
 
@@ -458,6 +480,82 @@ mod tests {
             mate_position: 0,
             template_length: 0,
         }
+    }
+
+    /// Flatten a built `Cigar` into (kind, len) pairs for exact comparison.
+    fn cigar_ops_of(cigar: &Cigar) -> Vec<(CigarKind, usize)> {
+        cigar.as_ref().iter().map(|o| (o.kind(), o.len())).collect()
+    }
+
+    /// Read every record's CIGAR back out of a written BAM, as a SAM-style string.
+    ///
+    /// Nothing in this repo read a CIGAR out of a produced BAM before this. That gap is
+    /// exactly why adapter soft clips could be emitted as `M` for as long as they were:
+    /// the FASTQ side pinned `'S'` and the BAM side silently turned it into `M`, and no
+    /// test spanned the two.
+    fn read_bam_cigars(path: &PathBuf) -> Vec<String> {
+        use noodles::sam::alignment::record::Cigar as _;
+        let file = std::fs::File::open(path).unwrap();
+        let mut reader = bam::io::Reader::new(file);
+        reader.read_header().unwrap();
+        reader
+            .records()
+            .map(|r| {
+                let rec = r.unwrap();
+                rec.cigar()
+                    .iter()
+                    .map(|o| {
+                        let o = o.unwrap();
+                        format!(
+                            "{}{}",
+                            o.len(),
+                            match o.kind() {
+                                CigarKind::Match => 'M',
+                                CigarKind::Insertion => 'I',
+                                CigarKind::Deletion => 'D',
+                                CigarKind::SoftClip => 'S',
+                                CigarKind::HardClip => 'H',
+                                _ => '?',
+                            }
+                        )
+                    })
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn soft_clips_are_not_silently_converted_to_matches() {
+        // Known answer, independent of the implementation: four aligned bases followed
+        // by two adapter bases is 4M2S. A soft clip does NOT consume reference, so
+        // emitting it as M asserts that adapter sequence aligned to the genome.
+        assert_eq!(
+            cigar_ops_of(&rle_to_cigar(&['M', 'M', 'M', 'M', 'S', 'S'])),
+            vec![(CigarKind::Match, 4), (CigarKind::SoftClip, 2)],
+        );
+    }
+
+    #[test]
+    fn every_op_the_read_pipeline_emits_round_trips_through_a_bam() {
+        // fastq_tools produces exactly four ops: M (match), I (insert error),
+        // D (delete error), S (adapter read-through). Each must survive to the BAM.
+        // Asserting the whole alphabet at once means a future op added on the FASTQ
+        // side and forgotten here shows up as a failure rather than as silent Ms.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ops.bam");
+        let contigs = vec![("chr1".to_string(), 1000usize)];
+        {
+            let mut w = BamWriter::new(&path, &contigs).unwrap();
+            let mut rec = make_read("ops", 10);
+            // SEQ length must equal the query-consuming ops (M + I + S = 7); 'D'
+            // marks a deleted reference base and consumes no query base.
+            rec.sequence = "ACGTACG".to_string();
+            rec.quality_scores = vec![30; 7];
+            //              2M        1I   1D    2M        2S
+            rec.cigar_ops = vec!['M', 'M', 'I', 'D', 'M', 'M', 'S', 'S'];
+            w.write_read_record(&rec).unwrap();
+        }
+        assert_eq!(read_bam_cigars(&path), vec!["2M1I1D2M2S".to_string()]);
     }
 
     fn read_bam_positions(path: &PathBuf) -> Vec<usize> {

--- a/eidolon/tests/adapter_bam_cigar.rs
+++ b/eidolon/tests/adapter_bam_cigar.rs
@@ -1,0 +1,134 @@
+//! Adapter read-through must reach the BAM as a SOFT CLIP, not as an aligned match.
+//!
+//! Two gaps met here, both found by audit:
+//!
+//! 1. **No test in this repo read a CIGAR out of a produced BAM.** `produce_bam: true`
+//!    appeared in exactly one integration test, which inspected only `template_length`.
+//!    So the BAM's alignment geometry — the thing every downstream aligner and caller
+//!    consumes — was asserted nowhere.
+//! 2. **"adapter" appeared in zero files under `eidolon/tests/`**, despite #125 backing
+//!    the largest single number in the ACCESS report's fix table (SNP recall
+//!    0.0004 → 0.944).
+//!
+//! Between them they hid a real defect: `fastq_tools.rs` tagged adapter bases `'S'` and
+//! `bam_writer.rs::char_to_cigar_kind` mapped everything except `I`/`D` to `Match`, so
+//! adapter was written as aligned sequence. Each side was self-consistent and unit
+//! tested; nothing asserted they agreed. A soft clip does not consume reference, so the
+//! defect also overstated each read's reference span.
+//!
+//! The negative control matters as much as the positive one: with adapters disabled the
+//! output must contain no soft clips at all, or a validator that stamped `S` on
+//! everything would satisfy the positive assertion.
+
+mod common;
+
+use common::{eidolon, h1n1_reference};
+use noodles::bam;
+use noodles::sam::alignment::record::cigar::op::Kind;
+use std::path::Path;
+
+/// Per-record (soft-clipped bases, query-consuming bases) from a BAM.
+fn clip_and_query_lengths(path: &Path) -> Vec<(usize, usize)> {
+    let file = std::fs::File::open(path).expect("bam not produced");
+    let mut reader = bam::io::Reader::new(file);
+    reader.read_header().unwrap();
+    reader
+        .records()
+        .map(|r| {
+            let rec = r.unwrap();
+            let (mut clipped, mut query) = (0usize, 0usize);
+            for op in rec.cigar().iter() {
+                let op = op.unwrap();
+                match op.kind() {
+                    Kind::SoftClip => {
+                        clipped += op.len();
+                        query += op.len();
+                    }
+                    Kind::Match
+                    | Kind::Insertion
+                    | Kind::SequenceMatch
+                    | Kind::SequenceMismatch => query += op.len(),
+                    _ => {}
+                }
+            }
+            (clipped, query)
+        })
+        .collect()
+}
+
+/// Run gen-reads on the H1N1 fixture with a short-insert library.
+/// `adapters` toggles 3' read-through; everything else is held constant.
+fn run(dir: &Path, name: &str, adapters: bool) -> Vec<(usize, usize)> {
+    let cfg_text = format!(
+        "reference: {ref}\nread_len: 100\ncoverage: 20\nploidy: 1\npaired_ended: true\n\
+         fragment_mean: 60\nfragment_st_dev: 5\n\
+         produce_bam: true\nproduce_fastq: false\nproduce_vcf: false\n\
+         overwrite_output: true\noutput_dir: {out}\noutput_filename: {name}\n\
+         rng_seed: adapter cigar\nnum_threads: 1\n{ad}",
+        ref = h1n1_reference().display(),
+        out = dir.display(),
+        ad = if adapters {
+            "adapters:\n  enabled: true\n  preset: truseq\n"
+        } else {
+            "keep_short_fragments: true\n"
+        },
+    );
+    let cfg = dir.join(format!("{name}.yml"));
+    std::fs::write(&cfg, cfg_text).unwrap();
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(&cfg)
+        .assert()
+        .success();
+    clip_and_query_lengths(&dir.join(format!("{name}.bam")))
+}
+
+#[test]
+fn adapter_readthrough_is_soft_clipped_in_the_bam() {
+    let tmp = tempfile::tempdir().unwrap();
+    let recs = run(tmp.path(), "withad", true);
+    assert!(
+        !recs.is_empty(),
+        "no BAM records — test would vacuously pass"
+    );
+
+    let clipped: Vec<_> = recs.iter().filter(|(c, _)| *c > 0).collect();
+    assert!(
+        !clipped.is_empty(),
+        "adapters enabled with a 60 bp mean insert and 100 bp reads, but not one record \
+         carries a soft clip. Adapter bases are being written as aligned sequence — the \
+         char_to_cigar_kind defect."
+    );
+
+    // Known answer, independent of the implementation: read_len is fixed at 100, and
+    // adapter fills exactly the bases past the insert, so every read is 100 query bases
+    // and the clip is whatever is not genomic. A record clipped to its full length would
+    // mean the genomic piece vanished.
+    for (clip, query) in &recs {
+        assert_eq!(
+            *query, 100,
+            "read_len is 100, so query-consuming ops must total 100; got {query}"
+        );
+        assert!(
+            *clip < 100,
+            "a read clipped over its entire length has no genomic anchor"
+        );
+    }
+}
+
+#[test]
+fn without_adapters_nothing_is_soft_clipped() {
+    // The must-not-fire case. `keep_short_fragments` gives the same short-insert library
+    // WITHOUT adapter read-through, so the only difference is the feature under test.
+    let tmp = tempfile::tempdir().unwrap();
+    let recs = run(tmp.path(), "noad", false);
+    assert!(
+        !recs.is_empty(),
+        "no BAM records — test would vacuously pass"
+    );
+    let total_clipped: usize = recs.iter().map(|(c, _)| *c).sum();
+    assert_eq!(
+        total_clipped, 0,
+        "adapters are disabled, so no base should be soft-clipped; found {total_clipped}"
+    );
+}


### PR DESCRIPTION
**P0 from the audit.** A core BAM-output defect: adapter bases were written as aligned sequence.

```rust
fastq_tools.rs:657     record.cigar_ops.push('S');        // adapter read-through
bam_writer.rs:373      match c { 'I' => Insertion, 'D' => Deletion, _ => Match }   // 'S' -> M
```

Any aligner or caller reading an eidolon BAM saw adapter as aligned to the reference. A soft clip does not consume reference, so this also overstated each affected read's reference span.

**Neither side was wrong alone.** `fastq_tools` sets `'S'` and pins it in its own unit test; `bam_writer` mapped correctly every op it knew about. They disagreed about the alphabet and nothing asserted they agreed — the cross-component invariant from CLAUDE.md, here in core.

**Why it survived:** no test in this repo read a CIGAR out of a produced BAM. `produce_bam: true` appears in one integration test, which inspects only `template_length`. And "adapter" appeared in zero files under `eidolon/tests/`, though #125 backs the largest single number in the report's fix table (SNP recall 0.0004 → 0.944).

**Contained by design:** POS and TLEN are carried on `ReadRecord`, not derived from the CIGAR, so only the emitted CIGAR string changes.

The catch-all is now a `debug_assert!` — a future op added on the FASTQ side fails loudly in tests instead of silently becoming `M`, which is exactly how this arrived.

## Verified — tests written before the fix, proven able to fail

| test | without the fix | with it |
|---|---|---|
| `soft_clips_are_not_silently_converted_to_matches` | `[(Match,4),(Match,2)]` | `[(Match,4),(SoftClip,2)]` |
| `every_op_the_read_pipeline_emits_round_trips_through_a_bam` | `2M1I1D2M2M` | `2M1I1D2M2S` |
| `adapter_readthrough_is_soft_clipped_in_the_bam` | **FAILED** | passes |
| `without_adapters_nothing_is_soft_clipped` | passes (must-not-fire) | passes |

The round-trip test asserts the **whole emitted alphabet** (M/I/D/S) through a real BAM, so an op added later and forgotten here shows up as a failure rather than as silent `M`s.

Workspace **765 passed, 0 failed**, fmt clean, 0 warnings.

## Not verified

Whether #125's reported recall numbers were measured against BAMs carrying this defect. Those runs predate the fix and the figure should be re-checked before it is cited again.