### PR TITLE
docs: retract the translocation claims — eidolon has never generated one

### DIFF
--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -482,9 +482,33 @@ where the caller fails to recover it.
   in the reads and correctly tumor-restricted.
 - **BND signal is in the reads even when uncalled.** Every truth-BND locus
   inspected carried **8–73 discordant/split reads** — the same range as the
-  *detected* BNDs. Manta calls only ~half of them (re-representing tandem-dup
-  pairs as `DUP:TANDEM` at the correct coordinates); the misses are a *caller*
-  limitation — translocations are the hardest short-read class — not absent signal.
+  *detected* BNDs. Manta calls only ~half of them, re-representing them as
+  `DUP:TANDEM`/`DEL` at the correct coordinates.
+
+  > **⚠️ Retraction (2026-08-01).** This bullet previously concluded: *"the misses
+  > are a *caller* limitation — translocations are the hardest short-read class —
+  > not absent signal."* The first and last clauses stand: the signal is present,
+  > and the reads are correct. **The attribution does not.** eidolon has never
+  > generated a translocation — the de novo sampler hardcodes the breakend mate to
+  > the same contig (`sv_model.rs:810`, `:936`), so all 466 junctions in job 20719077
+  > were intra-chromosomal by construction. The explanation invoked a class of event
+  > that was not in the data.
+  >
+  > The measured cause is our own representation. We type every junction `SVTYPE=BND`
+  > regardless of geometry, but a direct same-contig adjacency *is* a deletion or a
+  > tandem duplication, and Manta calls it as one. Job 20745149 confirmed this
+  > exactly — of 932 truth BND records, **all 452 direct-form records were false
+  > negatives and none appeared in `tp-base`**:
+  >
+  > ```
+  > tp-base: t[p[ 0    t]p] 188  [p[t 166  ]p]t 0     -> direct 0,   inv-oriented 354
+  > fn:      t[p[ 226  t]p] 68   [p[t 58   ]p]t 226   -> direct 452, inv-oriented 126
+  > ```
+  >
+  > Manta's recall over junctions it can represent as breakends is **354/480 = 0.738**
+  > (head-to-head 0.734, tail-to-tail 0.741 — no bias within the class). The
+  > "~half" figure was a ceiling set by us, not a caller limitation. See
+  > `docs/cancer_simulator.md` for the full retraction and its cause.
 
 Per-type recovery (Manta + truvari, 60×/0.8):
 
@@ -574,9 +598,20 @@ DUP-enriched (24 %, ~2× the others)** — the last exactly the expected BRCA1/2
 tandem-duplicator phenotype, and all three consistent with the PCAWG-derived models
 (#202 / #237). Two caveats: differentiation requires enough events (a scale
 requirement, not a defect — a small target won't show it), and BND is elevated
-across all tissues (a generation tendency, and unscored downstream since truvari
-does not benchmark breakends), so the tissue signal lives in the *relative*
-enrichments rather than the absolute mode.
+across all tissues, so the tissue signal lives in the *relative* enrichments rather
+than the absolute mode.
+
+> **⚠️ Correction (2026-08-01).** This paragraph previously called the BND elevation
+> "a generation tendency, and unscored downstream since truvari does not benchmark
+> breakends." Both halves were wrong. Truvari has matched breakends since v5.0.0 via
+> `-B/--bnddist` and Delta runs v5.4.0 — see §3.7.1, where the same inherited belief is
+> retracted. And the elevation is not a tendency but a direct inheritance: the BND share
+> is the PCAWG per-donor mean of `svclass == "TRA"` rows
+> (`normalize_pcawg_sv_model.py:108-114`), i.e. the **inter-chromosomal translocation
+> rate** — while the generator emits only same-contig junctions. The per-tissue BND
+> column therefore reports each tissue's translocation burden attached to events that are
+> not translocations. The *relative* enrichments across tissues may still be meaningful;
+> the absolute BND fraction is not. See the retraction in `docs/cancer_simulator.md`.
 
 **Honest caveats — tracked as realism enhancements (epic #311).** The simulated SVs
 are *idealized*: clean cuts in unique sequence, lacking the microhomology, imprecise
@@ -642,12 +677,34 @@ Confirmed by matching each FP's `END` against the truth's junction mates — 7 l
 junctions, 4 on real inversions (Manta redundancy). Excluding our own artifact, precision
 is **5/9 ≈ 0.556**.
 
-**Status of this section.** BND geometry sampling has since been implemented (#458 item
-2), so junctions will no longer all be inversion-shaped. **The numbers above predate that
-change and will move.** They are reported now because they are the first genuine BND
-measurements this project has produced, not because they are final. A post-geometry
-campaign is required before §3.7 is submittable, and until then *"BND recall"* here means
-**head-to-head junction recall**, seven junctions, not breakend detection in general.
+**Status of this section.** BND geometry sampling was implemented (#458 item 2) and the
+post-geometry campaign has now run — jobs 20719077 and 20745149, soy whole assembly, 466
+junctions against the 7 the numbers above rest on. **The numbers above are superseded.**
+
+Measured on the real truth, all four VCF 4.2 forms present and indistinguishable from the
+model's declared uniform weights (χ² ≈ 1.5, df = 2, p ≈ 0.47), with 0 unpaired and 0
+mispaired records across 932:
+
+```
+t[p[ 226 (24.2%)   t]p] 256 (27.5%)   [p[t 224 (24.0%)   ]p]t 226 (24.2%)
+```
+
+The headline correction: **`manta_BND recall = 0.380` is not a caller result.** Callers
+bucket only inversion-oriented adjacencies as BND; a direct same-contig adjacency is a
+deletion or tandem duplication and is called as one. All 452 direct-form truth records
+were false negatives and none appeared in `tp-base`. Manta's recall over the junctions it
+can represent as breakends is **354/480 = 0.738** (head-to-head 0.734, tail-to-tail 0.741).
+The harness now reports this as `BNDinv` alongside the aggregate, and asserts truth
+reciprocity before scoring.
+
+**§3.7 is still not submittable, for a deeper reason than the one previously given.**
+eidolon has never generated a translocation — the de novo sampler hardcodes the breakend
+mate to the same contig. "BND recall" here means **same-contig junction recall**, and the
+BND category itself is under audit: its 23.2% share is inherited from PCAWG's
+inter-chromosomal `TRA` count, and `BND` in a VCF is a representation convention rather
+than an event class (Manta and Delly typed identical junctions differently in job
+20745149). See the retraction in `docs/cancer_simulator.md`. A PCAWG measurement pass
+precedes any further BND claims here.
 
 ### 3.8 At-scale validation (chr1–3 subset, ~690 Mb)
 
@@ -934,8 +991,14 @@ remaining defects of the kind already found.
    somatic specificity confirmed — the first end-to-end check of the SV machinery.
    The BND half of this claim, and the "no simulator defect found" that accompanied
    it, are **retracted**: a de novo breakend defect had been misread as a scorer
-   limitation (§3.7.1). Corrected `manta_BND recall = 1.000`, pending a
-   post-geometry campaign.
+   limitation (§3.7.1). The post-geometry campaign has since run (jobs 20719077 /
+   20745149): the interim `manta_BND recall = 1.000` on 7 junctions is superseded by
+   **0.738 over 480 inversion-oriented records** across 466 junctions, and the
+   aggregate 0.380 is floored by our own SVTYPE choice rather than by the caller.
+   **A second, deeper retraction applies to this item:** the BND work cannot be
+   called DONE at all, because eidolon has never generated a translocation — the de
+   novo sampler places every breakend mate on the same contig. See the retraction in
+   `docs/cancer_simulator.md`; a PCAWG measurement pass precedes any further BND claim.
    Remaining sub-items: exercise the **per-tissue cancer models** (BRCA / skin /
    lung) to confirm tissue-specific SV spectra downstream, and sweep the
    **purity-mixing** machinery across purity/coverage.

--- a/docs/cancer_simulator.md
+++ b/docs/cancer_simulator.md
@@ -107,12 +107,53 @@ The cancer MVP's credibility depends on eidolon being able to generate the SVs t
 
 | Tier | Ticket | Gap | Cancer relevance | Status |
 |---|---|---|---|---|
-| **1** | **#187** | `<BND>` translocations with junction reads | **Critical** — BCR-ABL, PML-RARA, EWSR1-FLI1, MYC-IGH, TMPRSS2-ERG, etc. | ✅ Shipped in v1.12.0 |
+| **1** | **#187** | `<BND>` translocations with junction reads | **Critical** — BCR-ABL, PML-RARA, EWSR1-FLI1, MYC-IGH, TMPRSS2-ERG, etc. | ⚠️ **Partial — junction machinery shipped in v1.12.0; translocations were never generated. See retraction below.** |
 | **1** | **#188** | `<INV>` inversions with read-strand flipping | Moderate — inv(16) AML, inv(3) MDS, focal inversions in solid tumors | ✅ Shipped in v1.12.0 |
 | **2** | **#189** | Verify whole-arm / whole-chromosome aneuploidy via existing DEL/DUP | **High** (universal in cancer) but mostly verification, not new code | ✅ Resolved in v1.10.3 |
 | **2** | **#190** | De novo `<INS>` with novel-sequence generation | Moderate — L1 retrotransposition (lung, colorectal, HCC); viral integrations (HPV, HBV, EBV) | ✅ Shipped in v1.12.0 (random-novel-sequence MVP) |
 | **3** | **#191** | Complex rearrangement patterns (chromothripsis, chromoplexy, BFB) | **High in specific cancers** (sarcoma, GBM, prostate) — but requires correlated multi-event sampler | Design pending |
 | **3** | **#192** | ecDNA / double minutes | **High in some aggressive cancers** (~25–50% of GBM) but needs first-class extrachromosomal data-model concept | Design pending |
+
+> ### ⚠️ Retraction (2026-08-01): #187 was marked shipped; translocations were never generated
+>
+> **The de novo SV sampler cannot place a breakend mate on another contig.** Both
+> `sv_model.rs:810` and `:936` hardcode the mate contig to `Some(contig_name.to_string())`,
+> and `sample_variants` (`sv_model.rs:529-539`) receives one contig's name, length and
+> sequence — it has no view of any other contig. Every BND eidolon has ever generated
+> from a model is intra-chromosomal, by construction rather than by chance. Job 20719077
+> emitted 466 junctions and **466 of 466** were same-contig.
+>
+> Four of the five exemplars in the row above (BCR-ABL, PML-RARA, EWSR1-FLI1, MYC-IGH)
+> are inter-chromosomal fusions. None of them is reachable by the shipped generator.
+>
+> **What did ship, and is correct:** chimeric junction-read generation and all four
+> VCF 4.2 breakend orientation forms. The read path even supports off-contig mates —
+> `runner.rs:2360` resolves `reference.get(&mate_contig)` — so an inter-chromosomal BND
+> supplied via `input_vcf` works today. Only the **de novo sampler**, which is what
+> produces every cancer benchmark, cannot emit one.
+>
+> **How the mislabel arose.** The BND share (23.2%) is the PCAWG per-donor mean of
+> `svclass == "TRA"` rows (`normalize_pcawg_sv_model.py:108-114`) — TRA being precisely
+> the inter-chromosomal class. But `build_pcawg_sv_vcf.py:127-128` reads only
+> `f[0],f[1],f[3],f[4],f[10]`, and its BND branch (`:155-159`) emits a bare `<BND>`
+> anchor and `continue`s — discarding the mate chromosome, and never reading
+> `strand1`/`strand2` (fields 8, 9) at all. So we inherited the *count* of
+> translocations while dropping the two facts that make one a translocation.
+>
+> Consequently the shipped model carries no chromosome-pair, strand, or geometry field,
+> and geometry falls back to a uniform 25% per form (`sv_model.rs:101-103`). About a
+> quarter of emitted BNDs are therefore *deletion-like direct joins on one contig* — the
+> reads carry a plain deletion while the truth VCF types it `SVTYPE=BND`.
+>
+> A further conflation worth stating: **`BND` in a VCF is a notation for an adjacency a
+> caller did not resolve, not an event class.** Manta buckets inversion-oriented
+> junctions as BND; Delly types the same junction `<INV>`; both were observed on
+> identical data in job 20745149. Treating BND as an event type with its own 23.2% share
+> encodes which caller and chemistry produced the source calls, not tumour biology.
+>
+> Remediation is planned as a measurement pass over PCAWG first (intra/inter split,
+> strand spectrum, partner-distance distribution) with the implementation scope decided
+> by what that finds, rather than assumed now.
 
 ## Roadmap
 
@@ -131,11 +172,29 @@ The cancer MVP's credibility depends on eidolon being able to generate the SVs t
 **Exit criterion:** running the orchestration script with reasonable defaults produces a merged FASTQ that a current somatic SNV caller (Mutect2 or Strelka) calls into a VCF that scores reasonably well against the origin-tagged truth.
 
 ### Stage 2 — cancer SV credibility (shipped in v1.12.0)
-6. ✅ **#187** — `<BND>` translocations with junction reads. Chimeric-pair generation via `process_chimeric_variants` → `generate_chimeric_pair` → `get_bnd_pieces` + `get_stitched_sequence`, correctly handling the four VCF 4.2 breakend orientation forms (`t[p[`, `t]p]`, `[p[t`, `]p]t`). Paired-BND deduplication via canonical-ID HashSet.
+6. ⚠️ **#187** — `<BND>` junction reads (**not** translocations; see the retraction above). Chimeric-pair generation via `process_chimeric_variants` → `generate_chimeric_pair` → `get_bnd_pieces` + `get_stitched_sequence`, correctly handling the four VCF 4.2 breakend orientation forms (`t[p[`, `t]p]`, `[p[t`, `]p]t`). Paired-BND deduplication via canonical-ID HashSet. All of that is real and verified — but orientation is not translocation, and the de novo sampler emits only same-contig junctions.
 7. ✅ **#188** — `<INV>` inversions with strand flipping. Two-junction model (start of inversion + end of inversion), each independently sampling reads. `generate_inv_pair` + `get_inv_pieces` handle orientation flipping per junction. Smarter fragment-length sampling + graceful `TruncatedRead` handling shipped alongside, applied to BND too.
 8. ✅ **#190** — de novo `<INS>` with novel sequence. Emitted as LITERAL Insertion records (`REF="A"`, `ALT="A<novel-bases>"`) — same shape Manta / DELLY produce when they resolve the inserted sequence. Routes through the existing literal-insertion machinery. Novel sequence drawn from single-base composition of a ±250 bp window around the anchor.
 
-**Exit criterion:** a current somatic SV caller (GRIDSS or Manta) calls translocation breakpoints from the simulated data with high enough recall that the simulator could plausibly be used as a benchmark fixture. **Status:** validated — functionally against a synthetic 5 kb fixture (v1.12.0 CHANGELOG), and against real callers on Delta (Manta + Delly per-type SV recall, ACCESS report §3.7; cross-caller coverage #317, closed).
+**Exit criterion:** a current somatic SV caller (GRIDSS or Manta) calls translocation breakpoints from the simulated data with high enough recall that the simulator could plausibly be used as a benchmark fixture.
+
+**Status: ⚠️ NOT MET — previously recorded as "validated" (retracted 2026-08-01).** The
+criterion names *translocation* breakpoints, and no run could have tested it: the de novo
+sampler cannot place a mate off-contig, so no translocation was ever present in the data
+the callers were scored against. The evidence cited for "validated" measured something
+else — same-contig junction recall — and was accurate about that.
+
+What the cited evidence does support: callers recover same-contig breakend junctions at a
+measurable rate. Job 20745149 puts Manta at **0.738** over the 480 inversion-oriented
+records it can represent as breakends (the aggregate 0.380 is floored by our own SVTYPE
+choice, since direct junctions are correctly called `<DEL>`/`<DUP:TANDEM>` and cannot
+match a BND record). Delly emits no BND records at all — it types the same junctions
+`<INV>` — which is itself evidence that BND is a representation convention rather than an
+event class.
+
+Re-stating this criterion honestly requires either generating real translocations or
+narrowing the criterion to what is actually produced. That decision is deferred to the
+PCAWG measurement pass.
 
 #### Known limitations carried into v1.12.0
 - **Breakpoint double-counting — resolved in v1.14.1 (#236).** The regular per-contig pass used to also generate reads across BND / INV breakpoint positions (from the unbroken reference), leaving those loci with regular + junction reads — ~2× coverage for homozygous variants. Fixed: the regular pass now suppresses the broken-allele fraction of junction-crossing read-pairs (`collect_suppressible_junctions` / `suppress_junction_double_count`; DEL/BND/INV/CNV-loss, with DUP/CNV-gain intentionally excluded).


### PR DESCRIPTION
**P1 from the audit.** Four claims in circulation are corrected. The finding is verified directly, not inferred.

## The finding

The de novo SV sampler **cannot place a breakend mate on another contig**. `sv_model.rs:810` and `:936` both hardcode `Some(contig_name.to_string())`, and `sample_variants` (`:529-539`) receives one contig's name, length and sequence with no view of any other. Job 20719077 emitted 466 junctions and **466 of 466** were same-contig — structurally guaranteed, not chance.

## What is corrected

| # | Where | Was | Now |
|---|---|---|---|
| 1 | `cancer_simulator.md` #187 row | "**Critical** … ✅ Shipped in v1.12.0" for `<BND>` translocations | Partial — junction machinery shipped, translocations never generated |
| 2 | `cancer_simulator.md` Stage 2 exit criterion | "**Status:** validated" | ⚠️ NOT MET — the criterion names *translocation* breakpoints and no run could have tested it |
| 3 | `access_report_draft.md` §3.5 | "the misses are a *caller* limitation — translocations are the hardest short-read class" | Retracted attribution; the measured cause is our own SVTYPE choice |
| 4 | `access_report_draft.md` §3.6 | "unscored downstream since truvari does not benchmark breakends"; "a generation tendency" | Both wrong — truvari has matched breakends since v5.0.0, and the elevation is inherited from the PCAWG `TRA` rate |

Four of the five exemplars in row 1 (BCR-ABL, PML-RARA, EWSR1-FLI1, MYC-IGH) are inter-chromosomal fusions. None is reachable by the shipped generator.

## How the mislabel arose

`build_pcawg_sv_vcf.py:127-128` reads only `f[0],f[1],f[3],f[4],f[10]`, and its BND branch (`:155-159`) emits a bare `<BND>` anchor and `continue`s — discarding the mate chromosome, never reading `strand1`/`strand2`. **We inherited the count of translocations while dropping the two facts that make one a translocation.** The shipped model carries no chromosome-pair, strand or geometry field, so geometry falls back to uniform 25% per form and ~a quarter of emitted BNDs are deletion-like direct joins whose reads carry a plain deletion under a `SVTYPE=BND` label.

## A conflation worth separating

`BND` in a VCF is a **notation** for an adjacency a caller did not resolve, not an event class. Manta buckets inversion-oriented junctions as BND; Delly types the same junctions `<INV>` — observed on identical data in job 20745149. A "23.2% BND rate" partly encodes which caller and chemistry produced the source calls, not tumour biology.

## §3.7 updated with the post-geometry campaign

Jobs 20719077 / 20745149, 466 junctions against the 7 the old numbers rested on. All four forms present and indistinguishable from uniform (χ² ≈ 1.5, df = 2, p ≈ 0.47), 0 unpaired / 0 mispaired across 932 records. `manta_BND = 0.380` is floored by our own SVTYPE choice; the caller number is **BNDinv = 354/480 = 0.738**.

## What is *not* retracted

Chimeric junction reads and all four VCF 4.2 orientation forms shipped and are correct — orientation is simply not translocation. The read path already resolves off-contig mates (`runner.rs:2360`), so inter-chromosomal BND supplied via `input_vcf` works today; only the de novo sampler cannot emit one.

Germline, DEL/DUP/INV, CNV and signature sections are untouched — they rest on different machinery and are not implicated.