### PR TITLE
test(seq-error): assert the transition matrix's content, not that a file appeared

### DIFF
--- a/docs/transition_matrix_validation_plan.md
+++ b/docs/transition_matrix_validation_plan.md
@@ -1,0 +1,154 @@
+# SNP transition matrix — validation status and Delta plan
+
+Status: **local tier complete; Delta tier specified and NOT yet run** (2026-08-12).
+
+Covers `gen-seq-error-model`'s `bam_file:` / `transition_matrix_file:` inputs — the
+BAM-derived SNP substitution matrix, which is one of the few model-builder capabilities
+with no counterpart in NEAT 4 (its builders never open a BAM for this). Because it is
+cited as a differentiator in the README comparison table, the evidence behind it should be
+stated rather than assumed.
+
+## Why this document exists
+
+The feature shipped with tests that asserted only that a file appeared and deserialized.
+Three of them constructed a known answer — an all-A→C BAM, a 10/5/5 count matrix — and
+then asserted nothing about it. One said so in its own comment: *"We can't easily inspect
+the matrix after serialization, so just verify that the runner completes."* Under that
+coverage the matrix could have been garbage, or the default, or transposed, and every test
+would have passed.
+
+That is rule 1 in `CLAUDE.md` (assert content, not existence), and it had gone unnoticed
+because the code is in fact correct. A correct implementation with vacuous tests reads
+exactly like a verified one until something changes.
+
+## What is now proven locally
+
+Six unit tests in `eidolon/src/gen_seq_error_model/utils/runner.rs` and one output-fidelity
+test in `eidolon/tests/model_output_fidelity.rs`:
+
+| Claim | Test |
+|---|---|
+| MD-tagged mismatches produce the matching row | `test_runner_with_bam_md_tags_puts_all_a_weight_on_c` |
+| Multi-target, asymmetric patterns are fitted per row | `test_runner_bam_transitions_track_a_mixed_mismatch_pattern` |
+| The ref/read axes are not swapped | `test_build_transition_matrix_from_counts_is_not_transposed` |
+| Observed counts drive the fitted row | `test_build_transition_matrix_from_counts_uniform_fallback` |
+| A TSV overrides a BAM | `test_tsv_takes_precedence_over_bam` |
+| No MD tags → default matrix, not an invented one | `test_runner_bam_no_md_tags_falls_back` |
+| **The matrix decides the substituted base in output reads** | `built_seq_error_transition_matrix_decides_the_substituted_base` |
+
+Non-vacuity was established by mutation, not asserted:
+
+| Mutation | Result |
+|---|---|
+| BAM branch returns `None` (counts ignored) | 2 tests fail |
+| `transition_matrix_file` / `bam_file` precedence inverted | precedence test fails |
+| `counts[i][j]` → `counts[j][i]` (axes transposed) | 4 tests fail |
+| `generate_snp_error` reads a default instead of the model's matrix | fidelity test fails |
+
+Two findings came out of that exercise:
+
+- **The first version of the mixed-pattern test was itself vacuous.** Its fixture
+  (`ref=ACGT` / `read=CATG`) produced A→C and C→A in equal number — a count matrix equal to
+  its own transpose, so the transpose mutation passed it. The fixture is now asymmetric
+  (`ref=AAAACCCC` / `read=CCGTAAAG`, A row 2C/1G/1T against C row 3A/1G). Single-entry rows
+  are useless for this too, since normalization puts one nonzero cell at probability 1.0
+  wherever it sits.
+- **A forced matrix does not drive output to 100%.** `indel_probability` is 0.4 and
+  `insertion_bias` is uniform over ACGT, so ~40% of sequencing errors are indels whose
+  inserted bases never consult the transition matrix. An absolute `>98% T` assertion fails
+  on correct code. The fidelity test is therefore differential against a control run:
+  default matrix gives a T share of **0.198**, forcing the A row to T gives **0.867**.
+
+## What the local tier cannot establish
+
+Every fixture above is synthetic and degenerate by design — one reference base, one forced
+target, a hand-written count matrix. Three things remain unmeasured:
+
+1. **Fit against a real substitution spectrum.** Real data exercises all four rows with a
+   realistic skew (transition/transversion structure, strand and context effects). Nothing
+   yet shows that a matrix fitted from a real BAM *resembles that BAM*.
+2. **Round-trip through an aligner.** A user perceives this feature as "my simulated reads
+   carry my instrument's error spectrum." That is only observable after alignment, at
+   coverage, against a real reference.
+3. **Scale.** `read_bam_transitions` streams a whole BAM through `walk_bam`. Runtime and
+   peak RSS on a chromosome- or genome-scale BAM are unrecorded. The observer itself is a
+   4×4 matrix, so RSS should be flat, but "should be" is not a measurement.
+
+## Delta tier — proposed job
+
+Fits the existing pattern: a `scripts/delta/run_transition_matrix_validation.sh` sibling to
+`run_subclonal_vaf_validation.sh`, archiving to
+`/projects/bhrd/jallen17/rneat-access-results/`.
+
+### Inputs
+
+- GRCh38 chr22 (already staged by `fetch_validation_data.sh`).
+- A real aligned BAM over chr22 **carrying MD tags**. The HG002 / GIAB alignment used by
+  `stage_hg002.sh` is the natural choice. If MD is absent:
+  `samtools calmd -b in.bam ref.fa > with_md.bam` — the builder requires it and silently
+  falls back to the default matrix without it, which is exactly the failure this job must
+  not mistake for a result.
+
+### Steps
+
+1. **Independent ground truth.** Tally the training BAM's 12 off-diagonal substitution
+   counts **without eidolon** — parse `MD`/`CIGAR` with `samtools view` + awk, or use
+   `bcftools mpileup`. This must not come from `read_bam_transitions`, or the comparison is
+   circular and proves only that the reader agrees with itself.
+2. **Build two models.** `eidolon gen-seq-error-model` with `bam_file:` → *fitted*; the same
+   config without it → *control* (default matrix). Same training FASTQ for both, so the
+   quality model and `error_rate` are identical and the matrix is the only difference.
+3. **Check the fit directly.** Compare the fitted model's 12 cells against step 1's tally.
+4. **Simulate and align.** `gen-reads` over chr22 with `mutation_rate: 0.0` (so every
+   mismatch in the output is a sequencing error, not a planted variant), 30×, paired-end;
+   align with bwa-mem2. Run both models.
+5. **Tally the simulated spectrum** from the aligned BAM, using the same step-1 tool.
+   Insertion errors appear as CIGAR `I` rather than mismatches, so the uniform-insertion
+   floor that constrains the local test does **not** contaminate this comparison — worth
+   confirming in the output rather than assuming.
+6. **Compare** fitted-vs-training and control-vs-training across the 12 cells.
+
+### Pass criteria
+
+- **Fit:** each of the 12 cells within 2% relative of the independent tally. A cell-wise
+  check, not a summary statistic — a cosine similarity near 1.0 can hide one badly wrong
+  cell.
+- **Round trip:** max absolute deviation across the 12 proportions between simulated and
+  training spectrum below 0.02, **and** the fitted model beating the control by at least
+  5×. The control is what makes the number mean anything.
+- **Denominators reported** on both sides: total mismatches counted, and per-cell counts.
+  Per rule 4 a metric over an unknown denominator is not a result, and a zero or
+  suspiciously small denominator is a **hard failure, not a warning** — the same shape as
+  #450 and the `signature_check.sh` minimum-SNV gate.
+- **Scale:** record wall-clock and peak RSS for the MD walk. No pass/fail; this becomes the
+  first baseline entry, alongside `docs/model_builder_baseline.md`.
+
+### Failure modes to guard explicitly
+
+- MD tags absent → builder logs a warning and uses the default matrix. The job must detect
+  that the fitted and control matrices are *identical* and fail, rather than reporting a
+  perfect control match as a pass.
+- `mutation_rate: 0.0` not honored → planted variants inflate the mismatch tally and skew
+  the spectrum toward the mutation model. Assert the output VCF is empty.
+- The step-1 tool and eidolon disagreeing on how to count a multi-base MD run, or on
+  soft-clipped/secondary records. Pin the filter set (`walk_bam` uses
+  `BamWalkFilter::for_transitions()`, min MAPQ 0, secondary dropped) and mirror it in the
+  awk pass, or the 2% tolerance is measuring a filter mismatch.
+
+### Resource estimate
+
+Alignment dominates: comparable to `germline_e2e.sbatch` on chr22 at 30×. The MD walk is a
+streaming pass over the training BAM, so allow generously for I/O and expect flat RSS.
+Both figures are guesses until the job runs, and should be replaced with measurements
+rather than left as prose.
+
+## Not verified
+
+- No part of the Delta tier has run. Everything above the "Delta tier" heading is local,
+  synthetic, and asserted; everything below it is a design.
+- The BAM-derived matrix has never been compared against real data in any form.
+- `read_bam_transitions`' handling of soft clips, secondary alignments and multi-base MD
+  runs is exercised only by the fixtures in `bam_reader.rs`, which assert record counts —
+  and, for the transition observer, an all-zero matrix. The non-zero real-BAM case is
+  covered only transitively, through the runner tests.
+- Long-read BAMs are untested here and are not in scope; see `docs/longread_epic_scope.md`.

--- a/docs/transition_matrix_validation_plan.md
+++ b/docs/transition_matrix_validation_plan.md
@@ -77,8 +77,11 @@ target, a hand-written count matrix. Three things remain unmeasured:
 ## Delta tier — proposed job
 
 Fits the existing pattern: a `scripts/delta/run_transition_matrix_validation.sh` sibling to
-`run_subclonal_vaf_validation.sh`, archiving to
-`/projects/bhrd/jallen17/rneat-access-results/`.
+`run_subclonal_vaf_validation.sh`, archiving through `archive_run` from `lib_report.sh` rather
+than to a literal path. `RESULTS_DIR` already resolves to the one archive root
+(`/projects/$ACCESS_PROJECT/$USER/eidolon-access-results`); naming a path here is how a doc
+comes to reference `rneat-access-results/`, which was retired in the v2.0.0 rename and no
+longer exists.
 
 ### Inputs
 

--- a/eidolon-core/src/models/sequencing_error_model.rs
+++ b/eidolon-core/src/models/sequencing_error_model.rs
@@ -209,6 +209,14 @@ impl SequencingErrorModel {
     pub fn quality_score_model(&self) -> &QualityScoreModel {
         &self.quality_score_model
     }
+
+    /// Borrow the SNP transition matrix. Exists so a test can assert which matrix a
+    /// built model actually carries — a BAM-inferred one, a TSV-supplied one, or the
+    /// default. Without this the only reachable assertion was "the file exists and
+    /// deserializes", which passes just as happily when the matrix is wrong.
+    pub fn transition_distros(&self) -> &TransitionMatrix {
+        &self.transition_distros
+    }
 }
 
 #[cfg(test)]

--- a/eidolon/src/gen_seq_error_model/utils/runner.rs
+++ b/eidolon/src/gen_seq_error_model/utils/runner.rs
@@ -653,10 +653,40 @@ mod tests {
         assert!(output_path.exists());
     }
 
+    /// The cumulative weights of one transition-matrix row, as `[A, C, G, T]`.
+    ///
+    /// `DiscreteDistribution` stores a CDF rather than per-value probabilities, so a row
+    /// whose whole weight sits on C reads `[0.0, 1.0, 1.0, 1.0]`, and one split
+    /// 0.5/0/0.25/0.25 reads `[0.5, 0.5, 0.75, 1.0]`.
+    fn row_cdf(
+        tm: &eidolon_core::structs::transition_matrix::TransitionMatrix,
+        base: eidolon_core::structs::nucleotides::Nucleotide,
+    ) -> Vec<f64> {
+        tm[&base].weights().unwrap()
+    }
+
+    fn assert_row_cdf_eq(actual: &[f64], expected: &[f64; 4], what: &str) {
+        assert_eq!(actual.len(), 4, "{what}: expected a 4-wide row");
+        for (i, exp) in expected.iter().enumerate() {
+            assert!(
+                (actual[i] - exp).abs() < 1e-9,
+                "{what}: position {i} was {}, expected {exp} (full row {actual:?})",
+                actual[i]
+            );
+        }
+    }
+
+    /// The default matrix's A row, as a CDF. Any test asserting "this model did NOT take
+    /// its matrix from the data" compares against this.
+    const DEFAULT_A_ROW_CDF: [f64; 4] = [0.0, 0.4918, 0.8295, 1.0];
+
     #[test]
-    fn test_runner_with_bam_md_tags() {
-        // ref=AAAA, read=CCCC → every base is an A→C mismatch.
-        // Verifies that runner accepts a bam_file and completes successfully.
+    fn test_runner_with_bam_md_tags_puts_all_a_weight_on_c() {
+        // ref=AAAA, read=CCCC → every mismatch is A→C, so the built model's A row must
+        // place its entire weight on C. Asserting the artifact's content, not that a file
+        // appeared: the previous version of this test passed with any matrix at all,
+        // including the default, which is precisely the failure it needed to catch.
+        use eidolon_core::structs::nucleotides::Nucleotide;
         let temp = tempfile::tempdir().unwrap();
         let fastq_path = temp.path().join("test.fastq");
         make_test_fastq(&fastq_path, 20, 4);
@@ -675,8 +705,117 @@ mod tests {
             transition_matrix_file: None,
         };
         runner(&config).unwrap();
-        assert!(output_path.exists());
-        SequencingErrorModel::from_file(&output_path).unwrap();
+
+        let model = SequencingErrorModel::from_file(&output_path).unwrap();
+        let tm = model.transition_distros();
+
+        // A → C with probability 1: CDF steps to 1.0 at C and stays there.
+        assert_row_cdf_eq(
+            &row_cdf(tm, Nucleotide::A),
+            &[0.0, 1.0, 1.0, 1.0],
+            "A row inferred from an all-A→C BAM",
+        );
+
+        // And it must not simply be the default matrix wearing a disguise.
+        let a_row = row_cdf(tm, Nucleotide::A);
+        assert!(
+            (a_row[1] - DEFAULT_A_ROW_CDF[1]).abs() > 1e-6,
+            "A row matched the default matrix, so the BAM was not consulted: {a_row:?}"
+        );
+
+        // Rows the BAM said nothing about fall back to uniform off-diagonal (1/3 each):
+        // C row CDF = [1/3, 1/3, 2/3, 1.0].
+        assert_row_cdf_eq(
+            &row_cdf(tm, Nucleotide::C),
+            &[1.0 / 3.0, 1.0 / 3.0, 2.0 / 3.0, 1.0],
+            "C row, unobserved in the BAM",
+        );
+    }
+
+    #[test]
+    fn test_runner_bam_transitions_track_a_mixed_mismatch_pattern() {
+        // The fixture must be ASYMMETRIC, and each row must spread over more than one
+        // target base. A reciprocal pattern (ref=ACGT / read=CATG, giving A→C and C→A in
+        // equal number) produces a count matrix equal to its own transpose, so swapping
+        // the ref/read axes cannot be detected — the first version of this test had that
+        // flaw and a transpose mutation passed it. Single-entry rows are no good either:
+        // the distribution is normalized, so one nonzero cell lands on probability 1.0
+        // wherever it sits.
+        //
+        // ref=AAAACCCC vs read=CCGTAAAG gives
+        //   A row: A→C ×2, A→G ×1, A→T ×1  → 0.50 / 0.25 / 0.25
+        //   C row: C→A ×3, C→G ×1          → 0.75 / 0.25
+        // counts[A][C]=2 against counts[C][A]=3, so the matrix is not symmetric.
+        use eidolon_core::structs::nucleotides::Nucleotide;
+        let temp = tempfile::tempdir().unwrap();
+        let fastq_path = temp.path().join("test.fastq");
+        make_test_fastq(&fastq_path, 20, 4);
+        let bam_path = temp.path().join("mixed.bam");
+        write_test_bam(&bam_path, 8, b"AAAACCCC", b"CCGTAAAG", true);
+        let output_path = temp.path().join("model.json.gz");
+
+        let config = RunConfiguration {
+            fastq_file: fastq_path,
+            output_file: output_path.clone(),
+            overwrite_output: true,
+            max_reads: 0,
+            qual_offset: 33,
+            binned_quality_bins: None,
+            bam_file: Some(bam_path),
+            transition_matrix_file: None,
+        };
+        runner(&config).unwrap();
+
+        let model = SequencingErrorModel::from_file(&output_path).unwrap();
+        let tm = model.transition_distros();
+
+        // A: 0.50 C, 0.25 G, 0.25 T → CDF [0.0, 0.50, 0.75, 1.0].
+        assert_row_cdf_eq(
+            &row_cdf(tm, Nucleotide::A),
+            &[0.0, 0.5, 0.75, 1.0],
+            "A row (2 C, 1 G, 1 T)",
+        );
+        // C: 0.75 A, 0.25 G → CDF [0.75, 0.75, 1.0, 1.0].
+        assert_row_cdf_eq(
+            &row_cdf(tm, Nucleotide::C),
+            &[0.75, 0.75, 1.0, 1.0],
+            "C row (3 A, 1 G)",
+        );
+        // G and T were never the reference base here, so both fall back to uniform.
+        assert_row_cdf_eq(
+            &row_cdf(tm, Nucleotide::G),
+            &[1.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0, 1.0],
+            "G row, unobserved",
+        );
+    }
+
+    #[test]
+    fn test_build_transition_matrix_from_counts_is_not_transposed() {
+        // Guards the ref/read axis directly on the pure function, where the fixture can be
+        // made maximally asymmetric without having to express it as a BAM. Transposing
+        // `counts[i][j]` changes every row here.
+        use eidolon_core::structs::nucleotides::Nucleotide;
+        let mut counts = [[0usize; 4]; 4];
+        // A row: 6 C, 3 G, 1 T  → 0.6 / 0.3 / 0.1
+        counts[0][1] = 6;
+        counts[0][2] = 3;
+        counts[0][3] = 1;
+        // C row: 1 A, 1 G, 8 T  → 0.1 / 0.1 / 0.8
+        counts[1][0] = 1;
+        counts[1][2] = 1;
+        counts[1][3] = 8;
+        let tm = build_transition_matrix_from_counts(counts).unwrap();
+
+        assert_row_cdf_eq(
+            &row_cdf(&tm, Nucleotide::A),
+            &[0.0, 0.6, 0.9, 1.0],
+            "A row 0.6/0.3/0.1",
+        );
+        assert_row_cdf_eq(
+            &row_cdf(&tm, Nucleotide::C),
+            &[0.1, 0.1, 0.2, 1.0],
+            "C row 0.1/0.1/0.8",
+        );
     }
 
     #[test]
@@ -700,15 +839,29 @@ mod tests {
             transition_matrix_file: None,
         };
         runner(&config).unwrap();
-        assert!(output_path.exists());
+
+        // The case where inference must NOT fire: no MD tags means nothing was observed,
+        // so the model has to carry the default matrix. Asserting only "a file appeared"
+        // could not tell that apart from silently inventing a matrix from zero evidence.
+        let model = SequencingErrorModel::from_file(&output_path).unwrap();
+        assert_row_cdf_eq(
+            &row_cdf(
+                model.transition_distros(),
+                eidolon_core::structs::nucleotides::Nucleotide::A,
+            ),
+            &DEFAULT_A_ROW_CDF,
+            "A row with no MD tags available",
+        );
     }
 
     #[test]
     fn test_tsv_takes_precedence_over_bam() {
-        // When both transition_matrix_file and bam_file are set, the TSV wins.
-        // The BAM has A→C biased mismatches; the TSV has a uniform matrix.
-        // We can't easily inspect the matrix after serialization, so just verify
-        // that the runner completes and writes a valid model.
+        // When both transition_matrix_file and bam_file are set, the TSV wins. The BAM is
+        // all A→C; the TSV's A row is 0.5/0.3/0.2 across C/G/T. Those are distinguishable,
+        // so the assertion can actually establish precedence — the earlier version only
+        // checked that the runner completed, and would have passed with precedence
+        // inverted, which is the single thing it existed to rule out.
+        use eidolon_core::structs::nucleotides::Nucleotide;
         let temp = tempfile::tempdir().unwrap();
         let fastq_path = temp.path().join("test.fastq");
         make_test_fastq(&fastq_path, 20, 4);
@@ -737,8 +890,18 @@ mod tests {
             transition_matrix_file: Some(tsv_path),
         };
         runner(&config).unwrap();
-        assert!(output_path.exists());
-        SequencingErrorModel::from_file(&output_path).unwrap();
+
+        let model = SequencingErrorModel::from_file(&output_path).unwrap();
+        let a_row = row_cdf(model.transition_distros(), Nucleotide::A);
+
+        // TSV A row 0.0/0.5/0.3/0.2 → CDF [0.0, 0.5, 0.8, 1.0].
+        assert_row_cdf_eq(&a_row, &[0.0, 0.5, 0.8, 1.0], "A row taken from the TSV");
+
+        // The BAM would have produced [0.0, 1.0, 1.0, 1.0]. State the negative directly.
+        assert!(
+            (a_row[2] - 1.0).abs() > 1e-6,
+            "A row looks BAM-derived, so the TSV did not take precedence: {a_row:?}"
+        );
     }
 
     #[test]
@@ -752,6 +915,16 @@ mod tests {
         counts[1][2] = 5; // C→G
         counts[1][3] = 5; // C→T
         let tm = build_transition_matrix_from_counts(counts).unwrap();
+
+        // The observed row is the point of the function and went unasserted: 10/5/5 out of
+        // 20 is 0.5 / 0.25 / 0.25 across A / G / T, so the C row's CDF is
+        // [0.5, 0.5, 0.75, 1.0]. Without this, the counts could have been ignored entirely
+        // and only the untouched A row was ever checked.
+        assert_row_cdf_eq(
+            &row_cdf(&tm, Nucleotide::C),
+            &[0.5, 0.5, 0.75, 1.0],
+            "C row fitted from 10/5/5 counts",
+        );
 
         // Sample the A row at several evenly-spaced random values
         let a_dist = &tm[&Nucleotide::A];

--- a/eidolon/src/gen_seq_error_model/utils/runner.rs
+++ b/eidolon/src/gen_seq_error_model/utils/runner.rs
@@ -676,9 +676,33 @@ mod tests {
         }
     }
 
-    /// The default matrix's A row, as a CDF. Any test asserting "this model did NOT take
-    /// its matrix from the data" compares against this.
-    const DEFAULT_A_ROW_CDF: [f64; 4] = [0.0, 0.4918, 0.8295, 1.0];
+    /// The default SEQUENCING-ERROR matrix's A row as a CDF, derived rather than transcribed.
+    ///
+    /// A hardcoded copy would be a vacuity hazard precisely here: the assertions below use
+    /// this to prove a built matrix is *not* the default. If the default changed and a
+    /// transcribed constant did not, the check would compare against a value that is no
+    /// longer the default — and could pass while the built matrix IS the new default.
+    ///
+    /// DO NOT reach for `TransitionMatrix::default()`. Two differently-valued defaults share
+    /// that name: `TransitionMatrix::default()` is NEAT 2.0's *mutation* matrix (A row
+    /// 0.0/0.1695/0.6878/0.1427), while the sequencing-error default is a separate literal
+    /// inside `SequencingErrorModel` (A row 0.0/0.4918/0.3377/0.1705). Deriving from the
+    /// wrong one makes this test fail against correct code, which is how the distinction was
+    /// found.
+    ///
+    /// Residual, pre-existing: that literal appears TWICE in `sequencing_error_model.rs`
+    /// (`default()` and `from_raw_data`'s `None` arm). This reads the former while the
+    /// runner's fallback path uses the latter, so a drift between the two copies would slip
+    /// past. They are identical today.
+    fn default_a_row_cdf() -> [f64; 4] {
+        let m = SequencingErrorModel::default()
+            .expect("the default sequencing error model must be constructible");
+        let row = row_cdf(
+            m.transition_distros(),
+            eidolon_core::structs::nucleotides::Nucleotide::A,
+        );
+        [row[0], row[1], row[2], row[3]]
+    }
 
     #[test]
     fn test_runner_with_bam_md_tags_puts_all_a_weight_on_c() {
@@ -719,7 +743,7 @@ mod tests {
         // And it must not simply be the default matrix wearing a disguise.
         let a_row = row_cdf(tm, Nucleotide::A);
         assert!(
-            (a_row[1] - DEFAULT_A_ROW_CDF[1]).abs() > 1e-6,
+            (a_row[1] - default_a_row_cdf()[1]).abs() > 1e-6,
             "A row matched the default matrix, so the BAM was not consulted: {a_row:?}"
         );
 
@@ -849,7 +873,7 @@ mod tests {
                 model.transition_distros(),
                 eidolon_core::structs::nucleotides::Nucleotide::A,
             ),
-            &DEFAULT_A_ROW_CDF,
+            &default_a_row_cdf(),
             "A row with no MD tags available",
         );
     }

--- a/eidolon/tests/model_output_fidelity.rs
+++ b/eidolon/tests/model_output_fidelity.rs
@@ -642,3 +642,180 @@ fn built_seq_error_model_reproduces_the_positional_quality_profile() {
         "final-cycle quality {tail:.1} does not track the trained {end_q}"
     );
 }
+
+// ── sequencing-error transition matrix ─────────────────────────────────────────
+
+/// Write a single-contig all-A reference plus its `.fai`.
+///
+/// A homopolymer reference makes every true base an A, so every sequencing-error
+/// substitution must be drawn from the matrix's A row. That is what lets the assertion
+/// below name an expected base without reconstructing each read's alignment.
+fn write_homopolymer_reference(dir: &Path, len: usize) -> std::path::PathBuf {
+    let seq = "A".repeat(len);
+    let path = dir.join("polyA.fa");
+    let hdr = ">polyA\n";
+    fs::write(&path, format!("{hdr}{seq}\n")).unwrap();
+    fs::write(
+        dir.join("polyA.fa.fai"),
+        format!("polyA\t{}\t{}\t{}\t{}\n", len, hdr.len(), len, len + 1),
+    )
+    .unwrap();
+    path
+}
+
+/// Base composition of a gzipped FASTQ's sequence lines, as (A, C, G, T, other).
+fn base_counts(path: &Path) -> (usize, usize, usize, usize, usize) {
+    let mut raw = String::new();
+    GzDecoder::new(fs::File::open(path).unwrap())
+        .read_to_string(&mut raw)
+        .unwrap();
+    let mut c = (0usize, 0usize, 0usize, 0usize, 0usize);
+    for (i, line) in raw.lines().enumerate() {
+        if i % 4 != 1 {
+            continue; // sequence lines only
+        }
+        for b in line.bytes() {
+            match b {
+                b'A' => c.0 += 1,
+                b'C' => c.1 += 1,
+                b'G' => c.2 += 1,
+                b'T' => c.3 += 1,
+                _ => c.4 += 1,
+            }
+        }
+    }
+    c
+}
+
+/// Build a sequencing-error model (optionally with a forced transition matrix), simulate
+/// over an all-A reference with mutations disabled, and return the output base counts.
+fn simulate_over_polya(tmp: &Path, tag: &str, tsv: Option<&Path>) -> (usize, usize, usize, usize) {
+    let read_len = 100;
+    // Phred 8 → ~0.158 per-base error probability, so errors are plentiful.
+    let fq = tmp.join(format!("{tag}_train.fastq.gz"));
+    write_uniform_quality_fastq_gz(&fq, 500, read_len, 8);
+
+    let model = tmp.join(format!("{tag}_model.json.gz"));
+    let mut body = format!(
+        "fastq_file: {}\noutput_file: {}\noverwrite_output: true\n",
+        fq.display(),
+        model.display()
+    );
+    if let Some(tsv) = tsv {
+        body.push_str(&format!("transition_matrix_file: {}\n", tsv.display()));
+    }
+    let build_cfg = write_yaml(tmp, &format!("{tag}_build"), &body);
+    eidolon()
+        .args(["gen-seq-error-model", "-c"])
+        .arg(&build_cfg)
+        .assert()
+        .success();
+
+    let reference = write_homopolymer_reference(tmp, 20_000);
+    let sim_cfg = write_yaml(
+        tmp,
+        &format!("{tag}_sim"),
+        &format!(
+            "reference: {ref}\nread_len: {rl}\ncoverage: 30\npaired_ended: false\n\
+             sequence_error_model: {model}\nmutation_rate: 0.0\nproduce_fastq: true\n\
+             produce_bam: false\nproduce_vcf: false\noverwrite_output: true\n\
+             output_dir: {out}\noutput_filename: {tag}\nrng_seed: transition fidelity\n\
+             num_threads: 1\n",
+            ref = reference.display(),
+            rl = read_len,
+            model = model.display(),
+            out = tmp.display(),
+        ),
+    );
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(&sim_cfg)
+        .assert()
+        .success();
+
+    let (a, c, g, t, other) = base_counts(&tmp.join(format!("{tag}_r1.fastq.gz")));
+    assert_eq!(other, 0, "{tag}: unexpected non-ACGT bases in output");
+    (a, c, g, t)
+}
+
+/// The SNP transition matrix in a built sequencing-error model must decide WHICH base a
+/// sequencing error substitutes in the output reads — not merely be present in the file.
+///
+/// The unit tests in `gen_seq_error_model::utils::runner` establish that a BAM's MD-tagged
+/// mismatches produce the right matrix, and that a TSV overrides a BAM. Neither can show
+/// the matrix reaching the reads, which is the claim that matters: a model file carrying a
+/// perfect matrix is worth nothing if `gen-reads` ignores it.
+///
+/// Setup: an all-A reference, so every true base is an A and every substitution must come
+/// from the matrix's A row. Two runs at the same seed — one with the default matrix
+/// (0.4918 C / 0.3377 G / 0.1705 T), one with the A row forced entirely to T.
+///
+/// This is differential rather than absolute because a forced run does NOT reach 100% T.
+/// The model's `indel_probability` is 0.4 and its `insertion_bias` is uniform over ACGT, so
+/// roughly 40% of sequencing errors are indels whose inserted bases never consult the
+/// transition matrix. That floor puts a few hundred C and G into the output no matter what
+/// the matrix says — which is correct behavior, and the reason an absolute `>98% T`
+/// assertion would fail on working code. The control run pins where the substitution
+/// spectrum sits without the override, so the comparison isolates the matrix's effect.
+#[test]
+fn built_seq_error_transition_matrix_decides_the_substituted_base() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // A row: all weight on T. Diagonals are ignored by the loader. The remaining rows are
+    // never consulted — an all-A reference has no other true base.
+    let tsv = tmp.path().join("a_to_t.tsv");
+    fs::write(
+        &tsv,
+        "A\tC\tG\tT\n\
+         0.0\t0.0\t0.0\t1.0\n\
+         1.0\t0.0\t0.0\t0.0\n\
+         1.0\t0.0\t0.0\t0.0\n\
+         1.0\t0.0\t0.0\t0.0\n",
+    )
+    .unwrap();
+
+    let (_, c_def, g_def, t_def) = simulate_over_polya(tmp.path(), "ctrl", None);
+    let (_, c_for, g_for, t_for) = simulate_over_polya(tmp.path(), "forced", Some(&tsv));
+
+    let subs_def = c_def + g_def + t_def;
+    let subs_for = c_for + g_for + t_for;
+    let share_def = t_def as f64 / subs_def as f64;
+    let share_for = t_for as f64 / subs_for as f64;
+    eprintln!(
+        "[fidelity] default matrix: C={c_def} G={g_def} T={t_def} → T share {:.3}\n\
+         [fidelity] forced A→T:     C={c_for} G={g_for} T={t_for} → T share {:.3}",
+        share_def, share_for
+    );
+
+    // Non-vacuity: with no substitutions at all, every ratio below is meaningless.
+    assert!(
+        subs_def > 500 && subs_for > 500,
+        "too few substitutions to compare (default {subs_def}, forced {subs_for})"
+    );
+
+    // The control must look like the default matrix — mostly C, T in the minority.
+    assert!(
+        share_def < 0.35,
+        "default-matrix run put {:.1}% of substitutions on T; the default A row is only \
+         0.1705 T, so this run is not using the default matrix and the comparison below \
+         proves nothing",
+        share_def * 100.0
+    );
+
+    // Forcing the A row to T must dominate the spectrum. The residual C/G is the uniform
+    // insertion floor described above, not a matrix that went unread.
+    assert!(
+        share_for > 0.80,
+        "forcing the A row to T only moved the T share to {:.1}% (C={c_for}, G={g_for}) — \
+         the model's transition matrix is NOT deciding the substituted base in output reads",
+        share_for * 100.0
+    );
+
+    // State the causal claim directly: the override, not chance, moved the spectrum.
+    assert!(
+        share_for > share_def * 2.0,
+        "T share barely moved between the default ({:.3}) and forced ({:.3}) runs",
+        share_def,
+        share_for
+    );
+}


### PR DESCRIPTION
The BAM-derived SNP transition matrix (`gen-seq-error-model`'s `bam_file:`) is **correct code that was covered vacuously**. No behavior changes here — one new accessor, seven real assertions, and a validation plan.

## The problem

Three tests constructed a known answer and then asserted nothing about it. One said so in its own comment:

> `// We can't easily inspect the matrix after serialization, so just verify`
> `// that the runner completes and writes a valid model.`

| Test | Fixture (a known answer) | What it asserted |
|---|---|---|
| `test_runner_with_bam_md_tags` | ref=`AAAA`, read=`CCCC` — 100% A→C | `output_path.exists()` |
| `test_tsv_takes_precedence_over_bam` | A→C BAM vs uniform TSV | runner completes |
| `test_build_transition_matrix_from_counts_uniform_fallback` | C→A 10, C→G 5, C→T 5 | only the **A** row — the untouched fallback |

Under that coverage the matrix could have been the default, garbage, or transposed and all three would have passed. This is rule 1, and it went unnoticed precisely *because* the implementation is right — a correct implementation with vacuous tests reads exactly like a verified one until something changes.

## What changed

`SequencingErrorModel::transition_distros()` — so a test can read what a built model actually carries. `eidolon-core`'s API is explicitly **not** the public API per the v3.0.0 policy, and this mirrors the existing `error_rate()` / `quality_score_model()` accessors.

Seven assertions, each with the expected CDF spelled out per row (`DiscreteDistribution` stores a CDF, so an all-weight-on-C row reads `[0.0, 1.0, 1.0, 1.0]`):

- **`..._puts_all_a_weight_on_c`** — all-A→C BAM puts the A row entirely on C, is *not* the default matrix, and leaves unobserved rows uniform
- **`..._track_a_mixed_mismatch_pattern`** — asymmetric multi-target fixture, fitted per row
- **`..._is_not_transposed`** *(new)* — guards the ref/read axis on the pure function
- **`..._uniform_fallback`** — now also asserts the **observed** row (10/5/5 → 0.5/0.25/0.25)
- **`..._tsv_takes_precedence_over_bam`** — actually establishes precedence
- **`..._bam_no_md_tags_falls_back`** — asserts the default matrix: the case where inference must **not** fire
- **`built_seq_error_transition_matrix_decides_the_substituted_base`** *(new, `model_output_fidelity.rs`)* — closes the gap none of the others can reach: the matrix in the file decides which base a sequencing error substitutes in output **reads**

## Non-vacuity, by mutation

Per rule 2 — I broke the code four ways and watched them fail:

| Mutation | Result |
|---|---|
| BAM branch returns `None` (counts ignored) | 2 tests fail |
| TSV/BAM precedence inverted | precedence test fails |
| `counts[i][j]` → `counts[j][i]` | **4** tests fail |
| `generate_snp_error` reads a default, not the model's matrix | fidelity test fails |

## Two things that exercise turned up

**My own first fixture was vacuous.** `ref=ACGT` / `read=CATG` gives A→C and C→A in equal number — a count matrix equal to its own transpose — so the transpose mutation *passed it*. Now asymmetric (`ref=AAAACCCC` / `read=CCGTAAAG`). Single-entry rows are no good either: normalization puts one nonzero cell at probability 1.0 wherever it sits.

**A forced matrix does not drive output to 100%.** `indel_probability` is 0.4 and `insertion_bias` is uniform over ACGT, so ~40% of sequencing errors are indels whose inserted bases never consult the matrix. An absolute `>98% T` assertion **fails on correct code**. The fidelity test is therefore differential against a control run at the same seed:

```
[fidelity] default matrix: C=5092 G=3850 T=2204 → T share 0.198
[fidelity] forced A→T:     C=711  G=768  T=9667 → T share 0.867
```

## Delta plan

`docs/transition_matrix_validation_plan.md` records what is now proven locally, what synthetic fixtures **cannot** establish — fit against a real substitution spectrum, round trip through an aligner, scale of the MD walk — and a job design for it.

Notable guards it specifies: ground truth must be tallied **without** `read_bam_transitions` or the comparison is circular; a BAM missing MD tags makes the builder fall back to the default matrix, which would otherwise report as a *perfect control match*; and per rule 4 the per-cell denominators are reported, with a zero denominator a hard failure rather than a warning.

**Status: the Delta tier has NOT been run.** No Delta time was consumed by this PR.

Full suite green — 384 unit tests plus all integration suites, 0 failures, `cargo fmt` clean, no new clippy warnings against the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)