### PR TITLE
fix(delta): subvaf validation --mem 64G -> 96G; 64 was below the observed peak

### DIFF
--- a/scripts/delta/run_subclonal_vaf_validation.sh
+++ b/scripts/delta/run_subclonal_vaf_validation.sh
@@ -44,7 +44,14 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
-#SBATCH --mem=64G
+# 96G, sized from measurement rather than guessed. Two runs of this script:
+#   job 20553463  --mem=48G  -> OUT_OF_MEMORY, killed at 47.99 GB after 2h49m
+#   job 20556912  --mem=96G  -> COMPLETED, peak 60.33 GB (62.85% of 96)
+# The 48G failure was bumped to 64G, but 64 was a guess and sits BELOW the 60.33 GB
+# the only successful run actually consumed — under 4 GB of margin, i.e. one unlucky
+# draw from another OOM. bwa-mem2 + samtools sort on chr1 is the peak.
+# Check `seff <jobid>` before lowering this.
+#SBATCH --mem=96G
 #SBATCH --time=8:00:00
 #SBATCH --output=%x_%j.out
 #SBATCH --error=%x_%j.err


### PR DESCRIPTION
Found while reclaiming disk for the SV campaign.

## The evidence

| job | request | outcome | peak |
|---|---|---|---|
| 20553463 | `--mem=48G` | **OUT_OF_MEMORY** after 2h49m | 47.99 GB (99.98%) |
| 20556912 | `--mem=96G` | COMPLETED | **60.33 GB** (62.85%) |
| current script | `--mem=64G` | — | — |

After the OOM the request was bumped 48 → 64. But **64 GB sits below what the only successful run actually consumed once margin is counted** — 60.33 GB peak leaves under 4 GB of headroom, i.e. one unlucky draw from another OOM. 96 G is the value known to work.

`bwa-mem2` + `samtools sort` on chr1 is the peak.

## Why it went unnoticed

The 48 G OOM also left **56 GB of abandoned scratch** — merged FASTQs and a partial `samtools sort_tmp`, no BAM, no scored output — sitting from 2026-07-28 until a disk hunt today. The run produced nothing, and nothing flagged it. An OOM'd run is currently indistinguishable from a completed one without reading timestamps and noticing a missing BAM.

## Note in the file

The comment records both job IDs so the next person right-sizes from `seff` rather than guessing, which is how 64 was chosen in the first place.

## Follow-ups worth doing (not in this PR)

1. **A completion sentinel** — a `RUN_COMPLETE` marker written last would make abandoned runs findable in one command.
2. **`seff` in `archive_run`** — capturing peak RSS and CPU efficiency alongside the existing provenance would make right-sizing a lookup instead of a guess. Today's `--mem` question took three wrong estimates before landing on measurement.