### PR TITLE
fix(delta): stale-binary detection by commit, inline BAM prune, and a disk pre-flight

### DIFF
--- a/eidolon/build.rs
+++ b/eidolon/build.rs
@@ -1,0 +1,62 @@
+//! Stamp the build's git commit into the binary.
+//!
+//! WHY THIS EXISTS: `eidolon --version` reported only `CARGO_PKG_VERSION`, and the Delta
+//! validation pipeline's stale-binary guard compared that against `Cargo.toml`. Almost all
+//! work in this repo lands without a version bump — 3.1.0 has carried a dozen Rust commits
+//! and was never even tagged — so the common case, *a binary built from an older commit of
+//! the same version*, passed the guard silently. #513. The guard's own comment names the
+//! incident: job 20682989 reproduced job 20675480's numbers exactly and the log could not
+//! answer "was the fix even in this build?".
+//!
+//! Deliberately shells out to `git` rather than adding a crate (`vergen` et al). CLAUDE.md
+//! requires the shipped artifact stay pure Rust with no runtime requirements and a
+//! `Cargo.lock` free of extra dependencies; a build script invoking a subprocess adds
+//! neither.
+//!
+//! Degrades to "unknown" when git is unavailable or `.git` is absent — a conda build from a
+//! source tarball, for instance. It is then the CONSUMER's job to decide whether an
+//! unverifiable build is acceptable; the validation pipeline refuses one, because "cannot
+//! verify" must not read as "verified".
+
+use std::process::Command;
+
+fn main() {
+    // Re-run when HEAD moves or the index changes, so the stamp cannot go stale within a
+    // working tree. Both may be absent (tarball build); cargo tolerates missing paths here.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/index");
+    println!("cargo:rerun-if-env-changed=EIDOLON_GIT_SHA");
+
+    // An explicit override wins, so a packager can stamp a known provenance without git.
+    if let Ok(forced) = std::env::var("EIDOLON_GIT_SHA") {
+        if !forced.trim().is_empty() {
+            println!("cargo:rustc-env=EIDOLON_GIT_SHA={}", forced.trim());
+            return;
+        }
+    }
+
+    println!("cargo:rustc-env=EIDOLON_GIT_SHA={}", git_describe());
+}
+
+fn git_describe() -> String {
+    let sha = match run(&["rev-parse", "--short=7", "HEAD"]) {
+        Some(s) if !s.is_empty() => s,
+        // No git, no repo, or a tarball. Say so rather than inventing provenance.
+        _ => return "unknown".to_string(),
+    };
+    // A dirty tree means the SHA does NOT describe what was compiled. Saying so is the
+    // whole point: a guard that accepts a clean-looking SHA for uncommitted code is the
+    // same false-pass shape this stamp exists to prevent.
+    match run(&["status", "--porcelain", "--untracked-files=no"]) {
+        Some(s) if !s.is_empty() => format!("{sha}-dirty"),
+        _ => sha,
+    }
+}
+
+fn run(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}

--- a/eidolon/src/main.rs
+++ b/eidolon/src/main.rs
@@ -182,7 +182,17 @@ fn main() -> Result<(), NeatErrors> {
         .multicall(true)
         .subcommand(
             Command::new("eidolon")
-                .version(env!("CARGO_PKG_VERSION"))
+                // Version carries the build's git commit (build.rs, #513). The bare
+                // semver could not distinguish two binaries built from different commits
+                // of the same unreleased version, which is every build in this repo, so
+                // the validation pipeline's stale-binary guard was structurally unable to
+                // catch a forgotten rebuild. Format: "3.1.0+abc1234", or "+abc1234-dirty",
+                // or "+unknown" when built without git.
+                .version(concat!(
+                    env!("CARGO_PKG_VERSION"),
+                    "+",
+                    env!("EIDOLON_GIT_SHA")
+                ))
                 .arg_required_else_help(true)
                 .subcommand_value_name("SUB-COMMAND")
                 .subcommand_help_heading("SUB-COMMANDS")

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -202,6 +202,21 @@ check_binary_provenance() {  # <eidolon --version output> <repo root>
 }
 check_binary_provenance "${EIDOLON_VERSION:-}" "$REPO_ROOT" || exit 1
 
+# Disk state, in every log, before any work. Job 20904141 rep 5 died ~3h in when the
+# project quota filled at the FASTQ merge, having already spent simulation and alignment —
+# and the log gave no way to see how close the preceding replicates had come. Printed RAW
+# and never parsed: `df` misreports inside a project-quota'd directory (it shows the quota,
+# not the mount), the quota table and df have disagreed for /scratch, and a guard built on
+# fragile parsing is worse than no guard. One replicate needs ~113 GB peak (30 GB normal
+# BAM + 71 GB tumor + FASTQ held together at the merge), measured on job 20892075.
+echo "── disk before start (one replicate needs ~113 GB peak) ──"
+_projid="$(lfs project -d "$(dirname "$OUTDIR")" 2>/dev/null | awk '{print $1}')" || true
+if [[ -n "${_projid:-}" && "$_projid" != "0" ]]; then
+    lfs quota -h -p "$_projid" "$(df -P "$(dirname "$OUTDIR")" 2>/dev/null | awk 'NR==2{print $6}')" 2>&1 || true
+else
+    echo "  (no Lustre project id on $(dirname "$OUTDIR"); quota unknown)"
+fi
+
 if [[ "$FORCE_RESIM" == "0" && -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then
     echo "[1/5] Simulation outputs already present — skipping."
 else
@@ -1395,6 +1410,42 @@ if [[ "${PRUNE_FASTQ:-1}" == "1" ]]; then
     echo "[prune] removing FASTQ intermediates (set PRUNE_FASTQ=0 to keep)..."
     rm -f "$OUTDIR"/sample_*_r1.fastq.gz "$OUTDIR"/sample_*_r2.fastq.gz
 fi
+
+# The BAMs are the rest of the bulk — ~101 GB of a ~113 GB replicate (30 GB normal +
+# 71 GB tumor, measured on job 20892075). Pruning them here, INSIDE the pipeline, rather
+# than from a dependent cleanup job.
+#
+# WHY INLINE: the external strip job failed four different ways in one week — a script
+# path under $HOME that did not exist, a glob pointing at /work/nvme while runs landed on
+# /scratch, a missing --account, and a script whose creation was never confirmed. Each
+# time it exited quietly and nothing downstream noticed, because a cleanup job that does
+# nothing looks exactly like one that had nothing to do. An `--array=4-8%1` campaign then
+# accumulated ~100 GB per finished replicate until rep 5 hit the project quota and the
+# array died. A separate job is a separate thing to forget; this cannot be forgotten.
+#
+# GUARD: only when scoring actually produced a summary. A run that failed calibration, or
+# died before stage 5, keeps its BAMs — that is exactly when someone needs to re-call.
+# Note this makes the replicate re-SCOREABLE but not re-CALLABLE; the FASTQ prune above
+# already removed re-alignment, and CLAUDE.md's guidance for a campaign is to clear
+# finished replicates down to truvari_*/summary.json, which is all aggregate_sv_reps.sh
+# reads. Set PRUNE_BAM=0 to keep them (do that for a single diagnostic run, not a sweep).
+prune_bams() {  # <outdir>
+    local dir="$1" bam_kb
+    [[ "${PRUNE_BAM:-1}" == "1" ]] || { echo "[prune] keeping BAMs (PRUNE_BAM=0)"; return 0; }
+    # MUST NOT FIRE without a completed score. Deleting the BAMs of a run that died before
+    # stage 5 destroys the only artifact that makes it re-callable, and the FASTQ is already
+    # gone by this point, so there is no way back.
+    if [[ ! -f "$dir/truvari_manta_overall/summary.json" ]]; then
+        echo "[prune] KEEPING BAMs: no truvari_manta_overall/summary.json, so scoring did" >&2
+        echo "  not complete and this is a run someone will need to re-call." >&2
+        return 0
+    fi
+    bam_kb=$(du -sk "$dir"/normal.bam "$dir"/tumor.bam 2>/dev/null | awk '{s+=$1} END{print s+0}')
+    rm -f "$dir"/normal.bam "$dir"/normal.bam.bai "$dir"/tumor.bam "$dir"/tumor.bam.bai
+    echo "[prune] removed aligned BAMs, reclaimed $((bam_kb / 1048576)) GB" \
+         "(PRUNE_BAM=0 keeps them; replicate stays re-scoreable, not re-callable)"
+}
+prune_bams "$OUTDIR"
 
 # Persist report artifacts off scratch + record provenance/resources.
 # (manta overall always exists; delly summaries remain under $OUTDIR/truvari_delly_*)

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -150,13 +150,57 @@ echo "eidolon binary: $EIDOLON_BIN"
 echo "eidolon version: ${EIDOLON_VERSION:-unknown}"
 echo "repo HEAD:      $(git -C "$REPO_ROOT" describe --tags --always --dirty 2>/dev/null || echo unknown)"
 # A binary older than the checkout is almost always a forgotten rebuild.
-_repo_ver="$(awk -F\' '/^version = /{print $2; exit}' "$REPO_ROOT/Cargo.toml" 2>/dev/null)"
-if [[ -n "$_repo_ver" && "${EIDOLON_VERSION:-}" != *"$_repo_ver"* ]]; then
-    echo "ERROR: binary reports '${EIDOLON_VERSION:-unknown}' but the checkout is $_repo_ver." >&2
-    echo "  The binary is stale — rebuild before running, or the results describe code" >&2
-    echo "  that is not the code you think you are testing. Set ALLOW_STALE_BIN=1 to override." >&2
-    [[ "${ALLOW_STALE_BIN:-0}" == "1" ]] || exit 1
-fi
+#
+# The SEMVER half of this check cannot see a stale binary within a version, which is every
+# build in this repo (#513). `develop` carries 116 commits since v3.0.0 under one Cargo
+# version, and that version reads 3.1.0 against main's 3.0.0 with no release behind it — it
+# was bumped partly to make this very check fire. So the commit is compared too, from the
+# stamp `eidolon/build.rs` puts in `--version` ("3.1.0+abc1234", "+abc1234-dirty", or
+# "+unknown"). Job 20682989 reproduced job 20675480's numbers exactly and the log could not
+# answer "was the fix even in this build?"; the semver alone still could not.
+check_binary_provenance() {  # <eidolon --version output> <repo root>
+    local ver="$1" root="$2" rc=0
+    # dirty MUST be initialised, not merely declared: `local dirty` leaves it unset, and
+    # "${repo_sha}${dirty}" then aborts the whole job under `set -u` on a CLEAN checkout —
+    # i.e. the normal case. Caught by the suite before it reached Delta.
+    local repo_ver repo_sha want
+    local dirty=""
+
+    repo_ver="$(awk -F\' '/^version = /{print $2; exit}' "$root/Cargo.toml" 2>/dev/null)"
+    if [[ -n "$repo_ver" && "$ver" != *"$repo_ver"* ]]; then
+        echo "ERROR: binary reports '${ver:-unknown}' but the checkout is $repo_ver." >&2
+        echo "  The binary is stale — rebuild before running, or the results describe code" >&2
+        echo "  that is not the code you think you are testing." >&2
+        rc=1
+    fi
+
+    repo_sha="$(git -C "$root" rev-parse --short=7 HEAD 2>/dev/null)"
+    # -uno: the pipeline's own SLURM .out/.err files land in the submit dir, which IS the
+    # repo, so counting untracked files would report every run as dirty.
+    [[ -n "$(git -C "$root" status --porcelain --untracked-files=no 2>/dev/null)" ]] && dirty="-dirty"
+    want="${repo_sha}${dirty}"
+
+    if [[ -z "$repo_sha" ]]; then
+        echo "WARNING: cannot read the checkout's git commit; build provenance unverified." >&2
+    elif [[ "$ver" == *"+unknown"* ]]; then
+        # "Cannot verify" must not read as "verified" — the #509 lesson, one guard over.
+        echo "ERROR: the binary carries no git stamp (+unknown), so it cannot be matched to" >&2
+        echo "  this checkout. Rebuild where git is available." >&2
+        rc=1
+    elif [[ "$ver" != *"+$want"* ]]; then
+        echo "ERROR: the binary was built from a DIFFERENT COMMIT than this checkout — the" >&2
+        echo "  forgotten rebuild the version check above cannot see." >&2
+        echo "    binary:   $ver" >&2
+        echo "    checkout: $want" >&2
+        echo "  Run 'cargo build --release' before scoring." >&2
+        rc=1
+    fi
+
+    [[ "$rc" -eq 0 ]] && return 0
+    echo "  Set ALLOW_STALE_BIN=1 to override (the results then describe an unknown build)." >&2
+    [[ "${ALLOW_STALE_BIN:-0}" == "1" ]]
+}
+check_binary_provenance "${EIDOLON_VERSION:-}" "$REPO_ROOT" || exit 1
 
 if [[ "$FORCE_RESIM" == "0" && -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then
     echo "[1/5] Simulation outputs already present — skipping."

--- a/scripts/delta/tests/test_scorer_calibration.sh
+++ b/scripts/delta/tests/test_scorer_calibration.sh
@@ -68,6 +68,9 @@ commit check accepts any commit@elif [[ "$ver" != *"+$want"* ]]; then@elif false
 unstamped binary accepted@elif [[ "$ver" == *"+unknown"* ]]; then@elif false; then
 dirty tree not detected@[[ -n "$(git -C "$root" status --porcelain --untracked-files=no 2>/dev/null)" ]] && dirty="-dirty"@:
 provenance failure is advisory only@    [[ "$rc" -eq 0 ]] && return 0@    return 0; [[ "$rc" -eq 0 ]] && return 0
+prune deletes BAMs of an unscored run@    if [[ ! -f "$dir/truvari_manta_overall/summary.json" ]]; then@    if false; then
+prune ignores PRUNE_BAM=0@[[ "${PRUNE_BAM:-1}" == "1" ]] || { echo "[prune] keeping BAMs (PRUNE_BAM=0)"; return 0; }@:
+prune leaves the .bai files behind@rm -f "$dir"/normal.bam "$dir"/normal.bam.bai "$dir"/tumor.bam "$dir"/tumor.bam.bai@rm -f "$dir"/normal.bam "$dir"/tumor.bam
 MUTATIONS
     printf '\n──────── %d mutation(s) survived ────────\n' "$survived"
     [[ "$survived" -eq 0 ]]
@@ -96,7 +99,7 @@ fi
 
 # ── Load the functions under test, verbatim ────────────────────────────────────
 extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
-for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance; do
+for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams; do
     src="$(extract "$fn")"
     [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
     eval "$src"
@@ -327,6 +330,40 @@ NOGIT="$WORK/nogit"; mkdir -p "$NOGIT"
 printf "[workspace]\nversion = '3.1.0'\n" > "$NOGIT/Cargo.toml"
 is "non-git checkout warns but passes" 0 \
    "$(ALLOW_STALE_BIN=0 check_binary_provenance "eidolon 3.1.0" "$NOGIT" >/dev/null 2>&1; echo $?)"
+
+echo "── prune_bams: reclaim a scored replicate, never an unscored one ──"
+# Job 20904141 died at rep 5 with the project quota full because the external cleanup jobs
+# never ran at all. This moved inline, so the destructive half needs its own assertions.
+mk_rep() {  # <dir> <scored: yes|no>
+    rm -rf "$1"; mkdir -p "$1"
+    head -c 1048576 /dev/zero > "$1/normal.bam"; : > "$1/normal.bam.bai"
+    head -c 2097152 /dev/zero > "$1/tumor.bam";  : > "$1/tumor.bam.bai"
+    if [[ "$2" == "yes" ]]; then
+        mkdir -p "$1/truvari_manta_overall"
+        printf '{"recall": 0.9}\n' > "$1/truvari_manta_overall/summary.json"
+    fi
+}
+n_bams() { ls "$1"/normal.bam "$1"/tumor.bam 2>/dev/null | wc -l; }
+
+mk_rep "$WORK/rep_scored" yes
+outp="$(PRUNE_BAM=1 prune_bams "$WORK/rep_scored" 2>&1)"
+is  "scored replicate loses its BAMs"     0 "$(n_bams "$WORK/rep_scored")"
+is  "the .bai files go too"               0 "$(ls "$WORK/rep_scored"/*.bai 2>/dev/null | wc -l)"
+has "it reports what it reclaimed"        "$outp" "reclaimed"
+is  "the summary it keyed on survives"    1 \
+    "$(ls "$WORK/rep_scored/truvari_manta_overall/summary.json" 2>/dev/null | wc -l)"
+
+# THE DESTRUCTIVE MUST-NOT-FIRE. A run that died before stage 5 has no summary; its FASTQ is
+# already pruned, so deleting the BAMs makes it permanently un-re-callable.
+mk_rep "$WORK/rep_unscored" no
+outp="$(PRUNE_BAM=1 prune_bams "$WORK/rep_unscored" 2>&1)"
+is  "UNSCORED replicate keeps its BAMs"   2 "$(n_bams "$WORK/rep_unscored")"
+has "and says why"                        "$outp" "KEEPING BAMs"
+
+mk_rep "$WORK/rep_optout" yes
+outp="$(PRUNE_BAM=0 prune_bams "$WORK/rep_optout" 2>&1)"
+is  "PRUNE_BAM=0 keeps them"              2 "$(n_bams "$WORK/rep_optout")"
+has "and says so"                         "$outp" "PRUNE_BAM=0"
 
 printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/delta/tests/test_scorer_calibration.sh
+++ b/scripts/delta/tests/test_scorer_calibration.sh
@@ -64,6 +64,10 @@ empty stratum silently dropped (pre-fix)@TYPES_UNMEASURED+=("$svt")@:
 coverage-hole summary never printed@echo "  SV types with an EMPTY denominator@echo "  suppressed
 empty stratum reported for every type@if [[ "$n" -eq 0 ]]; then@if [[ "$n" -ge 0 ]]; then
 empty type leaves a stray truth file@rm -f "$typed" "${typed}.tbi"@:
+commit check accepts any commit@elif [[ "$ver" != *"+$want"* ]]; then@elif false; then
+unstamped binary accepted@elif [[ "$ver" == *"+unknown"* ]]; then@elif false; then
+dirty tree not detected@[[ -n "$(git -C "$root" status --porcelain --untracked-files=no 2>/dev/null)" ]] && dirty="-dirty"@:
+provenance failure is advisory only@    [[ "$rc" -eq 0 ]] && return 0@    return 0; [[ "$rc" -eq 0 ]] && return 0
 MUTATIONS
     printf '\n──────── %d mutation(s) survived ────────\n' "$survived"
     [[ "$survived" -eq 0 ]]
@@ -92,7 +96,7 @@ fi
 
 # ── Load the functions under test, verbatim ────────────────────────────────────
 extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
-for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type; do
+for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance; do
     src="$(extract "$fn")"
     [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
     eval "$src"
@@ -272,6 +276,57 @@ outp="$(cat "$WORK/split_full.log")"
 is    "no type reported unmeasured"        "" "${TYPES_UNMEASURED[*]}"
 hasnt "no NOT MEASURED line is emitted"    "$outp" "NOT MEASURED"
 hasnt "no coverage-hole summary is emitted" "$outp" "EMPTY denominator"
+
+echo "── check_binary_provenance: a stale binary within one version must be caught ──"
+# Build a throwaway repo so the function has a real git HEAD to compare against. The
+# defect (#513) is that the semver half passes whenever Cargo.toml is unchanged, which is
+# every commit in this project — so every case below holds the version CONSTANT and varies
+# only the commit.
+PROV_REPO="$WORK/provrepo"
+mkdir -p "$PROV_REPO"
+printf "[workspace]\nversion = '3.1.0'\n" > "$PROV_REPO/Cargo.toml"
+git -C "$PROV_REPO" init -q
+git -C "$PROV_REPO" add Cargo.toml
+git -C "$PROV_REPO" -c user.email=t@example.com -c user.name=t commit -q -m init
+PROV_SHA="$(git -C "$PROV_REPO" rev-parse --short=7 HEAD)"
+
+prov() { ALLOW_STALE_BIN="${2:-0}" check_binary_provenance "$1" "$PROV_REPO" >/dev/null 2>&1; echo $?; }
+
+is "matching version and commit passes"        0 "$(prov "eidolon 3.1.0+$PROV_SHA")"
+is "same version, DIFFERENT commit fails"      1 "$(prov "eidolon 3.1.0+deadbee")"
+is "unstamped binary (+unknown) fails"         1 "$(prov "eidolon 3.1.0+unknown")"
+is "version mismatch still fails"              1 "$(prov "eidolon 3.0.0+$PROV_SHA")"
+is "no stamp at all fails"                     1 "$(prov "eidolon 3.1.0")"
+is "ALLOW_STALE_BIN=1 overrides a bad commit"  0 "$(prov "eidolon 3.1.0+deadbee" 1)"
+
+# The message must name the actual defect, not just say "stale" — the semver wording sent
+# a previous investigation looking for a version problem that did not exist.
+outp="$(ALLOW_STALE_BIN=0 check_binary_provenance "eidolon 3.1.0+deadbee" "$PROV_REPO" 2>&1)"
+has "commit mismatch names the commit"  "$outp" "DIFFERENT COMMIT"
+has "commit mismatch shows both sides"  "$outp" "checkout: $PROV_SHA"
+
+# An UNSTAMPED binary and a WRONG-COMMIT binary both fail, so asserting the exit status
+# alone does not distinguish them — a mutation disabling the +unknown branch survived on
+# that basis, because control fell through to the commit check and failed anyway. The two
+# point at different fixes ("rebuild where git is available" vs "rebuild this checkout"),
+# so the diagnosis is part of the contract.
+outp="$(ALLOW_STALE_BIN=0 check_binary_provenance "eidolon 3.1.0+unknown" "$PROV_REPO" 2>&1)"
+has   "unstamped binary is diagnosed as unstamped" "$outp" "no git stamp"
+hasnt "unstamped is not misreported as wrong commit" "$outp" "DIFFERENT COMMIT"
+
+# A dirty tree means the stamp does not describe what was compiled, so the binary built
+# FROM that dirty tree must match and a clean-stamped binary must not.
+printf "[workspace]\nversion = '3.1.0'\n# edited\n" > "$PROV_REPO/Cargo.toml"
+is "dirty tree accepts the -dirty stamp"        0 "$(prov "eidolon 3.1.0+${PROV_SHA}-dirty")"
+is "dirty tree rejects a clean stamp"           1 "$(prov "eidolon 3.1.0+$PROV_SHA")"
+git -C "$PROV_REPO" checkout -q -- Cargo.toml
+
+# MUST NOT FIRE: outside a git repo there is nothing to compare, so warn and pass rather
+# than failing every conda/tarball install that never claimed a commit.
+NOGIT="$WORK/nogit"; mkdir -p "$NOGIT"
+printf "[workspace]\nversion = '3.1.0'\n" > "$NOGIT/Cargo.toml"
+is "non-git checkout warns but passes" 0 \
+   "$(ALLOW_STALE_BIN=0 check_binary_provenance "eidolon 3.1.0" "$NOGIT" >/dev/null 2>&1; echo $?)"
 
 printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #513.

## The gap

The stale-binary guard compared the binary's semver against `Cargo.toml`, so it could only ever
detect a **version** mismatch. Almost nothing here bumps the version — `develop` carries 116
commits since `v3.0.0` under one Cargo version — so the common case, *a binary built from an
older commit of the same version*, passed silently.

#510 is exactly that shape: it changed de novo INS emission with no version bump. A forgotten
rebuild would produce `truth INS: 0` — the very symptom #510 fixes — discoverable only ~6 hours
into a run, and indistinguishable from a genuine generation failure. On an 8-replicate campaign
that's the whole campaign.

The guard's own comment names the incident it was written for: job 20682989 reproduced job
20675480's numbers exactly and the log could not answer *"was the fix even in this build?"*. It
still couldn't, whenever the version was unchanged.

## The change

`eidolon/build.rs` stamps the commit into `--version`:

| build | `--version` |
|---|---|
| clean tree | `eidolon 3.1.0+ba9c0ba` |
| uncommitted tracked changes | `eidolon 3.1.0+ba9c0ba-dirty` |
| no git (tarball/conda) | `eidolon 3.1.0+unknown` |

It **shells out to git rather than adding a crate** (`vergen` et al): CLAUDE.md requires the
shipped artifact stay pure Rust with no runtime requirements and a `Cargo.lock` free of extra
dependencies, and a build script running a subprocess adds neither. An `EIDOLON_GIT_SHA`
override lets a packager stamp known provenance without git.

`check_binary_provenance()` in `sv_pipeline.sbatch` compares that commit against
`git rev-parse HEAD` and keeps the semver check. It distinguishes three failures because they
need **different fixes**: wrong commit (rebuild this checkout), unstamped (rebuild where git is
available), version mismatch. A dirty tree must match a `-dirty` stamp and must *reject* a clean
one — a stamp that accepts uncommitted code is the false-pass shape being removed. `+unknown`
**fails** rather than warns, because "cannot verify" must not read as "verified" — #509's lesson
one guard over. `ALLOW_STALE_BIN=1` still overrides everything, and
`check_outdir_version` benefits for free since it compares whole `--version` strings.

## Deliberately not a version bump

`3.1.0` was never released — no tag, and `main` reads `3.0.0`. It appears to have been bumped
partly to make this very check fire, which is the semver-as-build-id habit this replaces. A bump
would fix one transition and go blind again on the next commit.

(Incidentally, `git describe` on `develop` reporting `v1.19.1-255` is **not** divergence: release
tags sit on `main`'s merge commits, which are descendants of `develop`'s history, so `describe`
walking backwards can't reach them. There are **0 non-merge commits exclusive to `main`**.)

## Evidence

`test_scorer_calibration.sh` grows to **55 assertions, 14 mutations, 0 survivors**. Two findings
from writing them, both worth recording:

- **`local dirty` (declared, not initialised) aborts the entire job under `set -u`** on a *clean*
  checkout, via `"${repo_sha}${dirty}"` — i.e. the normal case. The suite caught it before Delta
  did. Textbook entry for CLAUDE.md's bash-footguns list.
- **A mutation disabling the `+unknown` branch initially SURVIVED.** With it disabled, control
  fell through to the commit check and failed anyway, so the test asserted the right *exit
  status* for the wrong *reason*. It now asserts the diagnosis, not just the outcome.

Workspace green (780 tests). Verified by hand that `eidolon --version` reports
`3.1.0+ba9c0ba-dirty` and that the stamp tracks HEAD across rebuilds via `rerun-if-changed` on
`.git/HEAD` and `.git/index`.

## Not verified

Not yet run on Delta, and not yet built through the conda recipe — a tarball build with no `.git`
reports `+unknown` by design, so scoring with a packaged binary would need `ALLOW_STALE_BIN=1`.

## ⚠️ Do not pull this on Delta while array 20904141 is running

The guard runs inside each array task and reads `Cargo.toml`/`HEAD` at runtime. Pulling this
mid-array gives every remaining task a binary with no `+sha` stamp against a checkout that has
one, and reps 5–8 would exit 1 at startup. Pull after the array drains, then
`cargo build --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)