### PR TITLE
docs: drop an invented timeframe from the v3.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ the reverse *is* a duplication. eidolon has been planting DELs and DUPs and labe
 them BNDs since v1.13.1 (#224) — the #451 fix only replaced the literal `N` with the real
 anchor base, leaving the bracket form untouched.
 
-This is the root cause of `BND recall=0.000`, which survived five explanations across a
-year. It was never a caller failure and never a scoring artifact. On Delta job 20675480
+This is the root cause of `BND recall=0.000`, which survived repeated confident
+explanations. It was never a caller failure and never a scoring artifact. On Delta job 20675480
 Manta placed DEL/DUP candidates within **1–2 bp of all seven planted junctions**, emitted
 no INV and no breakend anywhere near them, and was marked as having found none of them:
 


### PR DESCRIPTION
`CHANGELOG.md` said the `BND recall=0.000` defect "survived five explanations **across a
year**".

No source in this repo carries that timeframe. `CLAUDE.md` and
`docs/claude_engineering_audit.md` both describe **three** explanations — unpaired truth, then
truvari's supposed inability, then ALT orientation — and neither names an elapsed time. Both the
count and the duration were embellishment.

The same sentence was corrected in #526 earlier. This copy survived because that sweep covered
`docs/` and the issue but not `CHANGELOG.md`, which is precisely the failure mode CLAUDE.md rule
3 warns about: *grep for every instance of a claim*. It is now the last one —
`grep -rn "across a year\|five explanations"` returns nothing outside `.git`.

Replaced with "survived repeated confident explanations": no count, no duration, and the entry's
actual point — that the defect outlasted several plausible diagnoses — is unchanged.

Docs only, no code.