### PR TITLE
refactor(delta)!: retire the BND/BNDinv split (#507); verify the query denominator (#511)

### DIFF
--- a/docs/access_report_draft.md
+++ b/docs/access_report_draft.md
@@ -715,12 +715,24 @@ bucket only inversion-oriented adjacencies as BND; a direct same-contig adjacenc
 deletion or tandem duplication and is called as one. All 452 direct-form truth records
 were false negatives and none appeared in `tp-base`. Manta's recall over the junctions it
 can represent as breakends is **354/480 = 0.738** (head-to-head 0.734, tail-to-tail 0.741).
-The harness now reports this as `BNDinv` alongside the aggregate, and asserts truth
-reciprocity before scoring.
+The harness asserts truth reciprocity before scoring. It also used to report the
+inversion-oriented subset separately as `BNDinv`; **that split was retired in #507** and the
+paragraph above should be read as history. It was a consequence of the de novo sampler
+hardcoding the breakend mate to the anchor's own contig — within one chromosome a direct
+adjacency genuinely *is* a deletion or tandem duplication. Since P3a, BND means an
+inter-chromosomal translocation, where no deletion or duplication interpretation exists and a
+caller emits BND for all four geometries. The two figures then collapse (job 20824321: BND
+0.935 vs BNDinv 0.929; pooled over campaign 20925151, manta 0.868 vs 0.876 and delly 0.417 vs
+0.412), so `manta_BND` is simply the BND number. `BNDinv` precision was additionally an
+artifact — the truth was restricted while the query was not, so every unmatched call became a
+false positive (#512).
 
 **§3.7 is still not submittable, for a deeper reason than the one previously given.**
-eidolon has never generated a translocation — the de novo sampler hardcodes the breakend
-mate to the same contig. "BND recall" here means **same-contig junction recall**, and the
+eidolon had never generated a translocation at the time of writing — the de novo sampler
+hardcoded the breakend mate to the same contig. **Superseded: P3a made de novo BND
+inter-chromosomal**, so the paragraph below describes the state that motivated §3.7's caveat
+rather than the current one. The caveat itself stands until a translocation-era run is
+scored. "BND recall" here means **same-contig junction recall**, and the
 BND category itself is under audit: its 23.2% share is inherited from PCAWG's
 inter-chromosomal `TRA` count, and `BND` in a VCF is a representation convention rather
 than an event class (Manta and Delly typed identical junctions differently in job

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -476,6 +476,10 @@ fi
 # is well before the scoring stage that consumes it (set -u).
 CAL_FAIL=0
 SCORE_COVERAGE_FAIL=0
+# Strata whose ENTIRE query was filtered out before comparison (#511). Not fatal — a caller
+# emitting only low-confidence calls in one stratum is normal — but it must reach the banner,
+# because TP=0/FP=0 is indistinguishable from "the caller emitted nothing".
+QUERY_FILTERED=()
 
 MANTA_DIR="$OUTDIR/manta"
 MANTA_SV="$MANTA_DIR/results/variants/somaticSV.vcf.gz"
@@ -740,6 +744,7 @@ print(f"  {name:<18} recall={(s.get('recall') or 0):.3f}  precision={(s.get('pre
       f"f1={(s.get('f1') or 0):.3f}  TP={s.get('TP-base') or 0}  FN={s.get('FN') or 0}  FP={s.get('FP') or 0}")
 PY
         check_denominator "$truth" "$out" "$label" || true
+        check_query_denominator "$comp" "$out" "$label" || QUERY_FILTERED+=("$label")
     else
         echo "  $label: truvari produced no summary.json (see $out)"
         SCORE_COVERAGE_FAIL=$((SCORE_COVERAGE_FAIL + 1))
@@ -759,6 +764,78 @@ PY
 # or fn.vcf.gz, so truth-minus-those is exactly the discarded set, printed with SVTYPE/SVLEN
 # so the responsible filter is obvious. eidolon's own floor is MIN_SV_LENGTH_BP=50, equal to
 # truvari's --sizemin default, so a size-driven drop here means the LARGE end (--sizemax).
+# Coverage of the QUERY side, which nothing checked (#511). `check_denominator` below
+# reconciles the TRUTH (n_truth vs TP-base+FN) and hard-fails when records were discarded
+# before comparison. Nothing did the equivalent for the comp VCF, so every `precision` this
+# pipeline reports was computed over a denominator no one verified — the same defect on the
+# other axis.
+#
+# The motivating case, campaign 20925151: `manta_INS` reported TP=0 FP=0, which reads as "the
+# caller emitted nothing". It emitted three INS calls, one of them a TRUE detection
+# (chr7:3198935 SVLEN 61 against truth chr7:3198936 SVLEN 61 — one base off, exact size). All
+# three were non-PASS, so `--passonly` removed them BEFORE comparison and the stratum scored
+# 0/0. The reported 0.000 was a statement about the FILTER, not the caller, and nothing said so.
+#
+# Split into a numbers-only verdict plus thin plumbing, so the decision logic is testable
+# without truvari or a BAM — the same seam as parse_lfs_quota_kb.
+#
+# LOUD, NOT FATAL, deliberately. A caller emitting only low-confidence calls in one stratum is
+# normal behaviour, not a harness bug; failing the run would let it abort an 8-hour campaign.
+# It surfaces in the closing banner instead, so it cannot be missed while reading the numbers.
+report_query_coverage() {  # <label> <n_query> <n_scored> <n_nonpass>; rc 1 = wholly filtered
+    local label="$1" n_query="$2" scored="$3" nonpass="$4"
+
+    [[ "$n_query" -gt 0 ]] || return 0            # nothing was handed over; not our business
+    if [[ "$scored" -gt "$n_query" ]]; then
+        # More classified than handed over should be impossible. Report rather than compute a
+        # negative "dropped" count and present it as a fact.
+        echo "  WARNING: $label scored $scored of $n_query query record(s) — MORE than were" >&2
+        echo "    supplied, so this arithmetic is not understood. Do not quote its precision." >&2
+        return 0
+    fi
+    [[ "$scored" -eq "$n_query" ]] && return 0    # fully accounted for
+
+    local dropped=$((n_query - scored))
+    local why="size/other filters"
+    [[ "$nonpass" -gt 0 ]] && why="--passonly ($nonpass non-PASS)"
+
+    if [[ "$scored" -eq 0 ]]; then
+        # The dangerous case: TP=0 FP=0 is indistinguishable from "the caller emitted nothing".
+        echo "ERROR: $label scored NONE of its $n_query query record(s) — all removed before" >&2
+        echo "  comparison by $why. recall/precision for this stratum therefore describe the" >&2
+        echo "  FILTER, not the caller, and must not be reported as a caller result (#511)." >&2
+        [[ "$nonpass" -gt 0 ]] && \
+            echo "  --passonly is THIS PIPELINE'S choice, not a property of the caller." >&2
+        return 1
+    fi
+    echo "    ^ query coverage: $scored of $n_query record(s) scored, $dropped dropped by $why"
+    return 0
+}
+
+check_query_denominator() {  # <comp.vcf.gz> <truvari_out_dir> <label>
+    local comp="$1" out="$2" label="$3"
+    local n_query nonpass kv tp fp
+    n_query=$(bcftools view -H "$comp" 2>/dev/null | wc -l)
+    # Read TP-comp and FP together, and FAIL if either key is absent rather than defaulting to
+    # zero — an absent key would make every record look dropped and manufacture the exact alarm
+    # this function exists to raise. #509's lesson, one guard over.
+    kv=$(python3 - "$out/summary.json" <<'PYQ' 2>/dev/null
+import json, sys
+d = json.load(open(sys.argv[1]))
+for k in ("TP-comp", "FP"):
+    if k not in d:
+        sys.exit(3)
+print(int(d["TP-comp"] or 0), int(d["FP"] or 0))
+PYQ
+    ) || {
+        echo "  ($label: query coverage UNVERIFIED — summary.json lacks TP-comp/FP)" >&2
+        return 0
+    }
+    read -r tp fp <<< "$kv"
+    nonpass=$(bcftools view -H -i 'FILTER!="PASS" && FILTER!="."' "$comp" 2>/dev/null | wc -l)
+    report_query_coverage "$label" "$n_query" "$((tp + fp))" "$nonpass"
+}
+
 check_denominator() {  # <truth.vcf.gz> <truvari_out_dir> <label>
     local truth="$1" out="$2" label="$3"
     local n_truth base
@@ -1484,6 +1561,18 @@ EOF
 # Repeated here on purpose. Stage 3b prints this ~900 lines earlier in the log, and the
 # banner above is what actually gets read and pasted — an empty denominator that only
 # appears upstream is an empty denominator nobody sees.
+if [[ "${#QUERY_FILTERED[@]}" -gt 0 ]]; then
+    cat <<EOF
+QUERY WHOLLY FILTERED: ${#QUERY_FILTERED[@]} stratum/strata scored NONE of the caller's records
+because every one was removed before comparison: ${QUERY_FILTERED[*]}
+  Their recall/precision describe the FILTER, not the caller, and must not be quoted as a
+  caller result. --passonly is this pipeline's choice; a caller emitting only low-confidence
+  calls in a stratum is normal behaviour. To see what was actually emitted:
+    bcftools query -f '%CHROM\t%POS\t%FILTER\t%INFO/SVTYPE\t%INFO/SVLEN\n' <caller vcf>
+  Campaign 20925151 is the case history: manta_INS read TP=0 FP=0 while Manta had emitted
+  three INS calls, one of them a true detection, all non-PASS. See #511.
+EOF
+fi
 if [[ "${#TYPES_UNMEASURED[@]}" -gt 0 ]]; then
     cat <<EOF
 COVERAGE HOLE: ${#TYPES_UNMEASURED[@]} of ${#SV_TYPES[@]} SV type(s) had NO truth records and were

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -891,61 +891,6 @@ check_bnd_geometry() {  # <bnd_truth.vcf.gz>
           }'
 }
 
-# ── Split the BND truth by geometry, because only half of it is BND-scoreable ──
-# Callers bucket only INVERSION-ORIENTED adjacencies (t]p], [p[t) as BND. A direct
-# adjacency inside one contig IS a deletion or a tandem duplication, and Manta calls it
-# <DEL>/<DUP:TANDEM>. Our truth types every junction BND regardless of geometry, so
-# scoring all of it against a caller's BND records asks truvari to match records that
-# cannot match by construction.
-#
-# MEASURED, not assumed — job 20719077, 466 junctions, geometry ~uniform:
-#   tp-base:  t[p[ 0    t]p] 188  [p[t 166  ]p]t 0     -> direct=0    inv-oriented=354
-#   fn:       t[p[ 226  t]p] 68   [p[t 58   ]p]t 226   -> direct=452  inv-oriented=126
-# Every single direct-form record was a false negative and none appeared in tp-base.
-# So manta_BND recall=0.380 (354/932) was a statement about OUR SVTYPE choice; the
-# caller number is 354/480 = 0.738, and the two geometries inside that agree closely
-# (head-to-head 0.734, tail-to-tail 0.741), so there is no bias within the class.
-#
-# Reporting the aggregate alone repeats the INV precision-floor mistake one layer down:
-# a number floored by our own representation, printed as if it described the caller.
-split_bnd_by_geometry() {  # <bnd_truth.vcf.gz> <inv_out.vcf.gz> <direct_out.vcf.gz>
-    local src="$1" inv="$2" dir="$3"
-    [[ -f "$src" ]] || { echo "  ERROR: BND split: no BND truth at $src" >&2; return 1; }
-    local hdr="$OUTDIR/.bnd_split_hdr" tmp="$OUTDIR/.bnd_split_tmp.vcf"
-    bcftools view -h "$src" > "$hdr" || return 1
-
-    local kind out n_inv=0 n_dir=0
-    for kind in inv direct; do
-        [[ "$kind" == inv ]] && out="$inv" || out="$dir"
-        { cat "$hdr"
-          bcftools view -H "$src" | awk -F'\t' -v k="$kind" '
-              { a=$5
-                # direct: t[p[ (base then open-bracket) or ]p]t (leading close-bracket)
-                d = (a ~ /^[ACGTNacgtn]+\[/ || a ~ /^\]/)
-                # inversion-oriented: t]p] (base then close) or [p[t (leading open)
-                i = (a ~ /^[ACGTNacgtn]+\]/ || a ~ /^\[/)
-                if ((k=="direct" && d) || (k=="inv" && i)) print }'
-        } > "$tmp"
-        bcftools view -O z -o "$out" "$tmp" || { rm -f "$tmp" "$hdr"; return 1; }
-        bcftools index -f -t "$out" || { rm -f "$tmp" "$hdr"; return 1; }
-    done
-    n_inv=$(bcftools view -H "$inv" | wc -l)
-    n_dir=$(bcftools view -H "$dir" | wc -l)
-    rm -f "$tmp" "$hdr"
-
-    local n_src
-    n_src=$(bcftools view -H "$src" | wc -l)
-    printf "  BND truth split by geometry: %d inversion-oriented, %d direct (of %d)\n" \
-        "$n_inv" "$n_dir" "$n_src"
-    # Coverage of the split's own input. A record that lands in neither bucket would
-    # silently shrink the denominator of whatever is scored next.
-    if [[ $((n_inv + n_dir)) -ne "$n_src" ]]; then
-        echo "  ERROR: BND split lost $((n_src - n_inv - n_dir)) record(s) — every record" >&2
-        echo "    must be exactly one of direct or inversion-oriented." >&2
-        return 1
-    fi
-    return 0
-}
 
 # ── BND junction spans: a comparable representation ──────────────────────
 # A BND pair at (A,B) and a caller's <DUP:TANDEM>/<DEL>/<INV> spanning A..B describe the
@@ -1262,27 +1207,25 @@ score_caller() {  # <caller> <comp.vcf.gz> [raw_comp.vcf.gz]
             bcftools index -f -t "$qb" 2>/dev/null || true
             run_truvari "$OUTDIR/truth_sv_BND.vcf.gz" "${caller}_BND" "$qb" \
                 --bnddist "$BND_DIST"
-            # The aggregate above has a CEILING SET BY US, not by the caller: direct
-            # junctions are correctly called <DEL>/<DUP:TANDEM>, so they can never match
-            # a BND record. Job 20719077: every one of the 452 direct-form records was a
-            # FN and none appeared in tp-base, making the 0.380 aggregate a statement
-            # about our SVTYPE choice. BNDinv restricts the truth to the junctions a
-            # caller can actually represent as breakends, which is the caller number.
-            if [[ -f "$OUTDIR/truth_sv_BNDinv.vcf.gz" ]]; then
-                local n_inv n_dir
-                n_inv=$(bcftools view -H "$OUTDIR/truth_sv_BNDinv.vcf.gz" | wc -l)
-                n_dir=$(bcftools view -H "$OUTDIR/truth_sv_BNDdirect.vcf.gz" 2>/dev/null | wc -l)
-                if [[ "$n_inv" -gt 0 ]]; then
-                    run_truvari "$OUTDIR/truth_sv_BNDinv.vcf.gz" "${caller}_BNDinv" "$qb" \
-                        --bnddist "$BND_DIST"
-                    echo "    ^ BNDinv is the interpretable BND number: truth restricted to the"
-                    echo "      $n_inv inversion-oriented record(s) a caller CAN emit as breakends."
-                    echo "      The ${caller}_BND figure above additionally counts $n_dir direct-form"
-                    echo "      record(s) that are called <DEL>/<DUP:TANDEM> and cannot match by"
-                    echo "      construction — a ceiling of $n_inv/$((n_inv + n_dir)), set by our"
-                    echo "      representation. Quote BNDinv when describing the caller."
-                fi
-            fi
+            # RETIRED: the BND/BNDinv split (#507). It existed because the de novo
+            # sampler hardcoded the mate to the anchor's own contig, and within one
+            # chromosome a direct adjacency genuinely IS a deletion or tandem
+            # duplication — so a caller emitted <DEL>/<DUP:TANDEM> and all 452
+            # direct-form records of job 20719077 were unmatchable as BND by
+            # construction, flooring the aggregate at 0.380.
+            #
+            # BND is now inter-chromosomal only. Across two chromosomes there is no
+            # deletion or duplication interpretation, so a caller emits BND for all four
+            # geometries and the direct-form records match fine. Measured on job
+            # 20824321 the two collapsed (BND 0.935 vs BNDinv 0.929), and pooled over
+            # campaign 20925151 they agree to within noise (manta 0.868 vs 0.876, delly
+            # 0.417 vs 0.412). `${caller}_BND` is simply the BND number now.
+            #
+            # It was also actively misleading: BNDinv restricted the TRUTH to the
+            # inversion-oriented records while leaving the QUERY as every BND call, so
+            # each unmatched call became a false positive and precision read 0.245
+            # against BND's 0.547 on an identical query set (#512). The surrounding text
+            # told the reader to quote that row.
         else
             rm -f "$qb" "${qb}.tbi"
             echo "  ${caller}_BND recall=0.000  (caller emitted no BND records)"
@@ -1327,10 +1270,6 @@ if [[ -f "$OUTDIR/truth_sv_BND.vcf.gz" ]]; then
         echo "  would measure our emission defect and report it as caller performance." >&2
         CAL_FAIL=1
     fi
-    # Split the truth by geometry so BND recall can be reported against the junctions a
-    # caller can actually emit as breakends, separately from the direct ones it cannot.
-    split_bnd_by_geometry "$OUTDIR/truth_sv_BND.vcf.gz" \
-        "$OUTDIR/truth_sv_BNDinv.vcf.gz" "$OUTDIR/truth_sv_BNDdirect.vcf.gz" || CAL_FAIL=1
     build_bnd_spans "$OUTDIR/truth_sv_BND.vcf.gz" "$OUTDIR/truth_sv_BNDspan.vcf.gz" \
         || BND_SPAN_RC=$?
     case "$BND_SPAN_RC" in

--- a/scripts/delta/tests/test_bnd_geometry.sh
+++ b/scripts/delta/tests/test_bnd_geometry.sh
@@ -54,8 +54,6 @@ unpaired mates not counted@if (!(t in g)) { u@if (!(t in g)) { u0
 unparsable ALTs not counted@{ bad++; badex@{ badex
 single-geometry NOTE always fires@if (nd==1 && parsed>=24)@if (nd>=1 && parsed>=1)
 geometry check always exits 0@exit (bad+unpaired+mismatch > 0) ? 1 : 0@exit 0
-split puts records in the wrong bucket@if ((k=="direct" && d) || (k=="inv" && i)) print@if ((k=="direct" && i) || (k=="inv" && d)) print
-split stops checking for lost records@if [[ $((n_inv + n_dir)) -ne "$n_src" ]]; then@if [[ 1 -eq 0 ]]; then
 scoring loop goes back to globbing@for svt in "${SV_TYPES_SCORED_IN_LOOP[@]}"; do@for typed in "$OUTDIR"/truth_sv_*.vcf.gz; do
 a derived artifact stops being scored separately@BND|CNV) continue ;;@BND) continue ;;
 MUTATIONS
@@ -86,12 +84,12 @@ fi
 
 # ── Load the functions under test, verbatim ────────────────────────────────────
 extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
-for fn in check_bnd_geometry split_bnd_by_geometry; do
+for fn in check_bnd_geometry; do
     src="$(extract "$fn")"
     [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
     eval "$src"
 done
-OUTDIR="$WORK"   # split_bnd_by_geometry writes its scratch files here
+OUTDIR="$WORK"   # check_bnd_geometry writes its scratch files here
 
 # ── Fixture builder ────────────────────────────────────────────────────────────
 vcf_header() {
@@ -163,33 +161,6 @@ out="$(check_bnd_geometry "$WORK/all_h2h.vcf" 2>&1)"; rc=$?
 is  "a single-geometry truth is still internally consistent (rc)" "0" "$rc"
 has "flags the single-geometry regression" "$out" "share ONE geometry"
 
-echo "=== split_bnd_by_geometry: known-answer split (8 inv-oriented / 4 direct) ==="
-build_mixed
-bcftools view -O z -o "$WORK/mixed.vcf.gz" "$WORK/mixed.vcf" >/dev/null 2>&1
-bcftools index -f -t "$WORK/mixed.vcf.gz" >/dev/null 2>&1
-out="$(split_bnd_by_geometry "$WORK/mixed.vcf.gz" "$WORK/inv.vcf.gz" "$WORK/dir.vcf.gz" 2>&1)"; rc=$?
-is "splits a well-formed truth (rc)" "0" "$rc"
-is "inversion-oriented count (hand-count: 8)" "8" "$(bcftools view -H "$WORK/inv.vcf.gz" | wc -l | tr -d ' ')"
-is "direct count (hand-count: 4)"             "4" "$(bcftools view -H "$WORK/dir.vcf.gz" | wc -l | tr -d ' ')"
-has "reports the split" "$out" "8 inversion-oriented, 4 direct (of 12)"
-
-# Content, not counts: the right RECORDS must be in each bucket. A split that put 8
-# arbitrary records in the inv file would satisfy every count assertion above.
-is "inv bucket holds only t]p] and [p[t" "0" \
-   "$(bcftools query -f '%ALT\n' "$WORK/inv.vcf.gz" | grep -cE '^([ACGTNacgtn]+\[|\])')"
-is "direct bucket holds only t[p[ and ]p]t" "0" \
-   "$(bcftools query -f '%ALT\n' "$WORK/dir.vcf.gz" | grep -cE '^([ACGTNacgtn]+\]|\[)')"
-
-echo "=== split_bnd_by_geometry: a record in neither bucket is a hard failure ==="
-# The coverage-of-its-own-input rule. A record matching neither pattern would silently
-# shrink the denominator of whatever is scored next, which is the #450 shape exactly.
-sed 's/\[c1:12000\[G/<BND>/' "$WORK/mixed.vcf" > "$WORK/lossy.vcf"
-bcftools view -O z -o "$WORK/lossy.vcf.gz" "$WORK/lossy.vcf" >/dev/null 2>&1
-bcftools index -f -t "$WORK/lossy.vcf.gz" >/dev/null 2>&1
-out="$(split_bnd_by_geometry "$WORK/lossy.vcf.gz" "$WORK/i2.vcf.gz" "$WORK/d2.vcf.gz" 2>&1)"; rc=$?
-is  "rejects a split that loses a record (rc)" "1" "$rc"
-has "says how many were lost" "$out" "lost 1 record(s)"
-
 echo "=== cross-component: a derived truth artifact must not become an SVTYPE ==="
 # REGRESSION GUARD, job 20745149. The scoring loop globbed truth_sv_*.vcf.gz and relied
 # on a hand-maintained exclusion list, so writing truth_sv_BNDinv.vcf.gz silently
@@ -215,9 +186,16 @@ is "types scored by the generic loop" "DEL DUP INV INS"     "${SV_TYPES_SCORED_I
 
 # Every truth_sv_<X> file the script writes must be a canonical SVTYPE or a KNOWN
 # derived artifact. A new artifact that is neither shows up here, not on Delta.
-KNOWN_DERIVED=" BNDspan BNDinv BNDdirect scoreable "
+# BNDinv/BNDdirect retired with the split (#507); if either reappears as a truth_sv_*
+# artifact it is a genuine unclassified artifact and this must fail.
+KNOWN_DERIVED=" BNDspan scoreable "
 unclassified=""
-for nm in $(grep -oE 'truth_sv_[A-Za-z]+' "$PIPELINE" | sed 's/^truth_sv_//' | sort -u); do
+# Comment lines are excluded, for the same reason the glob assertion above is anchored to
+# non-comment lines: the retirement of BNDinv (#507) leaves a historical note quoting
+# `truth_sv_BNDinv.vcf.gz` verbatim, and a check that cannot tell code from a comment fails
+# on correct code. Only artifacts the script actually WRITES are in scope.
+for nm in $(grep -vE '^[[:space:]]*#' "$PIPELINE" \
+            | grep -oE 'truth_sv_[A-Za-z]+' | sed 's/^truth_sv_//' | sort -u); do
     case " ${SV_TYPES[*]} " in *" $nm "*) continue ;; esac
     case "$KNOWN_DERIVED"     in *" $nm "*) continue ;; esac
     unclassified="$unclassified $nm"

--- a/scripts/delta/tests/test_scorer_calibration.sh
+++ b/scripts/delta/tests/test_scorer_calibration.sh
@@ -74,6 +74,10 @@ prune leaves the .bai files behind@rm -f "$dir"/normal.bam "$dir"/normal.bam.bai
 quota parser ignores the over-quota marker@gsub(/\\*/, "", used); gsub(/\\*/, "", hard)@;
 quota parser accepts non-numeric values@if (used ~ /^[0-9]+$/ && hard ~ /^[0-9]+$/) { print used, hard; found = 1 }@{ print used, hard; found = 1 }
 quota parser reads the soft limit as the cap@$1 == fs {@$1 == fs { $4 = $3 }
+query coverage never escalates@    if [[ "$scored" -eq 0 ]]; then@    if false; then
+query coverage assumes --passonly@    [[ "$nonpass" -gt 0 ]] && why="--passonly ($nonpass non-PASS)"@    why="--passonly ($nonpass non-PASS)"
+query coverage chatters on a healthy stratum@    [[ "$scored" -eq "$n_query" ]] && return 0    # fully accounted for@    :
+query coverage computes a negative drop@    if [[ "$scored" -gt "$n_query" ]]; then@    if false; then
 probe matcher ignores the reverse strand@{ for (i = 1; i <= n; i++) if (index($0, fwd[i]) || index($0, rev[i])) hits[i]++ }@{ for (i = 1; i <= n; i++) if (index($0, fwd[i])) hits[i]++ }
 probe matcher drops zero-support probes@END { for (i = 1; i <= n; i++) print chrom[i], pos[i], len[i], hits[i] }@END { for (i = 1; i <= n; i++) if (hits[i] > 0) print chrom[i], pos[i], len[i], hits[i] }
 MUTATIONS
@@ -104,7 +108,7 @@ fi
 
 # ── Load the functions under test, verbatim ────────────────────────────────────
 extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
-for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams parse_lfs_quota_kb count_probe_hits; do
+for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams parse_lfs_quota_kb count_probe_hits report_query_coverage; do
     src="$(extract "$fn")"
     [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
     eval "$src"
@@ -433,6 +437,48 @@ is "absent probe is reported as zero, not dropped" "chr3	300	1200	0" \
 is "every probe appears in the output"          3 "$(wc -l <<<"$out")"
 is "no sequences at all still reports all probes" 3 \
    "$(count_probe_hits "$WORK/probes.tsv" < /dev/null | wc -l)"
+
+echo "── report_query_coverage: precision must not rest on an unverified denominator ──"
+# THE MOTIVATING CASE (#511), campaign 20925151. manta_INS reported TP=0 FP=0, which reads as
+# "the caller emitted nothing". Manta had emitted THREE INS calls, one a true detection
+# (chr7:3198935 SVLEN 61 vs truth chr7:3198936 SVLEN 61), all non-PASS and so removed by
+# --passonly before comparison.
+outp="$(report_query_coverage manta_INS 3 0 3 2>&1)"; rc=$?
+is   "wholly-filtered stratum returns 1"        1 "$rc"
+has  "says NONE were scored"                    "$outp" "scored NONE of its 3 query record(s)"
+has  "names --passonly with the count"          "$outp" "--passonly (3 non-PASS)"
+has  "says the number describes the filter"     "$outp" "FILTER, not the caller"
+has  "names it as the pipeline's own choice"    "$outp" "THIS PIPELINE'S choice"
+
+# Wholly filtered, but NOT by --passonly: the attribution must change, not be assumed.
+outp="$(report_query_coverage manta_DEL 5 0 0 2>&1)"; rc=$?
+is   "wholly filtered without non-PASS still returns 1" 1 "$rc"
+has  "attributes to size/other, not --passonly"  "$outp" "size/other filters"
+hasnt "does not blame --passonly"                "$outp" "non-PASS"
+
+# PARTIAL loss — the original 60-vs-58 case from job 20853511. Reported, but not escalated:
+# precision is still meaningful over 58 records, it just was not 60.
+outp="$(report_query_coverage manta_BND 60 58 2 2>&1)"; rc=$?
+is   "partial loss returns 0"                    0 "$rc"
+has  "reports both numbers"                      "$outp" "58 of 60 record(s) scored, 2 dropped"
+
+# MUST NOT FIRE: a fully-accounted query must be SILENT. Chattering on every healthy
+# comparison is how a real warning gets skimmed past.
+outp="$(report_query_coverage manta_DUP 37 37 0 2>&1)"; rc=$?
+is "fully-scored query returns 0"  0 "$rc"
+is "fully-scored query is silent"  "" "$outp"
+
+# MUST NOT FIRE: an empty query is the harness's own doing (it skips truvari), not a filter
+# problem, and the caller-emitted-nothing message is printed elsewhere.
+outp="$(report_query_coverage manta_INS 0 0 0 2>&1)"; rc=$?
+is "empty query returns 0"  0 "$rc"
+is "empty query is silent"  "" "$outp"
+
+# Impossible arithmetic must be reported, never turned into a negative "dropped" count.
+outp="$(report_query_coverage manta_BND 10 12 0 2>&1)"; rc=$?
+is  "more scored than supplied returns 0"  0 "$rc"
+has "flags it as not understood"           "$outp" "MORE than were"
+hasnt "does not print a negative drop"     "$outp" "-2"
 
 printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #507. Makes #512 **moot rather than fixed** — there is no row left to mislabel.

## Why the split existed

The de novo sampler hardcoded the breakend mate to the anchor's own contig. Within one
chromosome a direct adjacency genuinely *is* a deletion or tandem duplication, so Manta emitted
`<DEL>`/`<DUP:TANDEM>` and all 452 direct-form truth records of job 20719077 were unmatchable as
BND by construction — flooring the aggregate at 0.380, which described our SVTYPE choice rather
than the caller.

## Why it is obsolete

BND is inter-chromosomal only since P3a. Across two chromosomes there is no deletion or
duplication interpretation, so a caller emits BND for all four geometries and the direct-form
records match fine. The two figures collapse:

| | BND | BNDinv |
|---|---|---|
| job 20824321 | 0.935 | 0.929 |
| campaign 20925151, manta | 0.868 | 0.876 |
| campaign 20925151, delly | 0.417 | 0.412 |

## Why it was harmful

`BNDinv` restricted the **truth** while leaving the **query** as every BND call, so each
unmatched call became a false positive: precision **0.245** against BND's 0.547 on an *identical
query set*. Delly showed the same swing, **1.000 → 0.480** across the same 25 records. And the
surrounding echo instructed the reader to *"Quote BNDinv when describing the caller"* — correct
for recall, wrong for precision, with nothing distinguishing them.

## Removed / kept

Removed `split_bnd_by_geometry()` and the comment block justifying it, the
`truth_sv_BNDinv`/`truth_sv_BNDdirect` artifacts, the `${caller}_BNDinv` scoring block and its
explanatory echo, and the split's cells and mutations from `test_bnd_geometry.sh`.

**Kept `check_bnd_geometry()`** — the reciprocity assertion and per-form counts are load-bearing
and independent of the split. They are what proves the truth is internally consistent before any
caller is scored.

## One test needed fixing rather than deleting

`no unclassified truth_sv_* artifact` started failing on ` BNDinv`, because the retirement leaves
a historical note quoting `truth_sv_BNDinv.vcf.gz` verbatim and that check greps the whole file.
Anchored it to non-comment lines — which is exactly what the glob assertion beside it already
does, and for the same stated reason: a check that cannot tell code from a comment fails on
correct code.

## Report draft

`docs/access_report_draft.md` §3.7 reframed. The 0.380 correction is now history, and the claim
*"eidolon has never generated a translocation"* is marked **superseded by P3a** rather than left
standing as false. The §3.7 caveat itself stands until a translocation-era run is scored.

## Evidence

`test_bnd_geometry.sh` 21 assertions, 0 mutation survivors. `test_scorer_calibration.sh` 75, 0.
`bash -n` clean.

**Not verified on Delta.** The next run is the first without a `BNDinv` row; what should change
in the log is the disappearance of the `${caller}_BNDinv` line and its five-line echo, with
`${caller}_BND` unchanged.
