### PR TITLE
fix(delta): recover the missed disk pre-flight; pin the large-insertion read gap (#516)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,15 +147,15 @@ contig lengths).
   `df` also disagreed for `/scratch` (1000G vs a 500G mount). What actually stops a job is
   the **project quota** — check it with
   `lfs quota -h -p <projid> /work/nvme`, and read `Disk quota exceeded` literally.
-  Measured footprint for `sv_pipeline.sbatch` on GRCh38 at 30x: **~207 GB peak per
+  Measured footprint for `sv_pipeline.sbatch` on GRCh38 at 30x: **~214 GB peak per
   replicate**, itemised from job 20884022 — FASTQ 116 GB (merged 29+29, tumor 17+17,
-  normal 12+12) **plus** BAMs 91 GB (normal 30, tumor 61), which coexist because pruning
-  only runs at the end. An earlier "~113 GB" figure here counted the FASTQ only and was
-  wrong; every capacity estimate built on it was ~half of reality. With a ~171 GB fixed
+  normal 12+12) **plus** BAMs 98 GB (the figure `prune_bams` itself reported across
+  campaign 20925151), which coexist because pruning only runs at the end. An earlier
+  "~113 GB" figure here counted the FASTQ only and was wrong; every capacity estimate built on it was ~half of reality. With a ~171 GB fixed
   baseline (`neat_data` + bwa-mem2 index) **one replicate at a time is all that fits** in a
-  500 GB quota (171 + 207 = 378 GB), so serialize with `%1` — `%2` cannot work at any array
+  500 GB quota (171 + 214 = 385 GB), so serialize with `%1` — `%2` cannot work at any array
   size.
-  **A replicate that FAILS keeps all 207 GB**: its FASTQ prune never runs. Job 20884022 died
+  **A replicate that FAILS keeps all ~214 GB**: its FASTQ prune never runs. Job 20884022 died
   incomplete, held 203 GB indefinitely, and starved array 20904141 — all five tasks failed,
   task 4 spending 8 h 45 m producing 8 KB against a full filesystem. Clear a failed
   replicate's directory before the next campaign, and clear finished ones down to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,11 +147,19 @@ contig lengths).
   `df` also disagreed for `/scratch` (1000G vs a 500G mount). What actually stops a job is
   the **project quota** — check it with
   `lfs quota -h -p <projid> /work/nvme`, and read `Disk quota exceeded` literally.
-  Measured footprint for `sv_pipeline.sbatch` on GRCh38 at 30x: **~113 GB peak per
-  replicate** (normal + tumor + `cat`-merged FASTQ held together; pruning only runs at the
-  end). So `--array=1-8%2` needs ~900 GB and will die ~3 h in at the merge. Serialize with
-  `%1` and clear finished replicates down to `truvari_*/summary.json`, which is all
-  `aggregate_sv_reps.sh` reads.
+  Measured footprint for `sv_pipeline.sbatch` on GRCh38 at 30x: **~207 GB peak per
+  replicate**, itemised from job 20884022 — FASTQ 116 GB (merged 29+29, tumor 17+17,
+  normal 12+12) **plus** BAMs 91 GB (normal 30, tumor 61), which coexist because pruning
+  only runs at the end. An earlier "~113 GB" figure here counted the FASTQ only and was
+  wrong; every capacity estimate built on it was ~half of reality. With a ~171 GB fixed
+  baseline (`neat_data` + bwa-mem2 index) **one replicate at a time is all that fits** in a
+  500 GB quota (171 + 207 = 378 GB), so serialize with `%1` — `%2` cannot work at any array
+  size.
+  **A replicate that FAILS keeps all 207 GB**: its FASTQ prune never runs. Job 20884022 died
+  incomplete, held 203 GB indefinitely, and starved array 20904141 — all five tasks failed,
+  task 4 spending 8 h 45 m producing 8 KB against a full filesystem. Clear a failed
+  replicate's directory before the next campaign, and clear finished ones down to
+  `truvari_*/summary.json`, which is all `aggregate_sv_reps.sh` reads.
 - Staging: `fetch_validation_data.sh` (references), `stage_soy.sh` (align + call a
   self-consistent ref/BAM/VCF; `FULL_GENOME=1` for the whole-genome stress vs the
   fast single-chromosome default). `model_builders.sbatch` exercises the builders.

--- a/docs/sv_support_matrix.md
+++ b/docs/sv_support_matrix.md
@@ -33,7 +33,8 @@ a variant that silently fails to appear is a broken tool.
 | BND, single/unpaired (`A.`) | preserved | 0 chimeric; **depth 42.4 vs 72.0** | ❌ [#500](https://github.com/ncsa/eidolon/issues/500) destroys coverage |
 | Fragment spanning a whole DUP | — | *"4 of 30 reads match no haplotype"* | ❌ #474 |
 | Two junctions within one fragment | all 4 preserved | 60 chimeric; depth matches derived haplotype | ✅ |
-| Literal INS (`A`→`ACTGACTGCATG`) | preserved | **I=46** vs 15 baseline | ✅ |
+| Literal INS, ≤ ~150 bp | preserved | inserted bases present in reads | ✅ |
+| Literal INS, ≳ 200 bp | preserved **with full SVLEN** | **head only** — interior and far end in 0 reads | ❌ [#516](https://github.com/ncsa/eidolon/issues/516) partial |
 | Literal DEL (`TTTT…`→`A`) | preserved | **D=49** vs 20 baseline | ✅ |
 
 ### Untested cells: none remain
@@ -62,6 +63,38 @@ novel bases are present in the truth VCF, at a rate consistent with the model's
 in 2026-08 on the strength of `truth INS: 0` in the SV harness — which turned out to be
 measuring the harness's own selector, not the generator. See §"De novo generation" below and
 `docs/claude_engineering_audit.md` §5.3.
+
+**[#516] Large insertions are only PARTIALLY realized, which is worse than not at all.** An
+insertion longer than roughly one read is spliced into the haplotype, but only its first
+~100–150 bases are ever sequenced. Measured on the H1N1 fixture at `read_len=100`,
+`fragment_mean=250`, counting reads containing a 30-mer from the head / middle / far end of the
+inserted sequence:
+
+| insert | head | middle | tail |
+|---|---|---|---|
+| 50 bp | 16 | 13 | 8 |
+| 150 bp | 21 | 5 | 0 |
+| 200 bp | 25 | **0** | **0** |
+| 600 bp | 27 | **0** | **0** |
+
+The head count *rises* with size while the interior collapses to zero — so any probe near the
+insertion's start says it works, which is where a casual check looks. The truth VCF meanwhile
+declares the full `SVLEN`. **Read support saturates at ~one read length regardless of the
+declared size.**
+
+Consequence, measured: SV validation campaign 20925151 planted 22 de novo somatic insertions of
+61–2155 bp and Manta detected exactly one — the 61 bp event, and only at `MinSomaticScore`.
+That is not primarily a caller limitation. Manta documents a *fully assembled* ceiling of
+"approximately twice the read-pair fragment size" and states it also reports very large
+insertions from a breakend signature alone, as `IMPRECISE <INS>` with
+`LEFT_SVINSSEQ`/`RIGHT_SVINSSEQ`. Most of the planted set was inside that range, and Manta
+reported nothing within 2 kb of any of them — because the evidence for the declared length was
+not in the reads. **INS recall figures are invalid above ~a read length; DEL/DUP/INV/BND/CNV
+are unaffected.**
+
+Suspected mechanism, same family as #474 and #498: fragments are placed against *reference*
+coordinates and the insert is spliced in afterwards, so a fragment can reach into the start of
+an insertion but none ever *begins* inside it — nothing samples the interior.
 
 **[#500] A single breakend (`A.`) destroys coverage.** VCF 4.2 allows an unresolved
 partner. `parse_bnd_alt` returns no mate, and the result is worse than being ignored:

--- a/eidolon/tests/sv_support_matrix.rs
+++ b/eidolon/tests/sv_support_matrix.rs
@@ -333,6 +333,146 @@ fn coverage_modulation_over_delivers_by_about_eight_percent() {
     );
 }
 
+/// Deterministic, varied ACGT filler. A 30-mer of it has a ~4^-30 chance of occurring in the
+/// reference by accident, so finding one in a read is proof the NOVEL sequence reached the
+/// output rather than something spliced from the fixture.
+fn synthetic_insert(n: usize) -> String {
+    let mut s = String::with_capacity(n);
+    let mut x: u64 = 0x9E37_79B9_7F4A_7C15;
+    for _ in 0..n {
+        x = x
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        s.push(match (x >> 33) & 3 {
+            0 => 'A',
+            1 => 'C',
+            2 => 'G',
+            _ => 'T',
+        });
+    }
+    s
+}
+
+fn revcomp(s: &str) -> String {
+    s.chars()
+        .rev()
+        .map(|c| match c {
+            'A' => 'T',
+            'T' => 'A',
+            'C' => 'G',
+            'G' => 'C',
+            o => o,
+        })
+        .collect()
+}
+
+/// Insertions LARGER than a read must still reach the reads — the size regime the rest of
+/// this file never covered.
+///
+/// WHY THIS EXISTS: campaign 20925151 planted 22 de novo insertions of 61–2155 bp. Manta
+/// reported nothing at any of the 21 above 61 bp — not even the `IMPRECISE <INS>` its own
+/// user guide says it emits from a breakend signature for insertions it cannot fully
+/// assemble, and its documented full-assembly ceiling (~2x fragment size) sits above most of
+/// the planted set. That points at the reads rather than the caller, and the question was
+/// being chased through 8-hour whole-genome runs when it is answerable here in seconds.
+///
+/// `literal_indels_reach_the_reads` above covers an ELEVEN base insert. A de novo INS is
+/// emitted as the same `VariantType::Insertion` + `AlternateType::Literal` variant that an
+/// `input_vcf` literal insertion parses to, so both share this machinery downstream — which
+/// makes a size sweep here a valid probe of the de novo path.
+///
+/// KNOWN ANSWER: at coverage 60, a heterozygous insertion gets ~30x over the inserted
+/// sequence, so reads falling wholly inside it must exist for any size above a read length.
+/// The probe is a 30-mer from the MIDDLE of the insert, checked in both orientations.
+#[test]
+fn large_literal_insertions_reach_the_reads() {
+    let tmp = tempfile::tempdir().unwrap();
+    // MEASURED (read_len=100, fragment_mean=250): support degrades with size and hits zero
+    // at the FRAGMENT length, not the read length.
+    //   50bp -> 13 reads    150bp -> 5 reads    200bp -> ?    300bp -> 0    600bp -> 0
+    let mut carried: Vec<(usize, usize, usize, usize)> = Vec::new();
+    for size in [50usize, 150, 200, 300, 600] {
+        let insert = synthetic_insert(size);
+        let at = size / 2 - 15;
+        let probe = &insert[at..at + 30];
+
+        let rec = format!(
+            "{}\t500\tinsbig{size}\tA\tA{insert}\t60\tPASS\t.\tGT\t0/1",
+            EV.0
+        );
+        let out = run_cell(tmp.path(), &format!("ins_big_{size}"), &[rec.as_str()]);
+
+        let hits = seq_lines_containing(&out, probe) + seq_lines_containing(&out, &revcomp(probe));
+        // Probe the START and END as well as the middle. With 100bp reads from 250bp
+        // fragments there is a ~50bp unsequenced gap inside every fragment, so a middle-only
+        // probe could read zero for GEOMETRIC reasons. If the start appears and the middle
+        // does not, the insert is spliced but only partly sequenced; if none appear, the
+        // novel sequence never reached the output at all. Different bugs, different fixes.
+        let head = &insert[..30];
+        let tail = &insert[size - 30..];
+        let h = seq_lines_containing(&out, head) + seq_lines_containing(&out, &revcomp(head));
+        let t = seq_lines_containing(&out, tail) + seq_lines_containing(&out, &revcomp(tail));
+        eprintln!("[INS {size}bp] 30-mer hits — head={h} middle={hits} tail={t}");
+
+        // The truth VCF preserves every size — which is the problem, not the reassurance.
+        assert!(
+            truth_has_id(&out, &format!("insbig{size}")),
+            "{size}bp insertion lost from the truth VCF"
+        );
+        carried.push((size, h, hits, t));
+    }
+
+    // MEASURED, read_len=100 / fragment_mean=250:
+    //   size  head middle tail
+    //     50    16     13    8   fully realized
+    //    150    21      5    0   middle thinning, tail already gone
+    //    200    25      0    0   only the head survives
+    //    300    26      0    0
+    //    600    27      0    0
+    //
+    // REGRESSION GUARD. The head must ALWAYS reach the reads — that is what proves the
+    // insertion is spliced into the haplotype at all, and it is the part that makes this bug
+    // look like a working feature.
+    for &(size, h, _, _) in &carried {
+        assert!(
+            h > 0,
+            "{size}bp insertion: not even its first 30 bases reach the reads. This is worse \
+             than the known partial-realization gap — the splice itself is broken."
+        );
+    }
+    // Small insertions are fully realized, and must stay that way.
+    for &(size, _, m, _) in &carried {
+        if size <= 150 {
+            assert!(
+                m > 0,
+                "{size}bp insertion no longer reaches the reads mid-sequence — a regression, \
+                 not the known #516 gap"
+            );
+        }
+    }
+
+    // CHARACTERIZATION of the open bug. Beyond ~a read length, an insertion's interior and
+    // far end are never sequenced while the truth VCF keeps declaring the full SVLEN — so a
+    // benchmark built from this data asserts insertions the reads cannot support. Filed as
+    // #516. Same family as #498 (BND insert dropped) and #474 (a fragment spanning a whole
+    // DUP needs a stitch the fragment builder cannot express). It is why campaign 20925151
+    // measured Manta INS recall at 1/22: only the 61bp event had evidence for its declared
+    // length, and Manta called only that one.
+    //
+    // If any of these starts finding reads, the bug is FIXED: promote the size into the
+    // guards above and delete it from here.
+    for &(size, _, m, t) in &carried {
+        if size >= 200 {
+            assert_eq!(
+                (m, t),
+                (0, 0),
+                "{size}bp insertion now reaches the reads mid-sequence or at its tail \
+                 (middle={m}, tail={t}) — #516 may be FIXED."
+            );
+        }
+    }
+}
+
 #[test]
 fn literal_indels_reach_the_reads() {
     let tmp = tempfile::tempdir().unwrap();

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -209,10 +209,11 @@ check_binary_provenance "${EIDOLON_VERSION:-}" "$REPO_ROOT" || exit 1
 # not the mount), the quota table and df have disagreed for /scratch, and a guard built on
 # fragile parsing is worse than no guard. One replicate needs ~113 GB peak (30 GB normal
 # BAM + 71 GB tumor + FASTQ held together at the merge), measured on job 20892075.
-# Peak footprint of ONE replicate, measured on job 20884022: FASTQ 116 GB (merged 29+29,
-# tumor 17+17, normal 12+12) plus BAMs 91 GB (normal 30, tumor 61), coexisting because the
-# prune only runs at the end. A previous "113 GB" figure counted the FASTQ alone.
-REPLICATE_PEAK_GB="${REPLICATE_PEAK_GB:-207}"
+# Peak footprint of ONE replicate: FASTQ 116 GB (merged 29+29, tumor 17+17, normal 12+12,
+# itemised from job 20884022) plus BAMs 98 GB (the figure prune_bams itself reported across
+# campaign 20925151), coexisting because the prune only runs at the end. A previous "113 GB"
+# figure in CLAUDE.md counted the FASTQ alone and was half of reality.
+REPLICATE_PEAK_GB="${REPLICATE_PEAK_GB:-214}"
 
 # Extract used/limit in KB from `lfs quota -p` output. Separated from the check so the
 # decision logic is testable without Lustre: the parsing is the fragile half, and the real

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -209,12 +209,63 @@ check_binary_provenance "${EIDOLON_VERSION:-}" "$REPO_ROOT" || exit 1
 # not the mount), the quota table and df have disagreed for /scratch, and a guard built on
 # fragile parsing is worse than no guard. One replicate needs ~113 GB peak (30 GB normal
 # BAM + 71 GB tumor + FASTQ held together at the merge), measured on job 20892075.
-echo "── disk before start (one replicate needs ~113 GB peak) ──"
-_projid="$(lfs project -d "$(dirname "$OUTDIR")" 2>/dev/null | awk '{print $1}')" || true
-if [[ -n "${_projid:-}" && "$_projid" != "0" ]]; then
-    lfs quota -h -p "$_projid" "$(df -P "$(dirname "$OUTDIR")" 2>/dev/null | awk 'NR==2{print $6}')" 2>&1 || true
+# Peak footprint of ONE replicate, measured on job 20884022: FASTQ 116 GB (merged 29+29,
+# tumor 17+17, normal 12+12) plus BAMs 91 GB (normal 30, tumor 61), coexisting because the
+# prune only runs at the end. A previous "113 GB" figure counted the FASTQ alone.
+REPLICATE_PEAK_GB="${REPLICATE_PEAK_GB:-207}"
+
+# Extract used/limit in KB from `lfs quota -p` output. Separated from the check so the
+# decision logic is testable without Lustre: the parsing is the fragile half, and the real
+# output is not guessable — an over-quota row marks values with a trailing '*' and adds a
+# grace column, which naive field-splitting silently mangles.
+#   Filesystem   used  bquota  blimit  bgrace       files iquota ilimit igrace
+#     /scratch 549.9G*   500G    550G  6d6h28m43s  21516* 850000 935000      -
+# Called WITHOUT -h so the values are plain KB and no unit parsing is needed.
+parse_lfs_quota_kb() {  # <lfs-quota-output> <filesystem-path>; echoes "<used_kb> <limit_kb>"
+    awk -v fs="$2" '
+        $1 == fs {
+            used = $2; hard = $4
+            gsub(/\*/, "", used); gsub(/\*/, "", hard)
+            # blimit (hard) is what actually stops a write; 0 means "no hard limit set",
+            # in which case fall back to bquota (soft).
+            if (hard + 0 == 0) { soft = $3; gsub(/\*/, "", soft); hard = soft }
+            if (used ~ /^[0-9]+$/ && hard ~ /^[0-9]+$/) { print used, hard; found = 1 }
+        }
+        END { exit !found }
+    ' <<< "$1"
+}
+
+# Refuse to START a replicate that cannot fit. Task 4 of array 20904141 burned 8 h 45 m
+# against a full filesystem to produce an 8 KB output directory, and tasks 5-8 then failed
+# in turn; the log's only clue was `cat: write error: Disk quota exceeded` on stderr. The
+# footprint is known and the quota is one command, so this is answerable in a second, up
+# front. Advisory when the quota cannot be read — a check that cannot run must say so, but
+# must not invent a reason to stop a run that would have been fine.
+echo "── disk pre-flight (one replicate needs ~${REPLICATE_PEAK_GB} GB peak) ──"
+_scratch_root="$(dirname "$OUTDIR")"
+_projid="$(lfs project -d "$_scratch_root" 2>/dev/null | awk '{print $1}')" || true
+if [[ -z "${_projid:-}" || "$_projid" == "0" ]]; then
+    echo "  WARNING: no Lustre project id on $_scratch_root — free space UNVERIFIED." >&2
 else
-    echo "  (no Lustre project id on $(dirname "$OUTDIR"); quota unknown)"
+    _fsmount="$(df -P "$_scratch_root" 2>/dev/null | awk 'NR==2{print $6}')"
+    lfs quota -h -p "$_projid" "$_fsmount" 2>&1 || true
+    _raw="$(lfs quota -p "$_projid" "$_fsmount" 2>/dev/null)" || true
+    if _kb="$(parse_lfs_quota_kb "${_raw:-}" "$_fsmount")"; then
+        _free_gb=$(( ( ${_kb% *} > ${_kb#* } ? 0 : ${_kb#* } - ${_kb% *} ) / 1048576 ))
+        echo "  free before start: ${_free_gb} GB (need ~${REPLICATE_PEAK_GB} GB)"
+        if [[ "$_free_gb" -lt "$REPLICATE_PEAK_GB" ]]; then
+            echo "ERROR: only ${_free_gb} GB free; one replicate needs ~${REPLICATE_PEAK_GB} GB." >&2
+            echo "  Refusing to start rather than fail hours in with a partial output dir" >&2
+            echo "  that itself holds ~207 GB and starves the next replicate (job 20884022)." >&2
+            echo "  Largest consumers:" >&2
+            du -sh "$_scratch_root"/* 2>/dev/null | sort -rh | head -5 >&2
+            echo "  A FAILED replicate keeps its FASTQ, so clear those directories first." >&2
+            echo "  Set SKIP_DISK_PREFLIGHT=1 to override." >&2
+            [[ "${SKIP_DISK_PREFLIGHT:-0}" == "1" ]] || exit 1
+        fi
+    else
+        echo "  WARNING: could not parse the quota output — free space UNVERIFIED." >&2
+    fi
 fi
 
 if [[ "$FORCE_RESIM" == "0" && -f "$MERGED_R1" && -f "$NORMAL_R1" && -f "$TRUTH_VCF" ]]; then

--- a/scripts/delta/tests/test_scorer_calibration.sh
+++ b/scripts/delta/tests/test_scorer_calibration.sh
@@ -71,6 +71,9 @@ provenance failure is advisory only@    [[ "$rc" -eq 0 ]] && return 0@    return
 prune deletes BAMs of an unscored run@    if [[ ! -f "$dir/truvari_manta_overall/summary.json" ]]; then@    if false; then
 prune ignores PRUNE_BAM=0@[[ "${PRUNE_BAM:-1}" == "1" ]] || { echo "[prune] keeping BAMs (PRUNE_BAM=0)"; return 0; }@:
 prune leaves the .bai files behind@rm -f "$dir"/normal.bam "$dir"/normal.bam.bai "$dir"/tumor.bam "$dir"/tumor.bam.bai@rm -f "$dir"/normal.bam "$dir"/tumor.bam
+quota parser ignores the over-quota marker@gsub(/\\*/, "", used); gsub(/\\*/, "", hard)@;
+quota parser accepts non-numeric values@if (used ~ /^[0-9]+$/ && hard ~ /^[0-9]+$/) { print used, hard; found = 1 }@{ print used, hard; found = 1 }
+quota parser reads the soft limit as the cap@$1 == fs {@$1 == fs { $4 = $3 }
 MUTATIONS
     printf '\n──────── %d mutation(s) survived ────────\n' "$survived"
     [[ "$survived" -eq 0 ]]
@@ -99,7 +102,7 @@ fi
 
 # ── Load the functions under test, verbatim ────────────────────────────────────
 extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
-for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams; do
+for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams parse_lfs_quota_kb; do
     src="$(extract "$fn")"
     [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
     eval "$src"
@@ -364,6 +367,39 @@ mk_rep "$WORK/rep_optout" yes
 outp="$(PRUNE_BAM=0 prune_bams "$WORK/rep_optout" 2>&1)"
 is  "PRUNE_BAM=0 keeps them"              2 "$(n_bams "$WORK/rep_optout")"
 has "and says so"                         "$outp" "PRUNE_BAM=0"
+
+echo "── parse_lfs_quota_kb: the real output format, including over-quota ──"
+# VERBATIM from Delta (job 20904141's aftermath). The over-quota row is the one that
+# matters and the one that is not guessable: values carry a trailing '*' and a grace
+# column appears, so naive field-splitting mangles it. -h is NOT used in production, so
+# the numbers are plain KB; the -h form below only exists to prove it is REJECTED rather
+# than silently misread as kilobytes.
+OVER=$'Disk quotas for prj 21649 (pid 21649):\n      Filesystem    used   bquota  blimit  bgrace   files   iquota  ilimit  igrace\n        /scratch 576458752*  524288000 576716800 6d6h28m43s   21516*  850000  935000       -'
+UNDER=$'Disk quotas for prj 21649 (pid 21649):\n      Filesystem    used   bquota  blimit  bgrace   files   iquota  ilimit  igrace\n        /scratch 255852544  524288000 576716800       -   18131  850000  935000       -'
+HUMAN=$'      Filesystem    used   bquota  blimit  bgrace   files\n        /scratch  549.9G*    500G    550G 6d6h28m43s   21516*'
+
+is "over-quota row parses used and hard limit" "576458752 576716800" \
+   "$(parse_lfs_quota_kb "$OVER" /scratch)"
+is "under-quota row parses"                    "255852544 576716800" \
+   "$(parse_lfs_quota_kb "$UNDER" /scratch)"
+# MUST NOT FIRE: a human-readable row must be REJECTED, not read as kilobytes. "549.9G"
+# silently taken as 549 KB would report ~550 TB free and wave through a full filesystem —
+# a check that confidently returns the wrong answer, which is worse than none.
+is "human-readable (-h) output is rejected"    1 \
+   "$(parse_lfs_quota_kb "$HUMAN" /scratch >/dev/null 2>&1; echo $?)"
+is "a filesystem not in the output is rejected" 1 \
+   "$(parse_lfs_quota_kb "$OVER" /work/nvme >/dev/null 2>&1; echo $?)"
+is "empty input is rejected"                   1 \
+   "$(parse_lfs_quota_kb "" /scratch >/dev/null 2>&1; echo $?)"
+
+# The arithmetic the gate depends on: 576458752 - ... is NEGATIVE here (over hard limit),
+# and free must clamp to 0 rather than wrapping to a huge positive number.
+kb="$(parse_lfs_quota_kb "$OVER" /scratch)"
+is "over-hard-limit free space clamps to 0" 0 \
+   "$(( ( ${kb% *} > ${kb#* } ? 0 : ${kb#* } - ${kb% *} ) / 1048576 ))"
+kb="$(parse_lfs_quota_kb "$UNDER" /scratch)"
+is "under-quota free space is 306 GB" 306 \
+   "$(( ( ${kb% *} > ${kb#* } ? 0 : ${kb#* } - ${kb% *} ) / 1048576 ))"
 
 printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Recovers `a11b196`, which **never landed**. #514 merged between my push of `4569acd`
(`prune_bams`) and `a11b196` (disk pre-flight + footprint correction), so the second commit
went onto an already-merged branch and was silently dropped. Verified with
`git merge-base --is-ancestor`:

```
d6c4ee0 stamp the build's git commit into --version   IN develop
4569acd prune BAMs inside the pipeline                IN develop
a11b196 refuse to start a replicate that cannot fit   *** NOT IN develop ***
```

Exactly the failure mode CLAUDE.md warns about under "After a PR merges, verify your commits
actually landed." Recovered by `git cherry-pick` as that section prescribes.

## How it surfaced

Campaign 20925151 completed all six replicates, but `grep "disk pre-flight"` over the logs
returned nothing — while `tumor.bam` was absent from the output directories, proving
`prune_bams` *had* run. That contradiction (part of the PR deployed, part not) is what exposed
the missed commit rather than anyone noticing the PR was incomplete.

No operational harm: the campaign had ~322 GB free against a 207 GB requirement, so the gate
would have passed anyway.

## Why it still matters

The more dangerous half is the documentation. **CLAUDE.md still claims ~113 GB peak per
replicate**, which is roughly half of reality — the real figure is ~207 GB (FASTQ 116 GB
*plus* BAMs 91 GB, coexisting because the prune runs at the end). Every capacity plan built on
the old number was out by ~2x, which is what killed array 20904141: all five tasks lost, task
4 spending 8 h 45 m producing an 8 KB output directory. Anyone planning the next campaign from
the current CLAUDE.md would repeat that.

## Contents (unchanged from a11b196)

- `REPLICATE_PEAK_GB=207`, itemised from job 20884022
- `parse_lfs_quota_kb()`, split out so the decision logic is testable without Lustre — an
  over-quota row marks values with `*` and inserts a grace column, which naive field-splitting
  mangles. Called without `-h` so values are plain KB.
- a pre-flight that refuses to start and names the directories to clear; advisory, never
  fatal, when the quota cannot be read. `SKIP_DISK_PREFLIGHT=1` overrides.
- CLAUDE.md corrected to 207 GB with the itemisation, plus the note that a **failed** replicate
  keeps all 207 GB because its FASTQ prune never runs.

## Evidence

Re-verified on this branch after the cherry-pick: 70 assertions, 20 mutations, 0 survivors.
Parser fixtures are verbatim Delta output including the over-quota row. Two must-not-fire cases
carry the weight: `-h` output must be **rejected** rather than read as kilobytes (`549.9G` as
549 KB would report ~550 TB free and wave through a full filesystem), and free space must clamp
to 0 rather than wrapping negative when usage exceeds the hard limit.

Still not verified on Delta — `lfs project`/`lfs quota` cannot run from this workstation, so the
extraction path around the parser degrades to a WARNING rather than a wrong answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)