### PR TITLE
fix(delta): calibration controls that did not run must fail, and empty SV strata must be reported

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,16 @@ contig lengths).
   gone 2026-08-02), so **do not check for it**; a search there wastes a round trip and
   its absence is not evidence a run is missing.
 
+- **The Delta checkout is a separate working copy and goes stale silently.** A queued job
+  runs the script as it was when the job *started*, which on a busy queue can be days after
+  it was submitted — so a result can predate a fix you believe is in it. Establish the SHA
+  **before** interpreting any number:
+  `cd /projects/bhrd/jallen17/eidolon && git log -1 --format='%h %ci' -- <script>`, then
+  `git merge-base --is-ancestor <sha> origin/develop`. Job 20853511 was diagnosed for two
+  findings before the checkout turned out to be three days behind (`6e4c288`, predating
+  #508), which invalidated the run regardless. Ask for the SHA in the same round trip as
+  the results, not after.
+
 - **Disk is the binding constraint on Delta, and quota views lie about it.** `df` inside a
   project-quota'd directory reports the *quota*, not the mount: `df -h /work/nvme/bhrd`
   showed `500G/500G/0` while `df -h /work/nvme` showed 8.5P at 56%. The `quota` table and

--- a/docs/claude_engineering_audit.md
+++ b/docs/claude_engineering_audit.md
@@ -292,6 +292,41 @@ Harness-level instances follow the same pattern: a metric reported without check
 covered its own inputs. `VERDICT: PASS` over 160 silently-excluded sites; `nsom -gt 0`
 passing while every value was the malformed string `AF=AF=0.3000`.
 
+**The negative control that passed by not running (job 20853511, 2026-08-05).** The worst
+instance of this class so far, because the thing that failed silently was the check whose
+entire job is to catch silent failure. `decoy_truvari` in `sv_pipeline.sbatch` scores the
+truth against a deliberately displaced copy of itself; recall must be 0, and it is the only
+evidence that a reported recall means *detection* rather than a matching window loose enough
+to accept anything. Three defects compounded:
+
+```bash
+truvari bench … >/dev/null 2>&1 || true        # 1. every diagnostic discarded
+local r=0                                       # 2. absent measurement == measured zero
+[[ -f "$out/summary.json" ]] && r=$(… recall)
+if awk -v r="$r" 'BEGIN{exit !(r < 0.001)}'; then
+    echo "  decoy    $label: PASS (shifted truth recall=$r, expected 0)"
+else
+    echo "  WARNING: …" >&2                     # 3. never a failure, only a warning
+fi
+return 0                                        #    and the call sites ignored the status
+```
+
+A truvari that crashed left `r=0`, which satisfies `r < 0.001`, so the function *printed a
+PASS citing a recall it had never measured* and returned 0. The identical `local r=0` idiom
+in `selftest_truvari` fails safe purely because its comparison runs the other way
+(`r > 0.999`) — the same bug, invisible, in the control next door.
+
+Note the shape: this was not found by the control failing. It was found by its output being
+*absent* from a run log, and the run still reporting `complete`. A control that cannot
+distinguish "0" from "never ran" is indistinguishable from no control, but it is worse,
+because it is affirmatively reported as evidence that calibration happened.
+
+Fixed by routing both controls through a `truvari_metric` helper that returns non-zero for a
+missing or unparseable summary, making a decoy match *and* a decoy that did not run set
+`CAL_FAIL` like the selftest does, and keeping truvari's stderr. Covered by
+`scripts/delta/tests/test_scorer_calibration.sh` (31 assertions, 5 mutations, 0 survivors);
+the first mutation restores the `local r=0` default exactly and the suite catches it.
+
 ### 5.4 Confident wrong causal explanation
 
 `BND recall = 0.000` received three sequential confident explanations — unpaired truth,

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -901,6 +901,26 @@ build_bnd_spans() {  # <bnd_truth.vcf.gz> <out.vcf.gz>
     return 0
 }
 
+# Read one numeric metric out of a truvari summary.json. Prints the value and returns 0;
+# returns 1 if the summary is MISSING or unparseable.
+#
+# WHY THE DISTINCTION IS THE WHOLE POINT: both calibration controls used to open with
+# `local r=0` and then overwrite it only `[[ -f "$out/summary.json" ]]`. A truvari that
+# crashed therefore left r=0, which the selftest reads as "recall 0 → FAIL" (safe) but the
+# decoy reads as "recall 0 → PASS" — a negative control that passes *because it never ran*.
+# `truvari … >/dev/null 2>&1 || true` then discarded the only evidence of why.
+# Job 20853511 printed no decoy verdict at all with an empty truvari_decoy_scoreable/,
+# which is what sent us looking. An absent measurement must never be spellable as a
+# passing one; that is the same "assert content, not existence" rule as everywhere else.
+truvari_metric() {  # <summary.json> <key>
+    [[ -f "$1" ]] || return 1
+    python3 - "$1" "$2" <<'PY' || return 1
+import json, sys
+v = json.load(open(sys.argv[1])).get(sys.argv[2])
+print(float(v) if v is not None else 0.0)
+PY
+}
+
 # ── Rule 0: calibrate the scorer before believing it ────────────────────
 # A scorer must reproduce a PERFECT score against itself in the configuration the real
 # run uses. If truth-vs-truth is not 1.000, the configuration is broken and nothing it
@@ -911,11 +931,19 @@ build_bnd_spans() {  # <bnd_truth.vcf.gz> <out.vcf.gz>
 selftest_truvari() {  # <truth.vcf.gz> <label> [extra args...]
     local truth="$1" label="$2"; shift 2
     local out="$OUTDIR/truvari_selftest_$label"
+    local err="$OUTDIR/.selftest_${label}.stderr"
     rm -rf "$out"
     truvari bench -b "$truth" -c "$truth" -f "$REFERENCE" -o "$out" \
-        --passonly --sizemax "$TRUVARI_SIZEMAX" "$@" >/dev/null 2>&1 || true
-    local r=0
-    [[ -f "$out/summary.json" ]] && r=$(python3 -c "import json,sys;print(json.load(open('$out/summary.json')).get('recall') or 0)")
+        --passonly --sizemax "$TRUVARI_SIZEMAX" "$@" >"$err" 2>&1 || true
+    # "Did not run" is reported separately from "ran and scored 0". Both fail, but only
+    # one of them is a scoring-threshold problem, and conflating them cost a day.
+    local r
+    if ! r=$(truvari_metric "$out/summary.json" recall); then
+        echo "ERROR: scorer selftest for $label DID NOT RUN — no readable" >&2
+        echo "  $out/summary.json. truvari's own output follows:" >&2
+        sed -n '1,20p' "$err" >&2 2>/dev/null || true
+        return 1
+    fi
     if awk -v r="$r" 'BEGIN{exit !(r > 0.999)}'; then
         # recall=1.000 is necessary but NOT sufficient: a filter that discards a record
         # removes it from base AND comp alike, so the subset still matches itself
@@ -962,19 +990,28 @@ decoy_truvari() {  # <truth.vcf.gz> <label> [extra args...]
       | bcftools sort -O z -o "$decoy" 2>/dev/null || { echo "  decoy $label: could not build (skipped)"; return 0; }
     bcftools index -f -t "$decoy" 2>/dev/null || true
     rm -rf "$out"
+    local err="$OUTDIR/.decoy_${label}.stderr"
     truvari bench -b "$truth" -c "$decoy" -f "$REFERENCE" -o "$out" \
-        --passonly --sizemax "$TRUVARI_SIZEMAX" "$@" >/dev/null 2>&1 || true
-    local r=0
-    [[ -f "$out/summary.json" ]] && r=$(python3 -c "import json,sys;print(json.load(open('$out/summary.json')).get('recall') or 0)")
+        --passonly --sizemax "$TRUVARI_SIZEMAX" "$@" >"$err" 2>&1 || true
+    local r
+    if ! r=$(truvari_metric "$out/summary.json" recall); then
+        echo "ERROR: decoy control for $label DID NOT RUN — no readable" >&2
+        echo "  $out/summary.json. This is NOT a pass: the decoy is the only evidence that" >&2
+        echo "  a recall figure means detection rather than a matching window loose enough" >&2
+        echo "  to accept anything, so every number from this run would be uncalibrated." >&2
+        echo "  truvari's own output follows:" >&2
+        sed -n '1,20p' "$err" >&2 2>/dev/null || true
+        return 1
+    fi
     if awk -v r="$r" 'BEGIN{exit !(r < 0.001)}'; then
         echo "  decoy    $label: PASS (shifted truth recall=$r, expected 0)"
-    else
-        echo "  WARNING: decoy control for $label matched (recall=$r). Displacement now" >&2
-        echo "  scales with SVLEN, so this is no longer explained by an undersized shift —" >&2
-        echo "  the scorer is matching on position more loosely than intended, or records" >&2
-        echo "  ran off the end of their contig. Inspect $out/tp-base.vcf.gz." >&2
+        return 0
     fi
-    return 0
+    echo "ERROR: decoy control for $label matched (recall=$r). Displacement scales with" >&2
+    echo "  SVLEN, so this is not an undersized shift — the scorer is matching on position" >&2
+    echo "  more loosely than intended, or records ran off the end of their contig." >&2
+    echo "  Inspect $out/tp-base.vcf.gz." >&2
+    return 1
 }
 
 # Score one caller's VCF against the truth — aggregate + per-type + BND (#457).
@@ -1164,7 +1201,7 @@ fi
 echo "[5/5] Calibrating scorers (truth-vs-truth must be perfect; decoy must be zero)..."
 if [[ -f "$TRUTH_SCOREABLE" ]]; then
     selftest_truvari "$TRUTH_SCOREABLE" scoreable || CAL_FAIL=1
-    decoy_truvari    "$TRUTH_SCOREABLE" scoreable
+    decoy_truvari    "$TRUTH_SCOREABLE" scoreable || CAL_FAIL=1
 fi
 if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
     selftest_truvari "$OUTDIR/truth_sv_BND.vcf.gz" BND --bnddist "$BND_DIST" || CAL_FAIL=1
@@ -1173,7 +1210,7 @@ if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
     # proximity window; without a decoy nothing measures how often a *displaced*
     # breakend still lands inside it. Cheap, and this is exactly where the decoy works
     # best: a breakend is a point (END==POS), so any shift displaces it fully.
-    decoy_truvari    "$OUTDIR/truth_sv_BND.vcf.gz" BND --bnddist "$BND_DIST"
+    decoy_truvari    "$OUTDIR/truth_sv_BND.vcf.gz" BND --bnddist "$BND_DIST" || CAL_FAIL=1
 fi
 if [[ -f "$OUTDIR/truth_sv_BNDspan.vcf.gz" ]]; then
     selftest_truvari "$OUTDIR/truth_sv_BNDspan.vcf.gz" BNDspan -t || CAL_FAIL=1
@@ -1197,10 +1234,12 @@ fi
 # archiving precisely BECAUSE the scorer misbehaved, and the exit below runs after
 # archive_run. Scoring itself is pointless with a scorer that cannot score a known answer.
 if [[ "$CAL_FAIL" -ne 0 ]]; then
-    echo "ERROR: at least one scorer cannot match the truth to itself — refusing to" >&2
-    echo "  report caller results computed with a configuration that demonstrably" >&2
-    echo "  cannot score a perfect answer. Skipping caller scoring; see the selftest" >&2
-    echo "  output above and the archived truvari_selftest_* directories." >&2
+    echo "ERROR: at least one scorer failed calibration — either it cannot match the" >&2
+    echo "  truth to itself (positive control) or it matched a deliberately displaced" >&2
+    echo "  copy of it (negative control), and a control that DID NOT RUN counts as a" >&2
+    echo "  failure, not a pass. Refusing to report caller results from a configuration" >&2
+    echo "  not demonstrated to discriminate. Skipping caller scoring; see the output" >&2
+    echo "  above and the archived truvari_selftest_*/truvari_decoy_* directories." >&2
 else
     score_caller manta "$MANTA_SV" "$MANTA_SV_RAW"
     # Delly emits no BND at all and is not converted, so raw and scored are the same file.

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -279,7 +279,8 @@ fi
 
 # Pre-generate per-type truth subsets NOW, while bcftools (bioinf) is active, so
 # the truvari scoring stage needs only truvari on its PATH (no bcftools in that
-# env). Empty types are removed so the scoring loop skips them.
+# env). Empty types are removed so the scoring loop skips them — and RECORDED, because a
+# skipped type is an unmeasured stratum that has to be reported rather than dropped.
 # The canonical SVTYPE list, declared ONCE. The scoring loop iterates this same array
 # rather than globbing truth_sv_*.vcf.gz, so a derived artifact can never be mistaken
 # for an SVTYPE — see SV_TYPES_SCORED_IN_LOOP below.
@@ -292,14 +293,47 @@ for svt in "${SV_TYPES[@]}"; do
     case "$svt" in BND|CNV) continue ;; esac
     SV_TYPES_SCORED_IN_LOOP+=("$svt")
 done
-for svt in "${SV_TYPES[@]}"; do
-    typed="$OUTDIR/truth_sv_${svt}.vcf.gz"
-    bcftools view -i "INFO/SVTYPE=\"$svt\"" -O z -o "$typed" "$TRUTH_SV" 2>/dev/null || continue
-    bcftools index -f -t "$typed" 2>/dev/null || true
-    n=$(bcftools view -H "$typed" 2>/dev/null | wc -l)
-    echo "  truth $svt: $n"
-    [[ "$n" -eq 0 ]] && rm -f "$typed" "${typed}.tbi"
-done
+# A type the model ASKS FOR but that no record realises is an UNMEASURED STRATUM, not a
+# result. The zero-count file is deleted here and the scoring loop then skips it on
+# `[[ -f "$typed" ]] || continue`, so before this change the run printed a bare
+# `truth INS: 0` and never mentioned INS again — and the aggregate recall silently meant
+# "of the types we happened to draw". Job 20853511 reported manta_overall=0.861 over
+# DEL/DUP/INV only, with INS absent from 123 records.
+#
+# NOT a hard failure, deliberately: the pancancer model draws Ins at p=0.0279, so ~6% of
+# runs legitimately plant none and failing those would be a false alarm. What is not
+# acceptable is the silence, so the stratum is named here and again in the summary. Chasing
+# a real generation defect needs replicates, not one run — see docs/sv_support_matrix.md,
+# which records symbolic <INS> as a silent no-op from input_vcf (#500) while asserting the
+# de novo path synthesises sequence. That claim is untested and this is the run that would
+# have surfaced it.
+# Sets TYPES_UNMEASURED (global) to every SV_TYPES entry with zero truth records. A
+# function rather than an inline loop so it is reachable from the test suite: the
+# behaviour that matters is "an empty stratum is named", and asserting that by grepping
+# the source would only check that the code looks right.
+split_truth_by_type() {  # <truth_sv.vcf.gz> <outdir>
+    local truth="$1" dir="$2" svt typed n
+    TYPES_UNMEASURED=()
+    for svt in "${SV_TYPES[@]}"; do
+        typed="$dir/truth_sv_${svt}.vcf.gz"
+        bcftools view -i "INFO/SVTYPE=\"$svt\"" -O z -o "$typed" "$truth" 2>/dev/null || continue
+        bcftools index -f -t "$typed" 2>/dev/null || true
+        n=$(bcftools view -H "$typed" 2>/dev/null | wc -l)
+        echo "  truth $svt: $n"
+        if [[ "$n" -eq 0 ]]; then
+            rm -f "$typed" "${typed}.tbi"
+            TYPES_UNMEASURED+=("$svt")
+            echo "    NOT MEASURED: 0 $svt planted, so no $svt recall exists for any caller." >&2
+            echo "      This is a hole in the run's coverage, not a passing stratum." >&2
+        fi
+    done
+    if [[ "${#TYPES_UNMEASURED[@]}" -gt 0 ]]; then
+        echo "  SV types with an EMPTY denominator: ${TYPES_UNMEASURED[*]} (${#TYPES_UNMEASURED[@]} of ${#SV_TYPES[@]})"
+        echo "    Every recall below is over the remaining types only."
+    fi
+}
+TYPES_UNMEASURED=()
+split_truth_by_type "$TRUTH_SV" "$OUTDIR"
 
 # The aggregate must cover only what truvari can match. A BND has no SVLEN and
 # END==POS, and CNV is a copy-ratio call — truvari matches neither, so including
@@ -1284,6 +1318,20 @@ the other misses (especially BND) = a caller limitation, not a simulator defect.
 Low overall with high per-type recall = truvari SVTYPE/SVLEN representation
 mismatch (inspect the pre-flight schema dump).
 EOF
+
+# Repeated here on purpose. Stage 3b prints this ~900 lines earlier in the log, and the
+# banner above is what actually gets read and pasted — an empty denominator that only
+# appears upstream is an empty denominator nobody sees.
+if [[ "${#TYPES_UNMEASURED[@]}" -gt 0 ]]; then
+    cat <<EOF
+COVERAGE HOLE: ${#TYPES_UNMEASURED[@]} of ${#SV_TYPES[@]} SV type(s) had NO truth records and were
+not measured at all: ${TYPES_UNMEASURED[*]}
+  Every recall above is over the remaining types. There is no caller result for these,
+  neither pass nor fail. If a type here is one the model requests with p>0, replicate
+  before concluding anything: the draw is stochastic, and a single empty stratum is
+  weak evidence either way.
+EOF
+fi
 
 # Reclaim scratch once scoring is done: FASTQ is the bulk (~GBs/run at 60x) and
 # isn't needed afterward — BAMs, Manta calls, the truth VCFs, and the truvari

--- a/scripts/delta/tests/test_scorer_calibration.sh
+++ b/scripts/delta/tests/test_scorer_calibration.sh
@@ -60,6 +60,10 @@ decoy always passes@if awk -v r="$r" 'BEGIN{exit !(r < 0.001)}'; then@if true; t
 decoy tolerates a control that did not run@    if ! r=$(truvari_metric "$out/summary.json" recall); then\n        echo "ERROR: decoy control for $label DID NOT RUN@    if ! r=$(truvari_metric "$out/summary.json" recall); then\n        r=0; if false; then echo "ERROR: decoy control for $label DID NOT RUN
 selftest tolerates a control that did not run@    if ! r=$(truvari_metric "$out/summary.json" recall); then\n        echo "ERROR: scorer selftest for $label DID NOT RUN@    if ! r=$(truvari_metric "$out/summary.json" recall); then\n        r=1.0; if false; then echo "ERROR: scorer selftest for $label DID NOT RUN
 decoy match is only a warning@echo "ERROR: decoy control for $label matched@return 0; echo "ERROR: decoy control for $label matched
+empty stratum silently dropped (pre-fix)@TYPES_UNMEASURED+=("$svt")@:
+coverage-hole summary never printed@echo "  SV types with an EMPTY denominator@echo "  suppressed
+empty stratum reported for every type@if [[ "$n" -eq 0 ]]; then@if [[ "$n" -ge 0 ]]; then
+empty type leaves a stray truth file@rm -f "$typed" "${typed}.tbi"@:
 MUTATIONS
     printf '\n──────── %d mutation(s) survived ────────\n' "$survived"
     [[ "$survived" -eq 0 ]]
@@ -88,7 +92,7 @@ fi
 
 # ── Load the functions under test, verbatim ────────────────────────────────────
 extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
-for fn in truvari_metric selftest_truvari decoy_truvari check_denominator; do
+for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type; do
     src="$(extract "$fn")"
     [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
     eval "$src"
@@ -229,6 +233,45 @@ STUB_MODE=json; STUB_RECALL=1.0; STUB_TPBASE=3; STUB_FN=0
 outp="$(selftest_truvari "$TRUTH" st_subset 2>&1)"; rc=$?
 is  "selftest(perfect over 3 of 4) returns non-zero" 1 "$rc"
 has "selftest(subset) names the wrong denominator"   "$outp" "WRONG DENOMINATOR"
+
+echo "── split_truth_by_type: an empty stratum is named, not dropped ──"
+# The known answer is hand-counted from build_truth: DEL 1, DUP 2, INV 1, and INS/BND/CNV
+# absent entirely. So exactly INS BND CNV must be reported unmeasured, in SV_TYPES order.
+SV_TYPES=(DEL DUP INV INS BND CNV)
+TYPES_UNMEASURED=()
+mkdir -p "$WORK/split"
+# NOT in $( ): the function sets a global, and a command substitution runs it in a subshell
+# where that assignment is discarded — which made this assertion pass vacuously at first.
+split_truth_by_type "$TRUTH" "$WORK/split" >"$WORK/split.log" 2>&1
+outp="$(cat "$WORK/split.log")"
+is  "planted types are counted"            "1" "$(grep -cF 'truth DEL: 1' <<<"$outp")"
+is  "a type with 2 records counts 2"       "1" "$(grep -cF 'truth DUP: 2' <<<"$outp")"
+is  "empty strata are exactly INS BND CNV" "INS BND CNV" "${TYPES_UNMEASURED[*]}"
+has "an empty stratum is called out"       "$outp" "NOT MEASURED: 0 INS planted"
+has "it is not framed as a pass"           "$outp" "not a passing stratum"
+has "the count of holes is reported"       "$outp" "EMPTY denominator: INS BND CNV (3 of 6)"
+# A zero-count type must leave NO file behind: the scoring loop skips on `[[ -f ]]`, and a
+# stray empty file would make it run truvari against an empty truth instead.
+is "no file is left for an empty type" "0" \
+   "$(ls "$WORK/split"/truth_sv_INS.vcf.gz 2>/dev/null | wc -l)"
+is "files remain for planted types"    "1" \
+   "$(ls "$WORK/split"/truth_sv_DEL.vcf.gz 2>/dev/null | wc -l)"
+
+echo "── split_truth_by_type: must NOT fire when every type is planted ──"
+# The negative case. Most defects in this repo were things firing when they should not.
+{ bcftools view -h "$TRUTH"
+  printf 'c1\t70000\t.\tG\t<INS>\t60\tPASS\tSVTYPE=INS;SVLEN=300;END=70000\n'
+  printf 'c1\t80000\t.\tG\t<CNV>\t60\tPASS\tSVTYPE=CNV;SVLEN=5000;END=85000\n'
+  printf 'c1\t90000\t.\tN\tN[c1:95000[\t60\tPASS\tSVTYPE=BND\n'
+  bcftools view -H "$TRUTH"; } > "$WORK/full.vcf"
+bcftools sort -O z -o "$WORK/full.vcf.gz" "$WORK/full.vcf" 2>/dev/null
+bcftools index -f -t "$WORK/full.vcf.gz"
+TYPES_UNMEASURED=(); mkdir -p "$WORK/split_full"
+split_truth_by_type "$WORK/full.vcf.gz" "$WORK/split_full" >"$WORK/split_full.log" 2>&1
+outp="$(cat "$WORK/split_full.log")"
+is    "no type reported unmeasured"        "" "${TYPES_UNMEASURED[*]}"
+hasnt "no NOT MEASURED line is emitted"    "$outp" "NOT MEASURED"
+hasnt "no coverage-hole summary is emitted" "$outp" "EMPTY denominator"
 
 printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/delta/tests/test_scorer_calibration.sh
+++ b/scripts/delta/tests/test_scorer_calibration.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Automated tests for the scorer CALIBRATION controls in sv_pipeline.sbatch:
+# truvari_metric, selftest_truvari (positive control) and decoy_truvari (negative control).
+#
+# WHY THIS FILE EXISTS: the decoy is the only thing in the pipeline that distinguishes
+# "the caller found the variant" from "the matching window is loose enough to accept
+# anything". It was also the one control that could not fail a run — it always returned 0,
+# its call sites ignored the status, and a MISSING summary.json was indistinguishable from
+# a legitimate recall of 0, so a truvari that crashed printed
+#   decoy    scoreable: PASS (shifted truth recall=0, expected 0)
+# A negative control that passes because it never ran is worse than no control, because it
+# is affirmatively reported as evidence. Job 20853511 is the case history: it archived an
+# empty truvari_decoy_scoreable/ and emitted no decoy verdict at all.
+#
+# The functions are EXTRACTED VERBATIM from sv_pipeline.sbatch rather than copied here,
+# for the same reason test_bnd_geometry.sh does it: a copy drifts, and then this file tests
+# something that is not what runs on Delta.
+#
+# truvari is NOT installed on a workstation and is not needed: it is STUBBED, which is the
+# only way to exercise the paths that matter — a crash that writes no summary, and a decoy
+# that matches. Those cannot be provoked reliably from a real truvari. bcftools IS used, so
+# the decoy VCF is really built and really sorted.
+#
+# Usage:
+#   scripts/delta/tests/test_scorer_calibration.sh            # run the suite
+#   scripts/delta/tests/test_scorer_calibration.sh --mutate   # prove the suite is non-vacuous
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PIPELINE="${PIPELINE:-$HERE/../sv_pipeline.sbatch}"   # overridden by --mutate
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── Mutation driver ────────────────────────────────────────────────────────────
+# Each entry breaks the production code in a plausible way and names the assertion that
+# must catch it. A mutation that SURVIVES means that assertion is not testing what it
+# claims. `\n` in an anchor is expanded to a real newline, so an anchor can span lines —
+# needed because `if ! r=$(truvari_metric ...)` appears in BOTH controls and only the
+# surrounding lines tell them apart.
+if [[ "${1:-}" == "--mutate" ]]; then
+    survived=0
+    while IFS='@' read -r label from to; do
+        [[ -n "$label" ]] || continue
+        cp "$PIPELINE" "$WORK/mutant.sbatch"
+        FROM="$(printf '%b' "$from")" TO="$(printf '%b' "$to")" \
+            perl -0pi -e 's/\Q$ENV{FROM}\E/$ENV{TO}/' "$WORK/mutant.sbatch"
+        if cmp -s "$PIPELINE" "$WORK/mutant.sbatch"; then
+            printf '  ERROR   %-46s mutation did not apply — anchor not found\n' "$label"
+            survived=$((survived+1)); continue
+        fi
+        if PIPELINE="$WORK/mutant.sbatch" bash "$0" >/dev/null 2>&1; then
+            printf '  SURVIVED %-45s <- nothing caught this\n' "$label"
+            survived=$((survived+1))
+        else
+            printf '  caught   %s\n' "$label"
+        fi
+    done <<'MUTATIONS'
+absent summary silently reads as 0@[[ -f "$1" ]] || return 1@[[ -f "$1" ]] || { echo 0; return 0; }
+decoy always passes@if awk -v r="$r" 'BEGIN{exit !(r < 0.001)}'; then@if true; then
+decoy tolerates a control that did not run@    if ! r=$(truvari_metric "$out/summary.json" recall); then\n        echo "ERROR: decoy control for $label DID NOT RUN@    if ! r=$(truvari_metric "$out/summary.json" recall); then\n        r=0; if false; then echo "ERROR: decoy control for $label DID NOT RUN
+selftest tolerates a control that did not run@    if ! r=$(truvari_metric "$out/summary.json" recall); then\n        echo "ERROR: scorer selftest for $label DID NOT RUN@    if ! r=$(truvari_metric "$out/summary.json" recall); then\n        r=1.0; if false; then echo "ERROR: scorer selftest for $label DID NOT RUN
+decoy match is only a warning@echo "ERROR: decoy control for $label matched@return 0; echo "ERROR: decoy control for $label matched
+MUTATIONS
+    printf '\n──────── %d mutation(s) survived ────────\n' "$survived"
+    [[ "$survived" -eq 0 ]]
+    exit $?
+fi
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL  %s\n     expected: %s\n     actual:   %s\n' "$1" "$2" "$3"; }
+is()   { [[ "$2" == "$3" ]] && ok "$1" || bad "$1" "$2" "$3"; }
+has()  { case "$2" in *"$3"*) ok "$1";; *) bad "$1" "contains: $3" "$2";; esac; }
+hasnt(){ case "$2" in *"$3"*) bad "$1" "must NOT contain: $3" "$2";; *) ok "$1";; esac; }
+
+# Skipping is a convenience for a workstation without bcftools, never for CI — exiting 0
+# here would turn "tested nothing" into a green check, the false-pass shape this suite
+# exists to prevent.
+if ! command -v bcftools >/dev/null; then
+    if [[ -n "${CI:-}" ]]; then
+        echo "FATAL: bcftools is not on PATH and CI is set. Refusing to report success" >&2
+        echo "  for a suite that would run zero assertions." >&2
+        exit 2
+    fi
+    echo "SKIP: bcftools not on PATH (set CI=1 to make this fatal)"
+    exit 0
+fi
+
+# ── Load the functions under test, verbatim ────────────────────────────────────
+extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
+for fn in truvari_metric selftest_truvari decoy_truvari check_denominator; do
+    src="$(extract "$fn")"
+    [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
+    eval "$src"
+done
+
+OUTDIR="$WORK"
+REFERENCE="$WORK/ref.fa"       # only ever handed to the stub
+TRUVARI_SIZEMAX=100000000
+BND_DIST=500
+: > "$REFERENCE"
+
+# ── The truvari stub ───────────────────────────────────────────────────────────
+# Behaviour is driven by $STUB_MODE so a single stub covers every path:
+#   crash   -> exits non-zero and writes NO summary.json  (the regression under test)
+#   empty   -> creates the output dir but no summary.json  (what job 20853511 archived)
+#   json    -> writes summary.json from $STUB_RECALL / $STUB_TPBASE / $STUB_FN
+truvari() {
+    local out="" prev=""
+    for a in "$@"; do [[ "$prev" == "-o" ]] && out="$a"; prev="$a"; done
+    case "$STUB_MODE" in
+        crash) echo "truvari: simulated failure" >&2; return 2 ;;
+        empty) mkdir -p "$out"; echo "truvari: simulated failure" >&2; return 2 ;;
+        json)
+            mkdir -p "$out"
+            printf '{"recall": %s, "precision": 1.0, "f1": 1.0, "TP-base": %s, "FN": %s, "FP": 0}\n' \
+                "$STUB_RECALL" "${STUB_TPBASE:-0}" "${STUB_FN:-0}" > "$out/summary.json"
+            return 0 ;;
+    esac
+}
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+# A 4-record truth whose answers are hand-countable: 4 records, so a selftest that scores
+# all of them has TP-base=4, FN=0, and check_denominator must agree.
+#
+# Three records are SMALLER than the 2 Mb displacement floor and one is much larger — that
+# split is deliberate, because the shift has two branches and #508 only added the second.
+# The 6,111,196 bp DUP is the real one from job 20853511 (chr1:51454985-57566181), the size
+# class that defeated the old flat 2 Mb shift by still overlapping itself ~67%.
+build_truth() {
+    { printf '##fileformat=VCFv4.2\n##contig=<ID=c1,length=100000000>\n'
+      printf '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="t">\n'
+      printf '##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="l">\n'
+      printf '##INFO=<ID=END,Number=1,Type=Integer,Description="e">\n'
+      printf '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n'
+      printf 'c1\t1000\t.\tG\t<DEL>\t60\tPASS\tSVTYPE=DEL;SVLEN=-500;END=1500\n'
+      printf 'c1\t20000\t.\tG\t<DUP>\t60\tPASS\tSVTYPE=DUP;SVLEN=3000;END=23000\n'
+      printf 'c1\t50000\t.\tG\t<INV>\t60\tPASS\tSVTYPE=INV;SVLEN=800;END=50800\n'
+      printf 'c1\t51454985\t.\tG\t<DUP>\t60\tPASS\tSVTYPE=DUP;SVLEN=6111196;END=57566181\n'
+    } > "$WORK/truth.vcf"
+    bgzip -f -c "$WORK/truth.vcf" > "$WORK/truth.vcf.gz"
+    bcftools index -f -t "$WORK/truth.vcf.gz"
+}
+build_truth
+TRUTH="$WORK/truth.vcf.gz"
+
+echo "── truvari_metric: an absent measurement is not a zero ──"
+rm -f "$WORK/none.json"
+out="$(truvari_metric "$WORK/none.json" recall)"; rc=$?
+is "missing summary.json returns non-zero" 1 "$rc"
+is "missing summary.json prints nothing"    "" "$out"
+
+printf '{"recall": 0.25}\n' > "$WORK/s.json"
+out="$(truvari_metric "$WORK/s.json" recall)"; rc=$?
+is "present summary returns 0"        0 "$rc"
+is "present summary prints the value" 0.25 "$out"
+
+# truvari writes null (not 0) for a metric with no comparisons; that IS a real measured
+# zero and must be readable, which is exactly why absence needs a different channel.
+printf '{"recall": null}\n' > "$WORK/null.json"
+out="$(truvari_metric "$WORK/null.json" recall)"; rc=$?
+is "null metric returns 0"       0 "$rc"
+is "null metric reads as 0.0"    0.0 "$out"
+
+printf 'not json at all' > "$WORK/bad.json"
+truvari_metric "$WORK/bad.json" recall >/dev/null 2>&1; rc=$?
+is "unparseable summary returns non-zero" 1 "$rc"
+
+echo "── decoy_truvari: THE REGRESSION — a control that did not run must FAIL ──"
+for mode in crash empty; do
+    STUB_MODE="$mode"; STUB_RECALL=0
+    outp="$(decoy_truvari "$TRUTH" "dc_$mode" 2>&1)"; rc=$?
+    is  "decoy($mode) returns non-zero"      1 "$rc"
+    hasnt "decoy($mode) does not claim PASS"  "$outp" "PASS"
+    has "decoy($mode) says it did not run"   "$outp" "DID NOT RUN"
+    has "decoy($mode) surfaces truvari stderr" "$outp" "simulated failure"
+done
+
+echo "── decoy_truvari: a real measured zero still passes ──"
+STUB_MODE=json; STUB_RECALL=0.0
+outp="$(decoy_truvari "$TRUTH" dc_zero 2>&1)"; rc=$?
+is  "decoy(recall=0) returns 0"    0 "$rc"
+has "decoy(recall=0) reports PASS" "$outp" "PASS"
+
+echo "── decoy_truvari: a matching decoy is a failure, not a warning ──"
+# 0.202 is the real figure from job 20824321's flat-shift decoy.
+STUB_MODE=json; STUB_RECALL=0.202
+outp="$(decoy_truvari "$TRUTH" dc_match 2>&1)"; rc=$?
+is   "decoy(recall=0.202) returns non-zero" 1 "$rc"
+hasnt "decoy(recall=0.202) does not say PASS" "$outp" "PASS"
+has  "decoy(recall=0.202) reports the value"  "$outp" "0.202"
+
+echo "── decoy displacement exceeds the event (#508), and END travels with POS ──"
+STUB_MODE=json; STUB_RECALL=0.0
+decoy_truvari "$TRUTH" geom >/dev/null 2>&1
+DECOY="$WORK/.decoy_geom.vcf.gz"
+q() { bcftools query -f '%POS\t%INFO/END\n' "$DECOY" 2>/dev/null | awk -F'\t' -v p="$1" '$1==p'; }
+
+# Branch 1, the 2 Mb FLOOR. The 3000 bp DUP at POS=20000 is far smaller than the floor, so
+# it moves by 2000000, not by 2*3000: POS 2020000, END 23000+2000000=2023000.
+is "small DUP moves by the 2Mb floor, END carried" "2020000	2023000" "$(q 2020000)"
+
+# Branch 2, the SVLEN SCALING that #508 added, and the branch the old flat shift got wrong.
+# 6111196 bp DUP: 2*6111196 = 12222392 exceeds the floor, so POS 51454985+12222392=63677377
+# and END 57566181+12222392=69788573. Under the old flat 2 Mb shift this record would have
+# moved to 53454985 while keeping END=57566181 — still 67% self-overlapping, hence matched.
+is "large DUP moves by 2x SVLEN, END carried" "63677377	69788573" "$(q 63677377)"
+
+neg="$(bcftools query -f '%POS\t%INFO/END\n' "$DECOY" 2>/dev/null | awk -F'\t' '$2 < $1' | wc -l)"
+is "no decoy record has END before POS" 0 "$neg"
+n_decoy="$(bcftools view -H "$DECOY" 2>/dev/null | wc -l)"
+is "every truth record is represented in the decoy" 4 "$n_decoy"
+
+echo "── selftest_truvari: did-not-run is distinguished from scored-zero ──"
+STUB_MODE=crash; STUB_RECALL=0
+outp="$(selftest_truvari "$TRUTH" st_crash 2>&1)"; rc=$?
+is  "selftest(crash) returns non-zero"       1 "$rc"
+has "selftest(crash) says it did not run"    "$outp" "DID NOT RUN"
+hasnt "selftest(crash) does not claim PASS"  "$outp" "PASS"
+
+STUB_MODE=json; STUB_RECALL=1.0; STUB_TPBASE=4; STUB_FN=0
+outp="$(selftest_truvari "$TRUTH" st_ok 2>&1)"; rc=$?
+is  "selftest(perfect, full denominator) returns 0" 0 "$rc"
+has "selftest(perfect) reports PASS"                "$outp" "PASS"
+
+# recall=1.000 over a SUBSET must still fail: a filter drops a record from base and comp
+# alike, so the subset matches itself perfectly. Only check_denominator sees it.
+STUB_MODE=json; STUB_RECALL=1.0; STUB_TPBASE=3; STUB_FN=0
+outp="$(selftest_truvari "$TRUTH" st_subset 2>&1)"; rc=$?
+is  "selftest(perfect over 3 of 4) returns non-zero" 1 "$rc"
+has "selftest(subset) names the wrong denominator"   "$outp" "WRONG DENOMINATOR"
+
+printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What this fixes

Two silent-coverage defects found while diagnosing SV validation job 20853511. Neither
changes a caller result; both change what the harness is *able to tell you*.

### 1. The negative control passed by not running

`decoy_truvari` scores the truth against a deliberately displaced copy of itself. Recall
must be 0, and it is the pipeline's only evidence that a reported recall means *detection*
rather than a matching window loose enough to accept anything. Three defects compounded:

- `local r=0` followed by `[[ -f "$out/summary.json" ]] && r=$(…)` made an **absent
  measurement indistinguishable from a measured zero**. The decoy's pass test is
  `r < 0.001`, so a truvari that crashed printed
  `decoy scoreable: PASS (shifted truth recall=0, expected 0)` — a negative control
  reported as passing precisely because it never executed. The identical idiom in
  `selftest_truvari` fails *safe* only by accident of comparing `r > 0.999`.
- `>/dev/null 2>&1 || true` discarded the only evidence of why it crashed.
- The function always `return 0`ed and both call sites ignored its status, so a decoy that
  **matched** was a `WARNING` on stderr while the run still reported `complete` and exit 0.

Both controls now read metrics through `truvari_metric`, which returns non-zero for a
missing or unparseable summary, and report `DID NOT RUN` separately from a scored zero. A
decoy match *and* a decoy that did not run now set `CAL_FAIL`, which already skips caller
scoring, marks the run FAILED and exits 1. truvari's stderr is kept and printed on failure.

### 2. An SV type with zero truth records vanished from the report

Job 20853511 planted 123 somatic SVs and **0 insertions**. The run printed a bare
`truth INS: 0` and never mentioned INS again — the zero-count file is deleted and the
scoring loop skips it on `[[ -f "$typed" ]] || continue`. So `manta_overall=0.861` silently
meant "over DEL/DUP/INV", with 3 of 6 canonical types contributing no denominator and
nothing saying so.

Empty strata are now collected, named where found, counted (`3 of 6`), and **repeated in the
closing banner** — stage 3b prints ~900 lines above the part that actually gets read.

Deliberately **not** a hard failure: the pancancer model draws `Ins` at p=0.0279, so with
~101 events roughly 6% of runs legitimately plant none, and failing those would train people
to ignore it. Zero INS here is a ~5.7% outcome — suspicious, not conclusive.

## Evidence

New `scripts/delta/tests/test_scorer_calibration.sh`: **42 assertions, 9 mutations, 0
survivors.** truvari is stubbed, which is the only way to provoke crash-without-summary and
a matching decoy on demand; bcftools is real, so decoy VCFs are really built and sorted.

- One mutation restores the `local r=0` default **verbatim** and is caught.
- One mutation restores the pre-fix silent stratum drop **verbatim** and is caught.
- Known-answer fixture covers both displacement branches, including the 6,111,196 bp DUP
  from job 20853511 that defeated the pre-#508 flat shift by still overlapping itself ~67%.
- Includes the **negative case**: a truth with all six types planted must emit no
  `NOT MEASURED` line at all.

`test_bnd_geometry.sh` still passes (29 assertions) with 0 mutation survivors.

The per-type loop moved into `split_truth_by_type()` so the behaviour is reachable from
tests; asserting it by grepping the source would only check that the code *looks* right.

## Not verified

**Not yet run on Delta against a real truvari.** The stub proves the decision logic; it does
not prove truvari's `summary.json` keys are unchanged in the pinned env. That is the one
thing to confirm on the next run.

Whether eidolon can emit somatic `INS` de novo remains **open** — it needs replicate runs,
not this change. `docs/sv_support_matrix.md` records symbolic `<INS>` as a silent no-op from
`input_vcf` (#500) while asserting the de novo path does synthesise sequence; that claim is
untested, and this is the run that would have exercised it.

## Also

Job 20853511 itself used a checkout **three days stale** (`6e4c288`, predating #508), so its
numbers need regenerating regardless of this PR. `CLAUDE.md` gains the rule that produced
that surprise: establish the Delta checkout SHA *before* interpreting any number, since a
queued job runs the script as it was when the job started.

Case history added to `docs/claude_engineering_audit.md` §5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)