### PR TITLE
feat(delta): verify planted insertions reach the reads before the BAMs are pruned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,24 @@ contig lengths).
   task 4 spending 8 h 45 m producing 8 KB against a full filesystem. Clear a failed
   replicate's directory before the next campaign, and clear finished ones down to
   `truvari_*/summary.json`, which is all `aggregate_sv_reps.sh` reads.
+- **Smoke first, and never learn a mechanism from a 16-hour run.** `sv_pipeline.sbatch`
+  defaults `REFERENCE` to `$SCRATCH/neat_data/chr22.fa` — use that default with
+  `SV_RATE_SCALE=20` for a fast run that plants every SV type and exercises every stage in
+  well under an hour. Only then spend GRCh38 at `SV_RATE_SCALE=1.0`, which is for *numbers*,
+  not for finding out whether the machinery works. Faster still: most read-level questions are
+  answerable on the H1N1 fixture in **seconds** via `eidolon/tests/sv_support_matrix.rs` — that
+  is where #516 was finally caught, after being chased through three multi-hour campaigns.
+  Ask "can a local test answer this?" before submitting anything long.
+
+- **Evaluate the BAMs before pruning them.** `prune_bams` reclaims ~98 GB per replicate, and
+  for three campaigns the pipeline produced BAMs, scored VCF-against-VCF, and deleted them
+  without ever asking whether the reads contained what the truth VCF declared. That is exactly
+  how #516 survived. `verify_planted_ins` now probes the reads for a 30-mer from the **middle**
+  of each planted insertion before anything is deleted (the middle, not the head — a partially
+  realized insertion has a perfectly good head). Any new SV type added to the pipeline wants
+  the same treatment: **a caller recall of 0 is uninterpretable until you know the evidence was
+  there to find.** `PRUNE_BAM=0` keeps the BAMs when a run is specifically diagnostic.
+
 - Staging: `fetch_validation_data.sh` (references), `stage_soy.sh` (align + call a
   self-consistent ref/BAM/VCF; `FULL_GENOME=1` for the whole-genome stress vs the
   fast single-chromosome default). `model_builders.sbatch` exercises the builders.

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -1391,6 +1391,107 @@ else
     [[ -n "$DELLY_SV" ]] && score_caller delly "$DELLY_SV"
 fi
 
+# Count, per probe, how many input SEQUENCES contain it or its reverse complement. Probes come
+# from a TSV (chrom, pos, inserted-length, probe); sequences arrive on stdin, one per line.
+# Split out from verify_planted_ins so the matching is testable without samtools or a BAM.
+count_probe_hits() {  # <probes.tsv>  < sequences
+    awk -v pf="$1" '
+        function rc(s,   i, o, c) {
+            o = ""
+            for (i = length(s); i >= 1; i--) {
+                c = substr(s, i, 1)
+                o = o (c == "A" ? "T" : c == "T" ? "A" : c == "C" ? "G" : c == "G" ? "C" : c)
+            }
+            return o
+        }
+        BEGIN {
+            FS = OFS = "\t"
+            while ((getline line < pf) > 0) {
+                split(line, f, "\t")
+                if (f[4] == "") continue
+                n++; chrom[n] = f[1]; pos[n] = f[2]; len[n] = f[3]
+                fwd[n] = f[4]; rev[n] = rc(f[4]); hits[n] = 0
+            }
+        }
+        { for (i = 1; i <= n; i++) if (index($0, fwd[i]) || index($0, rev[i])) hits[i]++ }
+        END { for (i = 1; i <= n; i++) print chrom[i], pos[i], len[i], hits[i] }
+    '
+}
+
+# READ-LEVEL verification of what we PLANTED, before anything is pruned.
+#
+# WHY THIS EXISTS: every campaign to date produced BAMs, scored VCF-against-VCF, and deleted
+# the BAMs without ever asking whether the reads contained what the truth VCF declared. #516
+# survived all of them that way — insertions above ~a read length are spliced in but only their
+# first ~100bp is sequenced, so campaign 20925151 reported Manta INS recall 1/22 and the
+# missing evidence was ours. A caller recall of 0 is uninterpretable until you know the
+# evidence was there to find.
+#
+# INS is what gets checked because the truth VCF carries the inserted sequence LITERALLY, so a
+# probe is derivable with no extra input and no assumptions. Reads carrying novel sequence are
+# either soft-clipped near the locus or have no reference home at all, so both the locus
+# neighbourhood and the unmapped pile are searched. Set VERIFY_INS_READS=0 to skip (the
+# unmapped scan streams the whole BAM — minutes, against a multi-hour run).
+verify_planted_ins() {  # <truth_sv.vcf.gz> <tumor.bam> <outdir>
+    local truth="$1" bam="$2" dir="$3"
+    [[ "${VERIFY_INS_READS:-1}" == "1" ]] || { echo "  (INS read verification skipped)"; return 0; }
+    [[ -f "$bam" ]] || { echo "  (no $bam — cannot verify INS at read level)" >&2; return 0; }
+
+    local probes="$dir/.ins_probes.tsv"
+    # ALT is anchor+novel for a literal insertion, so the inserted bases are ALT past REF's
+    # length. A 30-mer from the MIDDLE is the probe: it cannot come from the reference
+    # (~4^-30 by chance), and the middle is the part #516 showed is missing while the head
+    # is present — probing the head would report success on a partially-realized insertion.
+    bcftools query -f '%CHROM\t%POS\t%REF\t%ALT\n' -i 'INFO/SVTYPE="INS"' "$truth" 2>/dev/null \
+      | awk -F'\t' 'BEGIN{OFS="\t"} {
+            ins = substr($4, length($3) + 1); L = length(ins)
+            if (L < 30) next
+            s = int(L / 2) - 14; if (s < 1) s = 1
+            print $1, $2, L, substr(ins, s, 30)
+        }' > "$probes" || true
+
+    local n_probes; n_probes=$(wc -l < "$probes" 2>/dev/null || echo 0)
+    if [[ "$n_probes" -eq 0 ]]; then
+        echo "  INS read check: no INS record carries >=30bp of novel sequence — nothing to verify"
+        return 0
+    fi
+
+    local seqs="$dir/.ins_seqs.txt"
+    : > "$seqs"
+    while IFS=$'\t' read -r c p _ _; do
+        local lo=$(( p > 1000 ? p - 1000 : 1 ))
+        samtools view "$bam" "$c:$lo-$((p + 1000))" 2>/dev/null | cut -f10 >> "$seqs" || true
+    done < "$probes"
+    # A read lying wholly inside a large insertion has no reference home, so it lands here.
+    samtools view -@ 4 -f 4 "$bam" 2>/dev/null | cut -f10 >> "$seqs" || true
+
+    echo "  INS read-level support (30-mer from the MIDDLE of each inserted sequence):"
+    local supported=0 unsupported=0
+    while read -r c p l h; do
+        if [[ "${h:-0}" -gt 0 ]]; then
+            supported=$((supported + 1))
+            printf '    %s:%s  %s bp  %s read(s)\n' "$c" "$p" "$l" "$h"
+        else
+            unsupported=$((unsupported + 1))
+            printf '    %s:%s  %s bp  NO READ SUPPORT\n' "$c" "$p" "$l" >&2
+        fi
+    done < <(count_probe_hits "$probes" < "$seqs")
+
+    echo "  INS read support: $supported of $n_probes planted insertion(s) present in the reads"
+    if [[ "$unsupported" -gt 0 ]]; then
+        echo "ERROR: $unsupported of $n_probes planted insertion(s) have NO read evidence for" >&2
+        echo "  their declared length. Any INS recall reported above is a statement about our" >&2
+        echo "  own read generation, not about the caller — see #516. DEL/DUP/INV/BND/CNV are" >&2
+        echo "  unaffected." >&2
+        INS_UNSUPPORTED="$unsupported"
+    fi
+    rm -f "$seqs"
+}
+INS_UNSUPPORTED=0
+if [[ -f "$OUTDIR/truth_sv_INS.vcf.gz" ]]; then
+    verify_planted_ins "$OUTDIR/truth_sv_INS.vcf.gz" "$TUMOR_BAM" "$OUTDIR" || true
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────
 # Never print an unqualified "complete" over a run whose numbers are not usable — a
 # summary banner that reads as success regardless of outcome is how a bad run gets

--- a/scripts/delta/tests/test_scorer_calibration.sh
+++ b/scripts/delta/tests/test_scorer_calibration.sh
@@ -74,6 +74,8 @@ prune leaves the .bai files behind@rm -f "$dir"/normal.bam "$dir"/normal.bam.bai
 quota parser ignores the over-quota marker@gsub(/\\*/, "", used); gsub(/\\*/, "", hard)@;
 quota parser accepts non-numeric values@if (used ~ /^[0-9]+$/ && hard ~ /^[0-9]+$/) { print used, hard; found = 1 }@{ print used, hard; found = 1 }
 quota parser reads the soft limit as the cap@$1 == fs {@$1 == fs { $4 = $3 }
+probe matcher ignores the reverse strand@{ for (i = 1; i <= n; i++) if (index($0, fwd[i]) || index($0, rev[i])) hits[i]++ }@{ for (i = 1; i <= n; i++) if (index($0, fwd[i])) hits[i]++ }
+probe matcher drops zero-support probes@END { for (i = 1; i <= n; i++) print chrom[i], pos[i], len[i], hits[i] }@END { for (i = 1; i <= n; i++) if (hits[i] > 0) print chrom[i], pos[i], len[i], hits[i] }
 MUTATIONS
     printf '\n──────── %d mutation(s) survived ────────\n' "$survived"
     [[ "$survived" -eq 0 ]]
@@ -102,7 +104,7 @@ fi
 
 # ── Load the functions under test, verbatim ────────────────────────────────────
 extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
-for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams parse_lfs_quota_kb; do
+for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams parse_lfs_quota_kb count_probe_hits; do
     src="$(extract "$fn")"
     [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
     eval "$src"
@@ -400,6 +402,37 @@ is "over-hard-limit free space clamps to 0" 0 \
 kb="$(parse_lfs_quota_kb "$UNDER" /scratch)"
 is "under-quota free space is 306 GB" 306 \
    "$(( ( ${kb% *} > ${kb#* } ? 0 : ${kb#* } - ${kb% *} ) / 1048576 ))"
+
+echo "── count_probe_hits: read-level support for planted insertions ──"
+# KNOWN ANSWER, hand-built. Probe P1 appears forward in one sequence, P2 only reverse
+# complemented, P3 not at all. #516 is exactly the P3 case, so a probe reading zero must
+# report zero rather than being lost.
+P1=AAACCCGGGTTTAAACCCGGGTTTAAACCC          # 30bp
+P2=CGCGATATCGCGATATCGCGATATCGCGAT          # 30bp
+P3=TTTTGGGGCCCCAAAATTTTGGGGCCCCAA          # 30bp, absent
+rc() { printf '%s' "$1" | rev | tr ACGT TGCA; }
+printf 'chr1\t100\t500\t%s\nchr2\t200\t900\t%s\nchr3\t300\t1200\t%s\n' "$P1" "$P2" "$P3" \
+  > "$WORK/probes.tsv"
+{ printf 'GGGG%sGGGG\n' "$P1"
+  printf 'TTTT%sTTTT\n' "$P1"
+  printf 'AAAA%sAAAA\n' "$(rc "$P2")"
+  printf 'ACGTACGTACGTACGTACGTACGTACGTACGT\n'; } > "$WORK/seqs.txt"
+
+out="$(count_probe_hits "$WORK/probes.tsv" < "$WORK/seqs.txt")"
+is "forward-orientation probe counts both reads" "chr1	100	500	2" \
+   "$(grep -P '^chr1\t' <<<"$out")"
+# MUST NOT MISS: half of all reads are reverse complemented, so a matcher that only checks
+# the forward strand would silently halve every support count and could report 0 for a
+# genuinely present insertion.
+is "reverse-complemented probe is found"        "chr2	200	900	1" \
+   "$(grep -P '^chr2\t' <<<"$out")"
+# MUST NOT FIRE: an absent probe must be reported with 0, not dropped — a dropped row would
+# shrink the denominator and hide exactly the #516 case this exists to catch.
+is "absent probe is reported as zero, not dropped" "chr3	300	1200	0" \
+   "$(grep -P '^chr3\t' <<<"$out")"
+is "every probe appears in the output"          3 "$(wc -l <<<"$out")"
+is "no sequences at all still reports all probes" 3 \
+   "$(count_probe_hits "$WORK/probes.tsv" < /dev/null | wc -l)"
 
 printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Acts on two process failures the user identified:

> *"we have a lot of questions about the bams and I find that concerning... Why isn't the bam
> locked down with a shorter run?"* and *"if we're going to run 16 hours, at the very least add
> some bam evaluation before we delete them."*

Both are fair, and the second indicts #514: `prune_bams` reclaims ~98 GB per replicate and the
pipeline never once looked at what it was deleting.

## The gap

For three campaigns this pipeline produced BAMs, scored VCF-against-VCF, and deleted the BAMs
without asking whether the reads contained what the truth VCF declared. That is exactly how
#516 survived — insertions above ~a read length are spliced in but only their first ~100 bp is
sequenced. Campaign 20925151 reported Manta INS recall 1/22 and the missing evidence was ours.

**A caller recall of 0 is uninterpretable until you know the evidence was there to find.**

## The change

`verify_planted_ins()` runs after scoring and **before** `prune_bams`. INS is what it checks
because the truth VCF carries the inserted sequence literally, so a probe needs no extra input:
a 30-mer from each insertion, searched in the locus neighbourhood and in the unmapped pile (a
read lying wholly inside a large insertion has no reference home). It reports
supported/planted and fails loudly on any insertion with no read evidence for its declared
length.

Three design points that are each a lesson from this repo:

- **The MIDDLE of the insert, not the head.** #516's signature is a partially realized
  insertion whose head is in 27 reads at 600 bp while its interior is in zero. A head probe
  reports success on exactly the broken case.
- **Both strands.** Half of all reads are reverse complemented; a forward-only matcher would
  silently halve every count and could report 0 for a present insertion.
- **Zero-support probes are reported as zero, not dropped.** A dropped row shrinks the
  denominator and hides the case this exists to catch — the same
  metric-over-an-unstated-denominator failure as #457, #509 and #511.

## Evidence

`count_probe_hits` is split out from `verify_planted_ins` so the matching is testable without
samtools or a BAM. **75 assertions, 22 mutations, 0 survivors.** The two new mutations —
forward-strand-only matching, and dropping zero-support probes — are both caught.

## Process rule, in CLAUDE.md

- **Smoke first.** `sv_pipeline.sbatch` already defaults `REFERENCE` to `chr22.fa`; with
  `SV_RATE_SCALE=20` that plants every type and exercises every stage in well under an hour.
  GRCh38 at `SV_RATE_SCALE=1.0` is for *numbers*, not for finding out whether the machinery
  works.
- **Prefer the fixture.** Most read-level questions are answerable on H1N1 in **seconds** via
  `sv_support_matrix.rs`. #516 was chased through three multi-hour campaigns and then caught
  locally in six.
- **Evaluate the BAMs before pruning.** Any new SV type added to the pipeline wants the same
  read-level check.

## Not verified

`verify_planted_ins` has not run on Delta. `count_probe_hits` is proven against hand-built
fixtures; the samtools plumbing around it is unexercised. The unmapped scan streams the whole
BAM — minutes against a multi-hour run — and `VERIFY_INS_READS=0` skips it.

Worth noting the expected first result: with #516 open, this will **fail** on any campaign
planting insertions above ~a read length. That is the point. It should be read as the harness
finally reporting a defect that three campaigns silently absorbed, not as a new regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)