### PR TITLE
docs(claude.md): one archive root; record the Delta disk constraints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,15 +125,23 @@ contig lengths).
 ## Delta / HPC (`scripts/delta/`)
 - Real-data validation runs on **NCSA Delta** (SLURM, account `bhrd-delta-cpu`). The
   cluster filesystem is **not reachable from this workstation** — the user runs jobs
-  and pastes results. Artifacts archive to **two** roots — the project was renamed
-  partway through, so Phase 1 / pre-v2.0.0 runs are under
-  `/projects/bhrd/jallen17/rneat-access-results/` (germline, cancer, sv, benchmark,
-  baseline, tune, threadscale, ppn, modelbuild — the corpus behind the ACCESS report's
-  §3.1–3.11) and v2.0.0-onward runs under
-  `/projects/bhrd/jallen17/eidolon-access-results/`. `lib_report.sh` writes only to the
-  latter (`RESULTS_DIR`, overridable), and `collect_report.sh` scans one root at a time —
-  so pass `RESULTS_DIR=` explicitly when looking for historical runs, or you will
-  conclude they are missing.
+  and pastes results. Artifacts archive to **one** root:
+  `/projects/bhrd/jallen17/eidolon-access-results/`. `rneat-access-results/` no longer
+  exists — the pre-v2.0.0 runs were merged in when the project rename settled (confirmed
+  gone 2026-08-02), so **do not check for it**; a search there wastes a round trip and
+  its absence is not evidence a run is missing.
+
+- **Disk is the binding constraint on Delta, and quota views lie about it.** `df` inside a
+  project-quota'd directory reports the *quota*, not the mount: `df -h /work/nvme/bhrd`
+  showed `500G/500G/0` while `df -h /work/nvme` showed 8.5P at 56%. The `quota` table and
+  `df` also disagreed for `/scratch` (1000G vs a 500G mount). What actually stops a job is
+  the **project quota** — check it with
+  `lfs quota -h -p <projid> /work/nvme`, and read `Disk quota exceeded` literally.
+  Measured footprint for `sv_pipeline.sbatch` on GRCh38 at 30x: **~113 GB peak per
+  replicate** (normal + tumor + `cat`-merged FASTQ held together; pruning only runs at the
+  end). So `--array=1-8%2` needs ~900 GB and will die ~3 h in at the merge. Serialize with
+  `%1` and clear finished replicates down to `truvari_*/summary.json`, which is all
+  `aggregate_sv_reps.sh` reads.
 - Staging: `fetch_validation_data.sh` (references), `stage_soy.sh` (align + call a
   self-consistent ref/BAM/VCF; `FULL_GENOME=1` for the whole-genome stress vs the
   fast single-chromosome default). `model_builders.sbatch` exercises the builders.


### PR DESCRIPTION
Two corrections from today's live campaign.

## 1. `rneat-access-results/` is gone

CLAUDE.md said artifacts archive to **two** roots and told agents to pass `RESULTS_DIR=` explicitly when hunting historical runs. The pre-v2.0.0 runs were merged into `eidolon-access-results/` when the rename settled, and the old root no longer exists (confirmed 2026-08-02). The file now says **there is one root, and not to check for the other** — its absence is not evidence a run is missing.

## 2. Delta disk constraints — three failed submissions' worth

**Quota views lie about available space, in both directions:**

```
df -h /work/nvme/bhrd  ->  500G / 500G / 0      (the project QUOTA, surfaced through df)
df -h /work/nvme       ->  8.5P at 56%          (the actual mount)
```

The `quota` table also reported 1000 G for `/work/hdd` where `df` showed a 500 G mount. What actually stops a job is the **project quota** — `lfs quota -h -p <projid> /work/nvme`. And `Disk quota exceeded` means exactly that; I read it as a full filesystem and went looking for the wrong problem.

**Measured footprint**, not estimated: `sv_pipeline.sbatch` on GRCh38 at 30× peaks at **~113 GB per replicate**. Normal + tumor + the `cat`-merged FASTQ are all held at once, and `PRUNE_FASTQ` only runs at the end — so the peak is at the merge, not at the finish.

Consequence: `--array=1-8%2` needs ~900 GB and dies ~3 h in at the `cat`, which is what happened to job 20809970. Serialize with `%1` and clear finished replicates down to `truvari_*/summary.json` — the only thing `aggregate_sv_reps.sh` reads.