### PR TITLE
docs(delta): link with gcc, not the Cray cc wrapper — and say why

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,33 @@ contig lengths).
   gone 2026-08-02), so **do not check for it**; a search there wastes a round trip and
   its absence is not evidence a run is missing.
 
+- **Building on Delta: link with `gcc`, never the Cray `cc` wrapper.** Delta's site-wide
+  `default` module set loads `PrgEnv-gnu` alongside **`craype-accel-nvidia80`**, which points
+  the Cray driver at NVIDIA A100s. `cc` then builds its link line from pkg-config's
+  `virtual:world`, dragging in a CUDA runtime plus `cray-mpich`, `cray-libsci`, `cray-dsmml`
+  and `libfabric`. **eidolon uses none of them** — it is pure Rust plus zlib-ng/libdeflate via
+  cmake. After the RHEL/PE upgrade that world named `cray-sdk-cudatoolkit-25.3_11.8`, whose
+  `.pc` file is gone, and `cc` refused to link anything at all — a hello-world included:
+  ```
+  Package 'cray-sdk-cudatoolkit-25.3_11.8', required by 'virtual:world', not found
+  ```
+  Nobody loaded those modules; they come from `default`, which is why this appeared overnight
+  with no local change (2026-08-12). Build with:
+  ```bash
+  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc \
+    CARGO_TARGET_DIR=$SCRATCH/cargo-target/eidolon cargo build --release
+  ```
+  `setup.sh` now exports this. `module unload craype-accel-nvidia80` also clears it but does
+  **not** persist — `default` reloads at every login. Note rustc already links with its own
+  bundled `lld`; `cc` only ever supplied a driver front-end.
+  **Symptom to recognise:** every dependency *build script* fails to link on a fresh
+  `CARGO_TARGET_DIR`, while a cached target dir gets all the way to the final binary and fails
+  there. Same cause; the cache only changes where it surfaces.
+  **`CARGO_TARGET_DIR` must be `$SCRATCH/cargo-target/eidolon`** — the pipeline reads
+  `$CARGO_TARGET_DIR/release/eidolon` and nothing else. Building into any other path (e.g. the
+  pre-rename `cargo-target/rneat-*`) leaves the old binary in place; #514's provenance guard
+  now catches that at job start rather than letting it produce stale numbers.
+
 - **The Delta checkout is a separate working copy and goes stale silently.** A queued job
   runs the script as it was when the job *started*, which on a busy queue can be days after
   it was submitted — so a result can predate a fix you believe is in it. Establish the SHA

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,12 @@ contig lengths).
   CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc \
     CARGO_TARGET_DIR=$SCRATCH/cargo-target/eidolon cargo build --release
   ```
-  `setup.sh` now exports this. `module unload craype-accel-nvidia80` also clears it but does
-  **not** persist — `default` reloads at every login. Note rustc already links with its own
-  bundled `lld`; `cc` only ever supplied a driver front-end.
+  `setup.sh` now exports this. **Confirmed working 2026-08-12.** Note rustc already links with
+  its own bundled `lld`; `cc` only ever supplied a driver front-end.
+  What does NOT work: **`module unload cudatoolkit/25.3_11.8` alone — measured, still fails.**
+  It removes the package while leaving `craype-accel-nvidia80`, the module that demands it.
+  Unloading `craype-accel-nvidia80` instead is untested; it should work by the same reasoning,
+  but it would not persist anyway since `default` reloads at every login.
   **Symptom to recognise:** every dependency *build script* fails to link on a fresh
   `CARGO_TARGET_DIR`, while a cached target dir gets all the way to the final binary and fails
   there. Same cause; the cache only changes where it surfaces.

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -75,6 +75,28 @@ if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
         echo "      is current. If a pull failed earlier, you may be building stale code." >&2
     fi
 fi
+# LINK WITH gcc, NOT the Cray `cc` wrapper.
+#
+# Delta's site-wide `default` module set loads PrgEnv-gnu together with
+# craype-accel-nvidia80, which tells the Cray compiler driver to target NVIDIA A100s. `cc`
+# then composes its link line from pkg-config's `virtual:world`, which pulls in a CUDA
+# runtime plus cray-mpich, cray-libsci, cray-dsmml and libfabric. eidolon uses NONE of
+# those — it is pure Rust plus zlib-ng/libdeflate via cmake.
+#
+# After the RHEL/PE upgrade that world referenced cray-sdk-cudatoolkit-25.3_11.8, whose .pc
+# file is absent, so `cc` refused to link ANYTHING — including a hello-world, and including
+# every dependency build script. Every build failed with "Package 'cray-sdk-cudatoolkit...',
+# required by 'virtual:world', not found" (2026-08-12).
+#
+# `module unload craype-accel-nvidia80` also clears it, but does not persist: `default`
+# reloads at every login, and the next change to the site's default set brings it back. This
+# is immune to that. rustc already does the real linking with its own bundled lld
+# (-fuse-ld=lld); `cc` was only ever supplying a driver front-end that insisted on resolving
+# a GPU stack we do not use. gcc-native/13.2 is in the default set, so `gcc` is present.
+#
+# Override CARGO_LINKER=cc to go back to the wrapper if a future PE actually needs it.
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CARGO_LINKER:-gcc}"
+echo "      Linker: $CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER (see the comment above; Cray cc pulls in CUDA)"
 cargo build --release 2>&1 | tail -5
 echo "      Binary: $CARGO_TARGET_DIR/release/eidolon"
 # Report the version actually produced. This is the line whose absence cost a run.

--- a/scripts/delta/setup.sh
+++ b/scripts/delta/setup.sh
@@ -88,11 +88,13 @@ fi
 # every dependency build script. Every build failed with "Package 'cray-sdk-cudatoolkit...',
 # required by 'virtual:world', not found" (2026-08-12).
 #
-# `module unload craype-accel-nvidia80` also clears it, but does not persist: `default`
-# reloads at every login, and the next change to the site's default set brings it back. This
-# is immune to that. rustc already does the real linking with its own bundled lld
-# (-fuse-ld=lld); `cc` was only ever supplying a driver front-end that insisted on resolving
-# a GPU stack we do not use. gcc-native/13.2 is in the default set, so `gcc` is present.
+# Confirmed working 2026-08-12. Unloading cudatoolkit ALONE was measured and still fails — it
+# removes the package while leaving craype-accel-nvidia80, which is what demands it. Unloading
+# craype-accel-nvidia80 instead is untested, and would not persist regardless: `default`
+# reloads at every login. This export is immune to that. rustc already does the real linking
+# with its own bundled lld (-fuse-ld=lld); `cc` was only ever supplying a driver front-end
+# that insisted on resolving a GPU stack we do not use. gcc-native/13.2 is in the default
+# set, so `gcc` is present.
 #
 # Override CARGO_LINKER=cc to go back to the wrapper if a future PE actually needs it.
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CARGO_LINKER:-gcc}"


### PR DESCRIPTION
Every build on Delta started failing on 2026-08-12 with:

```
Package 'cray-sdk-cudatoolkit-25.3_11.8', required by 'virtual:world', not found
```

Nothing in eidolon changed, and no module was loaded by hand.

## Cause

Delta's site-wide `default` module set loads `PrgEnv-gnu` alongside **`craype-accel-nvidia80`**,
which points the Cray compiler driver at NVIDIA A100s. `cc` then composes its link line from
pkg-config's `virtual:world`, dragging in a CUDA runtime plus `cray-mpich`, `cray-libsci`,
`cray-dsmml` and `libfabric`. **eidolon uses none of them** — it's pure Rust plus
zlib-ng/libdeflate via cmake.

After the RHEL/PE upgrade that world named a cudatoolkit whose `.pc` file is absent, so `cc`
refused to link *anything* — a hello-world included. All fourteen loaded modules came from
`default`, which is why this appeared overnight with no local change.

## Fix

Link with `gcc` directly. `setup.sh` now exports it; CLAUDE.md's Delta section documents it.
`gcc-native/13.2` is already in the default set.

```bash
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc \
  CARGO_TARGET_DIR=$SCRATCH/cargo-target/eidolon cargo build --release
```

This is the correct configuration rather than a workaround: rustc already performs the real
linking with its own bundled `lld` (`-fuse-ld=lld` appears in the failing command line), and `cc`
only ever supplied a driver front-end that insisted on resolving a GPU stack we never touch.
`CARGO_LINKER=cc` restores the wrapper if a future PE genuinely needs it.

`module unload craype-accel-nvidia80` also clears it — and is the faster confirmation the
diagnosis is right — but it does **not persist**: `default` reloads at every login.

## Two recognition aids, because the symptom misleads

- On a **fresh** `CARGO_TARGET_DIR` every dependency *build script* fails to link, ten at once,
  which reads as catastrophic. On a **cached** target dir the build reaches the final binary and
  fails there. Same cause; the cache only moves where it surfaces. Chasing that difference cost
  most of a session.
- `CARGO_TARGET_DIR` **must** be `$SCRATCH/cargo-target/eidolon`. The pipeline reads
  `$CARGO_TARGET_DIR/release/eidolon` and nothing else, so building into another path — e.g. the
  pre-rename `cargo-target/rneat-*` — silently leaves the old binary in place. #514's provenance
  guard now catches that at job start rather than letting it publish stale numbers.

## Scope

Docs and `setup.sh` only; no behaviour change, suites unaffected (102 assertions green).

**Not verified by me:** which of the two remedies was actually applied when the build succeeded.
Both are documented, with the env var recommended as the durable one — happy to trim this to
whichever it was.
