### PR TITLE
docs: expand CONTRIBUTING and add an ONBOARDING tour for teammates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,12 @@ After a PR merges, **confirm your commits actually landed**:
 git merge-base --is-ancestor <sha> origin/develop
 ```
 
-Late pushes have missed a merge more than once here. Recover with `git cherry-pick`.
+Keep PRs in draft form and tag an admin when you feel it is ready for review. If for any reason 
+you missed a commit after submitting a PR, pull the PR back and send the admin a note to let them
+know to hold off on a review. If you missed a commit but feel it is important, check if the PR has
+been merged before pushing any new code. If it has been, you recover your work commit locally with 
+`git cherry-pick` and submit a follow-up PR with a note for reviewers. If it's a breaking commit, 
+tests should fail and the PR would be rejected and you can add your commit at that time.
 
 ## The testing bar
 
@@ -43,7 +48,8 @@ green, and the case histories are in
 
 **Assert content, not existence.** A file existing, a non-zero count, or exit 0 is necessary and
 not sufficient. A guard once checked `count > 0` while every value was the malformed string
-`AF=AF=0.3000`. If a wrong value would still pass, the test is decoration.
+`AF=AF=0.3000`. If a wrong value would still pass, the test is decoration. Try to write tests with
+malformed inputs and stress the code.
 
 **Prove non-vacuity by mutation.** Break the code a test covers and watch it fail. If it still
 passes, it is not a test. This is free for a bug fix — you already have the broken state, so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,102 @@
-Contributing to eidolon
-====================
+# Contributing to eidolon
 
-We welcome contributions to the eidolon project. Before contributing, please review our [Code of Conduct](CODE_OF_CONDUCT.md).
+Thanks for your interest. Please review the [Code of Conduct](CODE_OF_CONDUCT.md) first.
 
-Note that this is a reworking of the NEAT project (https://github.com/ncsa/neat) purely in Rust. See the [README](README.md) for more details.
+eidolon is a Rust port of [NEAT](https://github.com/ncsa/NEAT), extended with a native
+tumour/normal cancer workflow. See the [README](README.md) for what it does, or
+[`ONBOARDING.md`](ONBOARDING.md) if you are new to the project and want the tour rather than
+the reference.
 
-Contributing
-------------
+## Getting set up
 
-This effort is directed at reworking NEAT using the Rust language and Cargo package framework. This effort will take advantage of open source code where possible and will likely be rough, as this is our first major Rust undertaking. As such, we don't yet have a ticketing system or a firm plan in place, but we'll update as it becomes available. If you would like to contribute, you may message Joshua Allen (see links on page) and we can discuss.
+```bash
+cargo build --release          # binary at target/release/eidolon
+cargo test --workspace         # the full suite, ~30s
+cargo fmt --all                # before every commit
+```
 
-License
--------
+Unit tests live in the binary crate, so `cargo test --package eidolon --lib` **fails** — there
+is no library target. Use `--bin eidolon`.
 
-NEAT is licensed under [BSD 3-Clause License](https://github.com/zstephens/neat-genreads/blob/master/LICENSE.md). Because we also use some of the software from Biopython, we additionally have included the Biopython License Agreement
+CI gates three things: `cargo fmt --all -- --check`, `cargo build --workspace --all-targets`
+with `RUSTFLAGS="-D warnings"` (a disabled test shows up as a rustc warning, and that has
+silently switched off a regression guard before), and `cargo test --workspace`.
+
+## Where changes go
+
+**PRs target `develop`, not `main`.** `main` carries release merges and tags; `develop` is the
+integration branch. Fetch before you start — `develop` moves quickly.
+
+After a PR merges, **confirm your commits actually landed**:
+
+```bash
+git merge-base --is-ancestor <sha> origin/develop
+```
+
+Late pushes have missed a merge more than once here. Recover with `git cherry-pick`.
+
+## The testing bar
+
+This is the part worth reading properly. These rules were each earned by a defect that shipped
+green, and the case histories are in
+[`docs/claude_engineering_audit.md`](docs/claude_engineering_audit.md).
+
+**Assert content, not existence.** A file existing, a non-zero count, or exit 0 is necessary and
+not sufficient. A guard once checked `count > 0` while every value was the malformed string
+`AF=AF=0.3000`. If a wrong value would still pass, the test is decoration.
+
+**Prove non-vacuity by mutation.** Break the code a test covers and watch it fail. If it still
+passes, it is not a test. This is free for a bug fix — you already have the broken state, so
+just revert your fix and check. For a new feature it has to be deliberate. A coverage claim with
+no mutation experiment behind it is an opinion.
+
+**Test the path that can break.** BND generation was "covered" through the input-VCF path while
+the *de novo* path shipped a truth file contradicting its own reads for eight releases.
+
+**Report the denominator.** A metric over an unknown denominator is not a result. If a step
+drops data — filters, thresholds, minimum depth — say how much. A zero or unexpectedly small
+denominator is a failure, not a warning.
+
+**Say what you did not verify.** "Vetted on a known-answer fixture; not yet run on real data"
+beats a checkmark. A merged PR is not evidence, a passing CI run is evidence about the tests,
+and *nothing is done until there is evidence it works as intended*.
+
+The bar is **higher for a new feature than for a fix**, because a fix has a known-bad baseline
+and a feature has none. A feature wants a known-answer fixture (an output computable
+independently of the code under test) and a case where it must *not* fire — most defects found
+here were things matching or counting when they should not have.
+
+`CLAUDE.md` has the full version, including the bash footguns this repo has actually hit. It is
+written for AI agents but the engineering content applies to everyone.
+
+## Languages
+
+**Product logic is Rust. Harness and orchestration are bash.** The shipped artifact invokes no
+interpreter, and the conda recipe declares no runtime requirements.
+
+Please do not add Python. The few Python files that exist are there because an external tool
+forces it — SigProfiler and truvari are Python packages — and they are all offline analysis, none
+shipped.
+
+## Commits and PRs
+
+Explain **why**, not what — the diff shows what. If a change fixes a defect, say what the defect
+produced, because that is what makes the test reviewable. Note explicitly what you did *not*
+verify.
+
+Two mechanics worth knowing: `gh pr edit` is broken on this repo (deprecated Projects-classic
+GraphQL), so patch a PR body with
+`gh api -X PATCH repos/ncsa/eidolon/pulls/<N> -f body=...`. `gh issue edit` works fine.
+
+## Reporting problems
+
+Open a GitHub issue. Bugs: what you ran, what you expected, what happened, and the version
+(`eidolon --version`). There is also a **Feedback** issue type for things that are not quite
+bugs — a rough edge, a confusing message, or a good experience worth hearing about.
+
+If you would rather talk first, message Joshua Allen (links on the repo page).
+
+## License
+
+BSD 3-Clause — see [LICENSE.md](LICENSE.md). Because some code derives from Biopython, the
+Biopython License Agreement is included there as well.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,163 @@
+# Welcome to eidolon
+
+A tour of the project for new teammates. **Everything marked *Deeper* is safely skippable** —
+the top of each section carries the whole idea, and the deep dives are there for when you need
+them.
+
+If you are here to *contribute code*, read [`CONTRIBUTING.md`](CONTRIBUTING.md) after this.
+
+---
+
+## The whole idea, in one paragraph
+
+**eidolon makes realistic fake DNA sequencing data where we already know the right answer.**
+
+You hand it a reference genome and a description of what genetic changes to plant. It writes out
+sequencing files that look like they came off a real instrument — and, alongside them, a "truth"
+file listing exactly what it planted and where. You then run your normal analysis software on the
+fake data and check whether it found what was actually there.
+
+That last step is the point, and it is something you **cannot** do with real patient data: for a
+real genome, nobody knows the complete correct answer. Simulated data is the only place you can
+measure "how much did my pipeline miss?" rather than guess at it.
+
+## Why anyone needs that
+
+- **Benchmarking.** Two variant callers disagree on a real sample. Which is right? On simulated
+  data you can just check.
+- **Pipeline validation.** Before running a study on real samples, confirm the pipeline actually
+  recovers what it should — and quantify what it drops.
+- **Cancer.** A tumour biopsy is a *mixture*: some cancer cells, some normal tissue, often several
+  competing cancer subpopulations. eidolon can build that mixture at a known composition, so you
+  can measure how well a tool copes with it. This is the part of the project with the most
+  original work in it.
+- **Development.** Small, fast, known-answer datasets to test against.
+
+## The mental model
+
+```
+   reference genome                          your analysis pipeline
+   + trained models      ┌──────────┐        (aligner, variant caller)
+   + what to plant  ───► │ eidolon  │ ───►  FASTQ reads  ───►  called variants
+                         └──────────┘                                │
+                                     └───►  TRUTH file  ────────────┐│
+                                            (what was planted)      ▼▼
+                                                              compare  ───►  "it found 86%
+                                                                               of deletions"
+```
+
+Two outputs matter. The **reads** are what your pipeline consumes; they are meant to be
+indistinguishable from real data in their statistical behaviour. The **truth file** is the answer
+key, and your pipeline never sees it.
+
+> ### Deeper: what "trained models" means *(skip freely)*
+>
+> Real sequencing data has quirks — some machines make more errors at the end of a read, some
+> genome regions get read more often than others, fragment lengths follow a particular
+> distribution. If simulated data ignores that, it is too clean and every tool looks better than
+> it is.
+>
+> So eidolon *learns* those quirks from your own real data first, then reproduces them. Each
+> `gen-*-model` subcommand builds one reusable model file: mutation patterns from a VCF,
+> sequencing-error behaviour from FASTQ, fragment lengths and GC bias from a BAM. You build them
+> once and reuse them across runs.
+
+## What you can run
+
+| Command | In plain terms |
+|---|---|
+| `gen-reads` | The main event: make reads + truth from a reference |
+| `gen-cancer-reads` | Make a tumour/normal mixture at a chosen purity |
+| `gen-mut-model` | Learn mutation patterns from real variant data |
+| `gen-seq-error-model` | Learn a sequencer's error behaviour from real reads |
+| `gen-frag-length-model` / `gen-gc-bias-model` / `gen-bam-models` | Learn physical/coverage properties from a real alignment |
+| `compare-vcfs` | Score a caller's output against the truth file |
+| `compare-af` | Check that per-variant allele fractions came out as requested |
+| `validate` | Check an emitted file against what downstream tools will accept |
+| `filter-reads` | Post-filter generated reads |
+
+Everything is driven by a YAML config file:
+`eidolon gen-reads -c my_config.yml`.
+
+## Try it in five minutes
+
+```bash
+cargo build --release                  # or: conda install -c bioconda eidolon
+./target/release/eidolon --help
+./target/release/eidolon gen-reads --help
+```
+
+[`docs/cancer_howto.md`](docs/cancer_howto.md) is the best starting point for a real worked
+example — copy-paste configs with explanations.
+
+## Where things live
+
+| Path | What is in it |
+|---|---|
+| `eidolon/` | The command-line program: argument parsing, per-subcommand runners |
+| `eidolon-core/` | The engine: models, variant types, file readers/writers |
+| `eidolon/tests/` | Integration tests — the ones that run the real binary end to end |
+| `docs/` | Design documents, how-tos, and measurement records |
+| `scripts/delta/` | The HPC validation harness (see below) |
+| `CLAUDE.md` | Working practices, written for AI coding agents but useful to anyone |
+
+## The unusual thing about this project
+
+Most simulators are validated by "we ran it and it produced output." This one is not, and that is
+deliberate — because a simulator that quietly generates *wrong* data is worse than one that
+crashes. A crash you notice. Wrong truth data silently invalidates every benchmark built on it,
+and you may not find out for months.
+
+So the project holds an explicit standard: **nothing is "done" until there is evidence it works as
+intended, and reports say which kind of evidence exists.** "Checked on a small known-answer
+fixture, not yet on real data" is a normal and respectable thing to write here.
+
+> ### Deeper: how that plays out *(skip freely)*
+>
+> Two habits do most of the work.
+>
+> **Assert content, not existence.** A test that checks "a file was produced" passes just as
+> happily when the file is garbage. Real example from this repo: a check confirmed a count was
+> above zero while every value in it was the malformed text `AF=AF=0.3000`.
+>
+> **Prove a test can fail.** Deliberately break the code a test covers and confirm the test
+> notices. If it still passes, it was never testing anything. This has repeatedly caught tests
+> that looked thorough and asserted nothing — in one case, eleven separate ways of breaking the
+> code that the whole suite ignored.
+>
+> `docs/claude_engineering_audit.md` collects the case histories, including the ones where the
+> tooling fooled us for weeks. It is unusually candid for a project document and it is the best
+> single read for understanding how this codebase thinks.
+
+> ### Deeper: HPC validation *(skip freely)*
+>
+> Small tests prove the machinery runs. They cannot prove the output looks like real data at
+> genome scale. So there is a second tier on NCSA Delta: simulate a whole tumour genome, run it
+> through production variant callers (Manta, Delly, GATK), and score their output against the
+> truth with an independent tool (truvari).
+>
+> That harness lives in `scripts/delta/` and is written in bash. It carries its own positive and
+> negative controls — it scores the truth against *itself* (must be perfect) and against a
+> deliberately shifted copy (must find nothing), because a scoring configuration loose enough to
+> match anything would otherwise report excellent results. Findings from those runs feed back into
+> `docs/sv_support_matrix.md`, which records exactly which capabilities are measured, which are
+> broken, and which are unverified.
+
+## How the work is organised
+
+Changes go through pull requests targeting the **`develop`** branch. `main` holds releases.
+Issues on GitHub track bugs and planned work — including a **Feedback** issue type for things
+that are not quite bugs, like a confusing error message or a rough edge.
+
+Versions follow [Semantic Versioning](https://semver.org) as of v3.0.0. The project was called
+`rusty-neat` / `rneat` before v2.0.0, so older notes and links use those names; the emitted output
+tokens changed at v3.0.0 as well, which matters if you have scripts that parse eidolon's output.
+
+## Questions
+
+Open an issue, or message **Joshua Allen** (links on the repo page). Questions that turn out to be
+gaps in the documentation are useful — say so and it gets fixed.
+
+Worth knowing if you are wondering whether to ask: nobody here expects you to have read the whole
+codebase, and "I could not tell from the docs" is treated as a docs bug rather than a
+you-problem.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,163 +1,157 @@
-# Welcome to eidolon
+# eidolon for NEAT users
 
-A tour of the project for new teammates. **Everything marked *Deeper* is safely skippable** —
-the top of each section carries the whole idea, and the deep dives are there for when you need
-them.
+Written for people who already know NEAT — what `gen_reads` does, why you train models from your
+own data, what a golden BAM is for. This is the **delta**, not an introduction.
 
-If you are here to *contribute code*, read [`CONTRIBUTING.md`](CONTRIBUTING.md) after this.
+Short version: eidolon is NEAT reimplemented in Rust, tracking the NEAT feature set, plus a
+native tumour/normal cancer workflow that has no NEAT counterpart. The conceptual model is
+unchanged — reference in, models trained from real data, FASTQ + golden BAM + truth VCF out.
+
+Sections marked *Deeper* are skippable.
 
 ---
 
-## The whole idea, in one paragraph
+## What is the same
 
-**eidolon makes realistic fake DNA sequencing data where we already know the right answer.**
+Everything you already reason about. Subcommand shape (`gen-reads`, `gen-mut-model`,
+`gen-seq-error-model`, `gen-frag-length-model`, `gen-gc-bias-model`), YAML config, models trained
+once and reused, BED targeting, variant insertion from an input VCF, golden BAM + truth VCF
+alongside the FASTQ, single or paired end.
 
-You hand it a reference genome and a description of what genetic changes to plant. It writes out
-sequencing files that look like they came off a real instrument — and, alongside them, a "truth"
-file listing exactly what it planted and where. You then run your normal analysis software on the
-fake data and check whether it found what was actually there.
+If you can read NEAT's outputs you can read these.
 
-That last step is the point, and it is something you **cannot** do with real patient data: for a
-real genome, nobody knows the complete correct answer. Simulated data is the only place you can
-measure "how much did my pipeline miss?" rather than guess at it.
+## What is different in practice
 
-## Why anyone needs that
-
-- **Benchmarking.** Two variant callers disagree on a real sample. Which is right? On simulated
-  data you can just check.
-- **Pipeline validation.** Before running a study on real samples, confirm the pipeline actually
-  recovers what it should — and quantify what it drops.
-- **Cancer.** A tumour biopsy is a *mixture*: some cancer cells, some normal tissue, often several
-  competing cancer subpopulations. eidolon can build that mixture at a known composition, so you
-  can measure how well a tool copes with it. This is the part of the project with the most
-  original work in it.
-- **Development.** Small, fast, known-answer datasets to test against.
-
-## The mental model
-
-```
-   reference genome                          your analysis pipeline
-   + trained models      ┌──────────┐        (aligner, variant caller)
-   + what to plant  ───► │ eidolon  │ ───►  FASTQ reads  ───►  called variants
-                         └──────────┘                                │
-                                     └───►  TRUTH file  ────────────┐│
-                                            (what was planted)      ▼▼
-                                                              compare  ───►  "it found 86%
-                                                                               of deletions"
-```
-
-Two outputs matter. The **reads** are what your pipeline consumes; they are meant to be
-indistinguishable from real data in their statistical behaviour. The **truth file** is the answer
-key, and your pipeline never sees it.
-
-> ### Deeper: what "trained models" means *(skip freely)*
->
-> Real sequencing data has quirks — some machines make more errors at the end of a read, some
-> genome regions get read more often than others, fragment lengths follow a particular
-> distribution. If simulated data ignores that, it is too clean and every tool looks better than
-> it is.
->
-> So eidolon *learns* those quirks from your own real data first, then reproduces them. Each
-> `gen-*-model` subcommand builds one reusable model file: mutation patterns from a VCF,
-> sequencing-error behaviour from FASTQ, fragment lengths and GC bias from a BAM. You build them
-> once and reuse them across runs.
-
-## What you can run
-
-| Command | In plain terms |
+| Change | Practical consequence |
 |---|---|
-| `gen-reads` | The main event: make reads + truth from a reference |
-| `gen-cancer-reads` | Make a tumour/normal mixture at a chosen purity |
-| `gen-mut-model` | Learn mutation patterns from real variant data |
-| `gen-seq-error-model` | Learn a sequencer's error behaviour from real reads |
-| `gen-frag-length-model` / `gen-gc-bias-model` / `gen-bam-models` | Learn physical/coverage properties from a real alignment |
-| `compare-vcfs` | Score a caller's output against the truth file |
-| `compare-af` | Check that per-variant allele fractions came out as requested |
-| `validate` | Check an emitted file against what downstream tools will accept |
-| `filter-reads` | Post-filter generated reads |
+| **~10–13× faster, 3–7× less memory** | chr22 at 10×: 61 s / 227 MB against NEAT 4.6.1's 810 s / 1525 MB, single thread. Shared-allocation runs stop being painful |
+| **Deterministic for a given seed at any thread count** | Byte-identical output. NEAT's varies with `--threads`, so a rerun is not a rerun |
+| **Output token names changed at v3.0.0** | `EIDOLON_*`, not `NEAT_*` / `RNEAT_*`. **Breaks any script that parses eidolon VCFs or read names** — see "Upgrading from 2.0.0" in the README |
+| **Quality binning is explicit** | You spell out `binned_quality_bins`. NEAT 4 has named presets (`--quality-preset novaseq`); eidolon does not, which is a real ergonomic loss |
+| **Default model Ts/Tv is 2.21** | NEAT 4's is 2.33. Default model only — a trained model uses your data ([#410](https://github.com/ncsa/eidolon/issues/410)) |
+| **Structural variants are actually generated** | NEAT 4.6.1 ships `Inversion`/`Duplication`/`Translocation`/`CopyNumberVariant` classes that are exported from nothing and referenced nowhere; `VariantTypes.types` lists only SNV/insertion/deletion/unknown. It also cannot render an SV from an input VCF — symbolic ALTs become `UnknownVariant`, whose accessors raise. Verified against tag `4.6.1` |
+| **SemVer since v3.0.0** | With a declared public API, so a MAJOR bump is a real signal |
 
-Everything is driven by a YAML config file:
-`eidolon gen-reads -c my_config.yml`.
+## What is new
 
-## Try it in five minutes
+Cancer work is where the original effort went.
 
-```bash
-cargo build --release                  # or: conda install -c bioconda eidolon
-./target/release/eidolon --help
-./target/release/eidolon gen-reads --help
-```
+- **`gen-cancer-reads`** — two `gen-reads` passes (normal-genotype and tumour) over one reference,
+  merged at a configurable purity into a single biopsy FASTQ that Mutect2 / Strelka / Manta
+  consume directly, plus a truth VCF tagged `INFO/EIDOLON_ORIGIN ∈ {germline, somatic, shared}`
+  so you can score germline and somatic separately.
+- **Intra-tumour heterogeneity** — a tumour as subclones at distinct cancer-cell fractions,
+  specified inline, fitted from PyClone-VI / DPClust output, or replayed from a real tumour's
+  observed VAF. Per-site VAF is `purity × dosage × CCF`, and the truth carries `EIDOLON_CCF` and
+  `EIDOLON_VAF`. Validated on SEQC2 HCC1395 at r = 0.99 against intended VAF.
+- **Per-tissue somatic models** — bundled pan-cancer plus BRCA / skin / lung, fitted from
+  COSMIC and PCAWG.
+- **Continuous per-variant allele fraction** from an input VCF's `AF`/`AD`, rather than genotype
+  `{0.5, 1.0}`. This is what makes pooled and somatic AF spectra reproducible.
+- **Trinucleotide-context-aware SNP placement**, so SBS-96 signatures reproduce (cosine 0.99).
+- **Sequencing-error transition matrix inferrable from a BAM's MD tags**, or a custom 4×4 TSV —
+  NEAT's builders never open a BAM for this.
+- **`compare-af`** (per-allele AF correlation, truth vs simulated) and **`validate`** (checks an
+  emitted file against what downstream tools actually accept, before you spend a pipeline run
+  finding out).
 
-[`docs/cancer_howto.md`](docs/cancer_howto.md) is the best starting point for a real worked
-example — copy-paste configs with explanations.
+## What to trust, and what not to
+
+The part worth reading before you design an experiment.
+
+**[`docs/sv_support_matrix.md`](docs/sv_support_matrix.md) is the authority on structural
+variants** — every row is a measurement against read-level evidence, and the broken cells are
+pinned by tests rather than quietly omitted. Current state worth knowing:
+
+- **Insertions above ~a read length are not fully realised** and the engine now refuses to plant
+  them de novo rather than write a truth record the reads cannot support
+  ([#516](https://github.com/ncsa/eidolon/issues/516)). Consequence: the realised INS rate sits
+  below the model's, and any insertion benchmark is limited to short insertions for now.
+- **DEL / DUP / CNV coverage runs ~8% high** whenever the copy-number multiplier is not 0 or 1
+  ([#499](https://github.com/ncsa/eidolon/issues/499)) — fine for detection, not for dosage
+  estimation.
+- **Symbolic `<INS>` from an input VCF is a silent no-op**, and a single unpaired breakend
+  destroys local coverage ([#500](https://github.com/ncsa/eidolon/issues/500)).
+- BND, INV and literal indels are measured good.
+
+Caller recall figures from the HPC tier live in `docs/access_report_draft.md`. Treat its section
+caveats as load-bearing — several sections say explicitly that they are not yet submittable and
+why.
+
+> ### Deeper: how the project decides something is verified *(skip freely)*
+>
+> A simulator that generates *wrong* truth data is worse than one that crashes: a crash you
+> notice, wrong truth silently invalidates every benchmark built on it. So the standard is that
+> nothing is "done" until there is evidence, and reports state which kind of evidence exists —
+> "known-answer fixture, not yet real data" is a normal thing to read here.
+>
+> In practice two habits do the work. **Assert content, not existence**: a check that a file
+> appeared passes just as happily when the file is garbage, and one here confirmed a non-zero
+> count while every value was the malformed string `AF=AF=0.3000`. **Prove a test can fail**:
+> deliberately break the code it covers and confirm it notices. That has repeatedly exposed
+> thorough-looking tests asserting nothing.
+>
+> `docs/claude_engineering_audit.md` collects the case histories, including the ones where the
+> tooling misled us for weeks. Unusually candid for a project document, and the best single read
+> for how this codebase thinks.
+
+> ### Deeper: the HPC validation tier *(skip freely)*
+>
+> Unit tests prove the machinery runs; they cannot prove genome-scale output resembles real data.
+> So `scripts/delta/` simulates a whole tumour genome on NCSA Delta, runs production callers
+> (Manta, Delly, GATK CNV) and scores them against the truth with truvari.
+>
+> It carries its own controls, which is the interesting part: the truth is scored against
+> **itself** (must be perfect) and against a **deliberately displaced copy** (must find nothing),
+> because a matching configuration loose enough to accept anything would otherwise report
+> excellent recall. Findings feed back into the SV support matrix.
+
+## Reading the outputs
+
+Truth-VCF INFO tags you will actually encounter:
+
+| Tag | Meaning |
+|---|---|
+| `EIDOLON_PROVENANCE` | `denovo` (sampled from a model) vs supplied via `input_vcf` |
+| `EIDOLON_ORIGIN` | `germline` \| `somatic` \| `shared` — cancer runs only |
+| `EIDOLON_CCF` | Cancer-cell fraction of the subclone carrying this variant |
+| `EIDOLON_VAF` | Intended observed VAF after purity mixing |
+| `EIDOLON_REASON` | Written by `compare-vcfs` on FN/FP records, explaining the classification |
+
+Read names carry `EIDOLON_chimeric` for reads spanning a structural-variant junction, which is
+how you find them without an aligner.
 
 ## Where things live
 
 | Path | What is in it |
 |---|---|
-| `eidolon/` | The command-line program: argument parsing, per-subcommand runners |
-| `eidolon-core/` | The engine: models, variant types, file readers/writers |
-| `eidolon/tests/` | Integration tests — the ones that run the real binary end to end |
-| `docs/` | Design documents, how-tos, and measurement records |
-| `scripts/delta/` | The HPC validation harness (see below) |
-| `CLAUDE.md` | Working practices, written for AI coding agents but useful to anyone |
+| `docs/cancer_howto.md` | **Start here** — copy-paste configs with worked examples |
+| `docs/sv_support_matrix.md` | What is measured, broken, and unverified |
+| `docs/cancer_simulator.md` | Cancer design rationale and calibration caveats |
+| `docs/hpc_guide.md` | Running on a cluster |
+| `eidolon/` | CLI: argument parsing, per-subcommand runners |
+| `eidolon-core/` | Engine: models, variant types, readers/writers |
+| `scripts/delta/` | The HPC validation harness (bash) |
+| `CLAUDE.md` | Working practices — written for AI agents, useful to anyone |
 
-## The unusual thing about this project
+## Getting it
 
-Most simulators are validated by "we ran it and it produced output." This one is not, and that is
-deliberate — because a simulator that quietly generates *wrong* data is worse than one that
-crashes. A crash you notice. Wrong truth data silently invalidates every benchmark built on it,
-and you may not find out for months.
+```bash
+conda install -c bioconda eidolon        # or cargo build --release
+eidolon --help
+```
 
-So the project holds an explicit standard: **nothing is "done" until there is evidence it works as
-intended, and reports say which kind of evidence exists.** "Checked on a small known-answer
-fixture, not yet on real data" is a normal and respectable thing to write here.
+## Working on it
 
-> ### Deeper: how that plays out *(skip freely)*
->
-> Two habits do most of the work.
->
-> **Assert content, not existence.** A test that checks "a file was produced" passes just as
-> happily when the file is garbage. Real example from this repo: a check confirmed a count was
-> above zero while every value in it was the malformed text `AF=AF=0.3000`.
->
-> **Prove a test can fail.** Deliberately break the code a test covers and confirm the test
-> notices. If it still passes, it was never testing anything. This has repeatedly caught tests
-> that looked thorough and asserted nothing — in one case, eleven separate ways of breaking the
-> code that the whole suite ignored.
->
-> `docs/claude_engineering_audit.md` collects the case histories, including the ones where the
-> tooling fooled us for weeks. It is unusually candid for a project document and it is the best
-> single read for understanding how this codebase thinks.
+PRs target **`develop`**; `main` holds releases. GitHub issues track bugs and planned work, and
+there is a **Feedback** issue type for things that are not quite bugs — a confusing message, a
+rough edge, or something that worked well. [`CONTRIBUTING.md`](CONTRIBUTING.md) has the testing
+bar if you are writing code.
 
-> ### Deeper: HPC validation *(skip freely)*
->
-> Small tests prove the machinery runs. They cannot prove the output looks like real data at
-> genome scale. So there is a second tier on NCSA Delta: simulate a whole tumour genome, run it
-> through production variant callers (Manta, Delly, GATK), and score their output against the
-> truth with an independent tool (truvari).
->
-> That harness lives in `scripts/delta/` and is written in bash. It carries its own positive and
-> negative controls — it scores the truth against *itself* (must be perfect) and against a
-> deliberately shifted copy (must find nothing), because a scoring configuration loose enough to
-> match anything would otherwise report excellent results. Findings from those runs feed back into
-> `docs/sv_support_matrix.md`, which records exactly which capabilities are measured, which are
-> broken, and which are unverified.
-
-## How the work is organised
-
-Changes go through pull requests targeting the **`develop`** branch. `main` holds releases.
-Issues on GitHub track bugs and planned work — including a **Feedback** issue type for things
-that are not quite bugs, like a confusing error message or a rough edge.
-
-Versions follow [Semantic Versioning](https://semver.org) as of v3.0.0. The project was called
-`rusty-neat` / `rneat` before v2.0.0, so older notes and links use those names; the emitted output
-tokens changed at v3.0.0 as well, which matters if you have scripts that parse eidolon's output.
+The project was `rusty-neat` / `rneat` before v2.0.0, so older notes, links and issue titles use
+those names.
 
 ## Questions
 
-Open an issue, or message **Joshua Allen** (links on the repo page). Questions that turn out to be
-gaps in the documentation are useful — say so and it gets fixed.
-
-Worth knowing if you are wondering whether to ask: nobody here expects you to have read the whole
-codebase, and "I could not tell from the docs" is treated as a docs bug rather than a
-you-problem.
+Open an issue or message **Joshua Allen** (links on the repo page). If something was unclear here,
+that is a docs bug — say so and it gets fixed.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -13,12 +13,16 @@ Sections marked *Deeper* are skippable.
 
 ## What is the same
 
-Everything you already reason about. Subcommand shape (`gen-reads`, `gen-mut-model`,
-`gen-seq-error-model`, `gen-frag-length-model`, `gen-gc-bias-model`), YAML config, models trained
-once and reused, BED targeting, variant insertion from an input VCF, golden BAM + truth VCF
-alongside the FASTQ, single or paired end.
+If you've tried the latest versions of NEAT, you'll find the user interface very familiar. 
+* Subcommand shape (`gen-reads`, `gen-mut-model`, `gen-seq-error-model`, `gen-frag-length-model`, 
+`gen-gc-bias-model`)
+* YAML config
+* models trained once, stored, and reused as input
+* BED targeting
+* variant insertion from an input VCF
+* golden BAM + truth VCF alongside the FASTQ, single or paired end.
 
-If you can read NEAT's outputs you can read these.
+The outputs are very similar, with some added features in the VCF output, and potential for much greater complexity.
 
 ## What is different in practice
 
@@ -48,9 +52,15 @@ Cancer work is where the original effort went.
   COSMIC and PCAWG.
 - **Continuous per-variant allele fraction** from an input VCF's `AF`/`AD`, rather than genotype
   `{0.5, 1.0}`. This is what makes pooled and somatic AF spectra reproducible.
-- **Trinucleotide-context-aware SNP placement**, so SBS-96 signatures reproduce (cosine 0.99).
-- **Sequencing-error transition matrix inferrable from a BAM's MD tags**, or a custom 4×4 TSV —
-  NEAT's builders never open a BAM for this.
+- **Trinucleotide-context-aware SNP placement**, so SBS-96 signatures reproduce (cosine 0.99). Originally 
+  trimmed from `rneat` for simplicity and because it's effects were difficult to detect, we discovered this 
+  came into play in `eidolon` while looking for cancer signals, as cancer detection looks for high-SNV regions, 
+  which were missing in the fully random placement. Signals began to show up once the placement became 
+  context-aware again.
+- **Sequencing-error nucleotide substitution matrix trainable from data** — from a BAM's MD tags, or a custom 
+  4×4 TSV. NEAT 4.6.1 hardcodes this matrix (model_sequencing_error/runner.py, with its own TODO incorporate 
+  these into the calculations); its trainable Markov model covers quality-score transitions from FASTQ, 
+  a different axis.
 - **`compare-af`** (per-allele AF correlation, truth vs simulated) and **`validate`** (checks an
   emitted file against what downstream tools actually accept, before you spend a pipeline run
   finding out).


### PR DESCRIPTION
Two documents, different audiences.

## `CONTRIBUTING.md` — highlights, pointing at the depth

It was 16 lines, last touched by the v2.0.0 rename, and mentioned **none** of the practices this
project runs on — zero occurrences of mutation testing, non-vacuity, assert-content-not-existence,
known-answer fixtures, or the Delta workflow. It also still said *"we don't yet have a ticketing
system,"* which stopped being true several hundred issues ago.

It now **states the highlights and points at the depth** rather than restating it. That's the
choice that keeps it from drifting out of sync with `CLAUDE.md`:

- assert content, not existence
- prove non-vacuity by mutation (free for a fix — revert it and look)
- test the path that can break, not the path that works
- report the denominator
- say what you did **not** verify
- the bar is higher for a feature than a fix

Case histories stay in `docs/claude_engineering_audit.md`; the full rules stay in `CLAUDE.md`.

Also now documented: what CI actually gates, that PRs target `develop`, the
verify-your-commit-landed step, the no-new-Python policy, and that `gh pr edit` is broken here.

## `ONBOARDING.md` — new, for teammates

Aimed at people joining the project, **including non-technical ones**. Structured so the top of
each section carries the whole idea and every deep dive is explicitly marked skippable.

It leads with why simulated data exists at all — you cannot measure what a pipeline *missed* on
real data, because nobody knows a real genome's complete answer — then the two-output mental
model (reads your pipeline consumes; a truth file it never sees), what each subcommand does in
plain terms, a repo map, and the project's validation standard.

Three deep dives, all skippable: what "trained models" means, how the testing discipline plays
out, and the HPC validation tier with its positive and negative controls.

## Verification

Every reference checked rather than assumed:

- all 13 linked files and directories exist
- all 11 subcommands in the table appear in `eidolon --help` — note the README's list on
  `develop` is missing `validate` and `compare-af`, which #523 fixes separately
- the `cargo test --package eidolon --lib` failure documented in both files was reproduced

**Not verified:** neither document has been read by anyone but me, which is the only test that
matters for onboarding material. Tone and level in `ONBOARDING.md` especially are a judgement
call — tell me if it pitches too low or too high and I'll adjust.
