### PR TITLE
fix(delta): scale the disk gate by genome size and coverage instead of a flat 214 GB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,9 @@ contig lengths).
   the **project quota** — check it with
   `lfs quota -h -p <projid> /work/nvme`, and read `Disk quota exceeded` literally.
   Measured footprint for `sv_pipeline.sbatch` on GRCh38 at 30x: **~214 GB peak per
-  replicate**, itemised from job 20884022 — FASTQ 116 GB (merged 29+29, tumor 17+17,
+  replicate** — the pipeline's disk gate scales this by genome size and coverage, so chr22 at
+  30x asks for the 5 GB floor rather than 214 (a constant would have refused every smoke run
+  once `/scratch` passed 336 GB used). Itemised from job 20884022 — FASTQ 116 GB (merged 29+29, tumor 17+17,
   normal 12+12) **plus** BAMs 98 GB (the figure `prune_bams` itself reported across
   campaign 20925151), which coexist because pruning only runs at the end. An earlier
   "~113 GB" figure here counted the FASTQ only and was wrong; every capacity estimate built on it was ~half of reality. With a ~171 GB fixed

--- a/scripts/delta/sv_pipeline.sbatch
+++ b/scripts/delta/sv_pipeline.sbatch
@@ -207,13 +207,47 @@ check_binary_provenance "${EIDOLON_VERSION:-}" "$REPO_ROOT" || exit 1
 # and the log gave no way to see how close the preceding replicates had come. Printed RAW
 # and never parsed: `df` misreports inside a project-quota'd directory (it shows the quota,
 # not the mount), the quota table and df have disagreed for /scratch, and a guard built on
-# fragile parsing is worse than no guard. One replicate needs ~113 GB peak (30 GB normal
-# BAM + 71 GB tumor + FASTQ held together at the merge), measured on job 20892075.
-# Peak footprint of ONE replicate: FASTQ 116 GB (merged 29+29, tumor 17+17, normal 12+12,
-# itemised from job 20884022) plus BAMs 98 GB (the figure prune_bams itself reported across
-# campaign 20925151), coexisting because the prune only runs at the end. A previous "113 GB"
-# figure in CLAUDE.md counted the FASTQ alone and was half of reality.
-REPLICATE_PEAK_GB="${REPLICATE_PEAK_GB:-214}"
+# fragile parsing is worse than no guard.
+#
+# Peak footprint of ONE replicate, ANCHORED on the only full measurement available: ~214 GB for
+# GRCh38 (3.1 Gbp) at 30x — FASTQ 116 GB (merged 29+29, tumor 17+17, normal 12+12, itemised from
+# job 20884022) plus BAMs 98 GB (the figure prune_bams itself reported across campaign 20925151),
+# coexisting because the prune only runs at the end. An earlier "113 GB" figure counted the FASTQ
+# alone and was half of reality.
+#
+# SCALED, not constant. Both FASTQ and BAM grow with genome size x coverage, so a fixed 214 GB
+# demanded 61x more than a chr22 replicate actually needs (~3.5 GB) and would have refused every
+# smoke run once /scratch passed 336 GB used — breaking the smoke-first workflow exactly when
+# disk is tight and a cheap run matters most. Job 21035422 passed only because 343 GB happened to
+# be free.
+scaled_replicate_peak_gb() {  # <reference_bp> <coverage>; echoes whole GB
+    awk -v bp="$1" -v cov="$2" 'BEGIN {
+        # Cannot scale -> assume the worst rather than wave a run through. "Unknown" must not
+        # read as "small", which is the same rule as the calibration controls.
+        if (bp <= 0 || cov <= 0) { print 214; exit }
+        gb = 214.0 * (bp / 3100000000.0) * (cov / 30.0)
+        # Floor: below this the reference index, Manta workspace and temp files dominate and the
+        # read-proportional model understates the real need.
+        if (gb < 5) gb = 5
+        printf "%d", (gb == int(gb) ? gb : int(gb) + 1)
+    }'
+}
+
+# Reference size in bases. Prefers the .fai (exact); falls back to the FASTA byte count, which is
+# a fine proxy for a capacity gate (~60 bases per 61 bytes with newlines) and — unlike the .fai —
+# always exists, since the index is not built until stage 2.
+reference_bp() {  # <reference.fa>
+    local ref="$1" bytes
+    if [[ -s "$ref.fai" ]]; then
+        awk '{s += $2} END {print s + 0}' "$ref.fai"
+        return
+    fi
+    bytes=$(stat -c %s "$ref" 2>/dev/null || echo 0)
+    awk -v b="$bytes" 'BEGIN {printf "%d", b * 0.98}'
+}
+
+REPLICATE_PEAK_GB="${REPLICATE_PEAK_GB:-$(scaled_replicate_peak_gb \
+    "$(reference_bp "$REFERENCE")" "$TOTAL_COVERAGE")}"
 
 # Extract used/limit in KB from `lfs quota -p` output. Separated from the check so the
 # decision logic is testable without Lustre: the parsing is the fragile half, and the real

--- a/scripts/delta/tests/test_scorer_calibration.sh
+++ b/scripts/delta/tests/test_scorer_calibration.sh
@@ -78,6 +78,10 @@ query coverage never escalates@    if [[ "$scored" -eq 0 ]]; then@    if false; 
 query coverage assumes --passonly@    [[ "$nonpass" -gt 0 ]] && why="--passonly ($nonpass non-PASS)"@    why="--passonly ($nonpass non-PASS)"
 query coverage chatters on a healthy stratum@    [[ "$scored" -eq "$n_query" ]] && return 0    # fully accounted for@    :
 query coverage computes a negative drop@    if [[ "$scored" -gt "$n_query" ]]; then@    if false; then
+peak is a constant again@        gb = 214.0 * (bp / 3100000000.0) * (cov / 30.0)@        gb = 214.0
+peak ignores coverage@ * (cov / 30.0)@ * 1.0
+unknown reference size reads as small@        if (bp <= 0 || cov <= 0) { print 214; exit }@        if (bp <= 0 || cov <= 0) { print 5; exit }
+reference_bp ignores the .fai@    if [[ -s "$ref.fai" ]]; then@    if false; then
 probe matcher ignores the reverse strand@{ for (i = 1; i <= n; i++) if (index($0, fwd[i]) || index($0, rev[i])) hits[i]++ }@{ for (i = 1; i <= n; i++) if (index($0, fwd[i])) hits[i]++ }
 probe matcher drops zero-support probes@END { for (i = 1; i <= n; i++) print chrom[i], pos[i], len[i], hits[i] }@END { for (i = 1; i <= n; i++) if (hits[i] > 0) print chrom[i], pos[i], len[i], hits[i] }
 MUTATIONS
@@ -108,7 +112,7 @@ fi
 
 # ── Load the functions under test, verbatim ────────────────────────────────────
 extract() { awk "/^$1\(\)/,/^}\$/" "$PIPELINE"; }
-for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams parse_lfs_quota_kb count_probe_hits report_query_coverage; do
+for fn in truvari_metric selftest_truvari decoy_truvari check_denominator split_truth_by_type check_binary_provenance prune_bams parse_lfs_quota_kb count_probe_hits report_query_coverage scaled_replicate_peak_gb reference_bp; do
     src="$(extract "$fn")"
     [[ -n "$src" ]] || { echo "FATAL: could not extract $fn from $PIPELINE"; exit 2; }
     eval "$src"
@@ -479,6 +483,35 @@ outp="$(report_query_coverage manta_BND 10 12 0 2>&1)"; rc=$?
 is  "more scored than supplied returns 0"  0 "$rc"
 has "flags it as not understood"           "$outp" "MORE than were"
 hasnt "does not print a negative drop"     "$outp" "-2"
+
+echo "── scaled_replicate_peak_gb: the gate must not over-demand on a small reference ──"
+# ANCHOR, measured: 214 GB for GRCh38 (3.1 Gbp) at 30x. Everything else scales from it, because
+# both FASTQ and BAM grow with genome size x coverage.
+is "GRCh38 at 30x reproduces the anchor" 214 "$(scaled_replicate_peak_gb 3100000000 30)"
+is "double the coverage doubles it"      428 "$(scaled_replicate_peak_gb 3100000000 60)"
+is "half the genome halves it"           107 "$(scaled_replicate_peak_gb 1550000000 30)"
+
+# THE REGRESSION THIS EXISTS FOR. A constant 214 demanded 61x what a chr22 replicate needs and
+# would have refused every smoke run once /scratch passed 336 GB used — breaking the
+# smoke-first workflow precisely when disk is tight.
+is "chr22 at 30x is bounded by the floor, not 214" 5 "$(scaled_replicate_peak_gb 50818468 30)"
+is "a tiny reference still gets the floor"          5 "$(scaled_replicate_peak_gb 100000 30)"
+
+# MUST NOT FIRE: an unmeasurable reference must assume the WORST, not the smallest. "Unknown"
+# reading as "small" would wave through a run that cannot fit — the same rule as the
+# calibration controls.
+is "unknown size falls back to the full anchor" 214 "$(scaled_replicate_peak_gb 0 30)"
+is "unknown coverage falls back too"           214 "$(scaled_replicate_peak_gb 3100000000 0)"
+
+echo "── reference_bp: exact from .fai, proxy from the FASTA ──"
+printf 'c1\t1000\t0\t60\t61\nc2\t2500\t0\t60\t61\n' > "$WORK/r.fa.fai"
+: > "$WORK/r.fa"
+is "sums contig lengths from the .fai" 3500 "$(reference_bp "$WORK/r.fa")"
+# No .fai (the index is not built until stage 2), so fall back to the byte count.
+rm -f "$WORK/r.fa.fai"
+head -c 10000 /dev/zero > "$WORK/r.fa"
+is "falls back to ~0.98x the FASTA bytes" 9800 "$(reference_bp "$WORK/r.fa")"
+is "a missing reference reports 0 (-> worst case)" 0 "$(reference_bp "$WORK/nope.fa")"
 
 printf '\n──────── %d passed, %d failed ────────\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Follow-up to #520, from the first live run of the disk pre-flight (job 21035422).

## The gate worked, then showed its flaw

It parsed real Lustre output correctly on the first try:

```
── disk pre-flight (one replicate needs ~214 GB peak) ──
        /scratch  206.4G     500G    550G       -   34084 ...
  free before start: 343 GB (need ~214 GB)
```

343 = 550 − 206.4, exactly right. **But it demanded 214 GB for a chr22 replicate that needs about
3.5 GB** — a 61× over-demand that passed only because 343 GB happened to be free. Once `/scratch`
exceeds 336 GB used it would refuse every smoke run, breaking the smoke-first workflow precisely
when disk is tight and a cheap run matters most.

## Scaled from the one measurement available

FASTQ and BAM both grow with genome size × coverage, so the requirement scales off the GRCh38/30×
anchor of 214 GB:

| reference | coverage | demanded |
|---|---|---|
| GRCh38 (3.1 Gbp) | 30× | 214 GB (the anchor) |
| GRCh38 | 60× | 428 GB |
| chr22 (50.8 Mbp) | 30× | **5 GB** (floor) |
| unmeasurable | — | **214 GB** |

**Floored at 5 GB**, because below that the reference index, Manta workspace and temp files
dominate and a read-proportional model understates the real need.

**An unmeasurable reference falls back to the full 214, not the floor.** "Unknown" must not read as
"small" — that would wave through a run that cannot fit. Same rule as the calibration controls, and
it's a must-not-fire test rather than a comment.

`reference_bp` prefers the `.fai` (exact) and falls back to the FASTA byte count. The fallback
isn't a nicety: the index isn't built until stage 2, so on a fresh reference the `.fai` doesn't
exist when the gate runs.

## Also: a retracted claim left next to its own correction

`sv_pipeline.sbatch` still carried *"One replicate needs ~113 GB peak … measured on job 20892075"*
directly above the 214 GB text that retracts it. Removed — that's exactly the stale-copy pattern
rule 3 warns about, and it survived two passes over this file.

## Evidence

**102 assertions, 29 mutations, 0 survivors.** The four new mutations cover reverting to a
constant, ignoring coverage, letting an unknown reference read as small, and ignoring the `.fai`.

## Not verified

The scaled value hasn't run on Delta. What should change in the next chr22 log is the header
reading `one replicate needs ~5 GB peak` instead of `~214`.
