### PR TITLE
chore(gitignore): ignore JetBrains Junie's .junie/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # AI junk
 .mcp.json
 /gnomad_validation_work/
+/.junie/
 
 # Test drift dumps (written by model_parity when a baseline mismatches)
 *.canonical.actual.json


### PR DESCRIPTION
Junie (the JetBrains AI assistant) writes a `.junie/memory/` tree into the repo root, which showed up as untracked noise and tripped the "1 uncommitted change" warning on `gh pr create`.

One line, filed under the existing **AI junk** heading next to `.mcp.json` rather than beside `/.idea/` — it's assistant state, not IDE configuration.

**Nothing to purge from history.** Verified before deleting anything:

- `git log --all -- .junie .junie/**` → empty, so it was never committed on any branch;
- a `git ls-tree -r` sweep over every remote branch → no hits.

The local copy contained only empty scaffolding — `errors.md`, `feedback.md` and `tasks.md` all 0 bytes, `language.json` holding `[]`, and `memory.version` holding `3.0` — and has been removed from the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)