### PR TITLE
test(sv): Gate 2 for DEL — assert a real aligner produces the evidence a caller needs

### DIFF
--- a/docs/sv_support_matrix.md
+++ b/docs/sv_support_matrix.md
@@ -232,6 +232,91 @@ multiplier and the depth actually delivered. Mechanism not diagnosed — see #49
 
 ---
 
+## Whole-genome tier — de novo, scored by callers
+
+Everything above is **H1N1**: 8 contigs of 1–2.3 kb, largest event ~1.2 kb. That fixture cannot
+say whether an SV behaves at the sizes anyone simulates. This section is the other tier —
+GRCh38 at 30×, purity 0.6, `SV_RATE_SCALE=1.0`, scored by Manta 1.6.0 and Delly against truvari.
+
+**It answers a different question.** The tables above are *input fidelity* — what you supplied
+came out. This is *de novo generation as an independent tool can recover it*. Neither
+substitutes for the other, and the gap between them is the subject of
+`docs/sv_polish_roadmap.md`.
+
+**Job 21072620** (2026-08-13, 1173.7 core-hours, 127 somatic SVs planted):
+
+| type | truth | Manta | Delly | note |
+|---|---|---|---|---|
+| DEL | 29 | 0.828 | 0.862 | query coverage 28/40 and 37/58 — precision rests on the scored subset |
+| DUP | 32 | 0.875 | 0.875 | identical across two independent callers |
+| INV | 9 | 1.000 | 1.000 | precision 0.500 both — see below, it is our representation |
+| BND | 50 (= 25 junctions) | 0.920 | 0.440 | Delly's figure is a caller limitation, not a simulator defect |
+| CNV | 6 | 4 of 6 by direction | — | denominator of 6 is thin |
+| INS | 1 | 0 | 0 | verified miss; see below |
+
+Calibration controls passed: truth-vs-truth recall 1.000 with **all** 71 scoreable records
+scored, decoy (shifted truth) recall 0.000; same for BND across all 50. So the matching
+configuration is not loose enough to accept anything.
+
+### BND geometry is fixed, confirmed at genome scale
+
+This is the first whole-genome confirmation of the v3.1.0 fix. `BND recall=0.000` was the
+symptom of a truth VCF describing a rearrangement the reads did not carry; it now reads:
+
+```
+BND geometry: 50 record(s), 50 parsed into a form, 0 unparsable
+  t[p[  direct/deletion-like    9      t]p]  head-to-head            18
+  [p[t  tail-to-tail           14      ]p]t  direct/duplication-like  9
+  reciprocity: 0 unpaired, 0 mispaired
+```
+
+All four bracket forms present, every record parsed, **0 unpaired and 0 mispaired** — the
+#451-era failure (truth emitted unmatchable by construction) is gone, and Manta independently
+recovers 46 of the 50 records from the reads alone.
+
+### INV precision 0.500 is ours, not the callers'
+
+Both callers report TP=9, FP=9 — *identically*. The pipeline predicts this in its own pre-flight:
+16 of the truth's junctions are inversion-oriented (`t]p]` or `[p[t`), and a caller's breakends
+for those convert to `<INV>` via Manta's `convertInversion.py`, landing as INV false positives.
+Two independent callers arriving at the same number is the evidence that it is a representation
+artifact. **INV recall 1.000 is real; INV precision from this tier is not quotable.**
+
+### INS: one planted, one verified present, zero found
+
+`truth INS: 1` (65 bp) is the #516 cap working as designed, and the drop log proves it rather
+than implying it: 2 insertions dropped (chr2, chr19) + 1 kept = 3 draws, against ~3.5 expected
+from `Ins = 0.0279` over ~130 SVs, of which ~0.9 were expected to survive the 150 bp cap.
+
+`INS read support: 1 of 1` — 7 reads carry a 30-mer from the **middle** of the inserted
+sequence. This is the first campaign to check that the reads contained what the truth declared
+*before* the BAMs were pruned, which is exactly how #516 survived three campaigns.
+
+Neither caller found it. Manta's only INS call was a false positive on another chromosome
+(`chr11:99348945`, 58 bp, non-PASS); nothing was called within 2 kb of the planted event. Delly
+emitted no INS records at all. So the miss is **verified rather than inferred** — the reads
+demonstrably carried the insertion. With n=1 this does not constrain a recall rate (95% CI
+≈ [0, 0.98]); why it was missed is unresolved, and separating "somatic-score threshold at ~7
+supporting reads" from "the reads lack a signature the aligner can present" needs `PRUNE_BAM=0`
+and a look at the CIGARs.
+
+**A 30× GRCh38 replicate yields ~3 INS draws and ~1 after the cap.** INS cannot be validated at
+caller level from single replicates at any runtime — it needs pooled replicates or an
+INS-enriched model.
+
+### What this tier does NOT establish
+
+- **Input fidelity at scale.** Every cell above this section is still H1N1-only.
+- **Dosage.** Detection is not dosage; the ~8% over-delivery (#499) was measured on a 1.2 kb
+  event and has never been checked at these sizes.
+- **Subclonal behaviour.** SVs receive no CCF at all ([#537](https://github.com/ncsa/eidolon/issues/537)),
+  so every somatic SV here is clonal within the tumor regardless of the subclone model.
+- **Small events.** The planted set skews very large (DUP 3.4 Mb, DEL 9.1 Mb, INV 2.0 Mb).
+  Multi-megabase events are easy to detect by depth; these recall figures say little about the
+  1–50 kb range where callers actually struggle.
+
+---
+
 ## De novo generation
 
 | type | source | status |

--- a/docs/sv_support_matrix.md
+++ b/docs/sv_support_matrix.md
@@ -299,14 +299,17 @@ from `Ins = 0.0279` over ~130 SVs, of which ~0.9 were expected to survive the 15
 sequence. This is the first campaign to check that the reads contained what the truth declared
 *before* the BAMs were pruned, which is exactly how #516 survived three campaigns.
 
-> ❌ **And in the very next replicate it failed.** Job 21076622, same array, reports
-> `INS read support: 0 of 1` — a planted insertion whose reads do not contain its middle,
-> which is #516's failure mode occurring *after* the interim cap. Of two insertions planted
-> across four replicates, one is unsupported. **The cap at `read_len - 1` does not guarantee
-> the reads support the truth**; it enforces the *head* visibility condition, which carries no
-> length term, while the middle condition (`anchor_offset <= 84 - L/2`) tightens as the
-> insertion grows. An insertion just under the cap is plantable and still hollow. See #516.
-> Note also that the run reported `0 of 1` and exited 0, archiving the replicate as a result.
+> ⚠ **But the check itself is not trustworthy yet.** Job 21076622, same array, reports
+> `INS read support: 0 of 1` — which turned out to measure nothing. Its probe file is well
+> formed (`chr3 92124128 56bp` + a valid 30-mer), yet no per-insertion line was emitted on
+> stdout or stderr: `count_probe_hits` produced no output, the reporting loop ran zero
+> iterations, and the `0` is an untouched initialiser printed against an independently counted
+> `n_probes`. Worse, `unsupported` stayed `0`, so the failure gate never fired and the
+> replicate archived as a clean result ([#540](https://github.com/ncsa/eidolon/issues/540)).
+>
+> The `1 of 1` above came through the same code path. It did print its detail line, so it is
+> probably a true pass, but **treat the #516 cap as unverified in production** until #540 is
+> fixed and both replicates are re-checked.
 
 Neither caller found it. Manta's only INS call was a false positive on another chromosome
 (`chr11:99348945`, 58 bp, non-PASS); nothing was called within 2 kb of the planted event. Delly

--- a/docs/sv_support_matrix.md
+++ b/docs/sv_support_matrix.md
@@ -243,6 +243,13 @@ came out. This is *de novo generation as an independent tool can recover it*. Ne
 substitutes for the other, and the gap between them is the subject of
 `docs/sv_polish_roadmap.md`.
 
+> ⚠ **ONE REPLICATE.** Everything below is job 21072620 alone. `aggregate_sv_reps.sh` exists
+> because a single run is not the intended unit of analysis: at `SV_RATE_SCALE=1.0` GRCh38
+> yields ~25 translocations per run, so **~8 replicates** are needed for a meaningful
+> recall/precision figure, pooled as summed TP/FN/FP rather than as a mean of per-replicate
+> ratios. Treat every number here as one draw, not as a result. Replicates from the same array
+> (seeds 9–12) have not been pooled in.
+
 **Job 21072620** (2026-08-13, 1173.7 core-hours, 127 somatic SVs planted):
 
 | type | truth | Manta | Delly | note |
@@ -302,7 +309,8 @@ and a look at the CIGARs.
 
 **A 30× GRCh38 replicate yields ~3 INS draws and ~1 after the cap.** INS cannot be validated at
 caller level from single replicates at any runtime — it needs pooled replicates or an
-INS-enriched model.
+INS-enriched model. Across the ~8 replicates the aggregator targets that is still only ~8
+planted insertions, so an INS-enriched model is likely the only route to a usable denominator.
 
 ### What this tier does NOT establish
 

--- a/docs/sv_support_matrix.md
+++ b/docs/sv_support_matrix.md
@@ -243,23 +243,58 @@ came out. This is *de novo generation as an independent tool can recover it*. Ne
 substitutes for the other, and the gap between them is the subject of
 `docs/sv_polish_roadmap.md`.
 
-> ⚠ **ONE REPLICATE.** Everything below is job 21072620 alone. `aggregate_sv_reps.sh` exists
-> because a single run is not the intended unit of analysis: at `SV_RATE_SCALE=1.0` GRCh38
-> yields ~25 translocations per run, so **~8 replicates** are needed for a meaningful
-> recall/precision figure, pooled as summed TP/FN/FP rather than as a mean of per-replicate
-> ratios. Treat every number here as one draw, not as a result. Replicates from the same array
-> (seeds 9–12) have not been pooled in.
+> ⚠ **Four replicates, pooled — against a target of ~8.** `aggregate_sv_reps.sh` pools summed
+> TP/FN/FP (not a mean of per-replicate ratios, which would weight a replicate with 3 events the
+> same as one with 40). At `SV_RATE_SCALE=1.0` GRCh38 yields ~25 translocations per run, so ~8
+> replicates is the design target. Per-replicate truth counts vary widely — BND 50–76, INV 9–20,
+> DUP 18–34 — so single-replicate figures were never going to be stable.
+>
+> ⚠ **Every recall below is PASS-only.** truvari is run with `--passonly`, so a truth event whose
+> only matching call was non-PASS is scored FN. Measured instance: `chr10:45850637` was called by
+> Manta with *identical* POS/END/SVLEN and scored a DUP false negative because its FILTER was
+> `MinSomaticScore`. These recalls are therefore **underestimates by an unmeasured amount** —
+> see [#541](https://github.com/ncsa/eidolon/issues/541).
 
-**Job 21072620** (2026-08-13, 1173.7 core-hours, 127 somatic SVs planted):
+**Array 21072620** (2026-08-13, seeds 9–12, GRCh38 30x, purity 0.6, `SV_RATE_SCALE=1.0`),
+pooled over 4 replicates:
 
-| type | truth | Manta | Delly | note |
-|---|---|---|---|---|
-| DEL | 29 | 0.828 | 0.862 | query coverage 28/40 and 37/58 — precision rests on the scored subset |
-| DUP | 32 | 0.875 | 0.875 | identical across two independent callers |
-| INV | 9 | 1.000 | 1.000 | precision 0.500 both — see below, it is our representation |
-| BND | 50 (= 25 junctions) | 0.920 | 0.440 | Delly's figure is a caller limitation, not a simulator defect |
-| CNV | 6 | 4 of 6 by direction | — | denominator of 6 is thin |
-| INS | 1 | 0 | 0 | verified miss; see below |
+| scorer | reps | TP | FN | FP | recall | precision |
+|---|---|---|---|---|---|---|
+| `manta_overall` | 4 | 255 | 30 | 84 | 0.895 | 0.752 |
+| `manta_DEL` | 4 | 105 | 11 | 13 | 0.905 | 0.890 |
+| `manta_DUP` | 4 | 91 | 14 | 15 | 0.867 | 0.858 |
+| `manta_INV` | 4 | 59 | 3 | 56 | 0.952 | 0.513 |
+| `manta_BND` | 4 | 214 | 28 | 230 | 0.884 | 0.482 |
+| `manta_INS` | **2** | 0 | 2 | 0 | 0.000 | — |
+| `delly_overall` | 4 | 253 | 32 | 114 | 0.888 | 0.689 |
+| `delly_DEL` | 4 | 104 | 12 | 44 | 0.897 | 0.703 |
+| `delly_DUP` | 4 | 91 | 14 | 17 | 0.867 | 0.843 |
+| `delly_INV` | 4 | 58 | 4 | 52 | 0.935 | 0.527 |
+| `delly_BND` | 4 | 108 | 134 | 0 | 0.446 | **1.000** |
+| `delly_INS` | **1** | 0 | 1 | 1 | 0.000 | — |
+
+The INS rows ran in 1 and 2 of 4 replicates respectively and are **not comparable** with the
+rest; the aggregator says so itself rather than pooling them silently.
+
+### DUP: both callers miss the identical set, and one of them is ours
+
+`manta_DUP` and `delly_DUP` agree to the record — TP=91, FN=14 — differing only in FP. Two
+independent callers missing the same events points at a property of the events, not the callers.
+Examined for one replicate (FN = 4):
+
+| missed DUP | size | N content | called by Manta? |
+|---|---|---|---|
+| chr14:66171649 | 16 kb | 0.0% | nothing |
+| chr11:39805201 | 43 kb | 0.0% | nothing |
+| chr10:45850637 | 122 kb | 0.0% | **yes, exactly — filtered by `--passonly`** |
+| chr15:19940438 | 1.7 Mb | 5.2% | nothing |
+
+So it is **not** a size floor (1.7 Mb is trivially detectable by depth) and **not** assembly
+gaps (three are 0.0% N; SV placement already requires a ±200 bp N-free window at both
+breakpoints, `sv_model.rs` `ALIGNABLE_WINDOW`, #224). One of the four is a filter artifact
+(#541). The remaining three — including a megabase-scale duplication with nothing called
+anywhere near it — are unexplained, and diagnosing them needs reads, so `PRUNE_BAM=0` on a
+future run.
 
 Calibration controls passed: truth-vs-truth recall 1.000 with **all** 71 scoreable records
 scored, decoy (shifted truth) recall 0.000; same for BND across all 50. So the matching

--- a/docs/sv_support_matrix.md
+++ b/docs/sv_support_matrix.md
@@ -299,6 +299,15 @@ from `Ins = 0.0279` over ~130 SVs, of which ~0.9 were expected to survive the 15
 sequence. This is the first campaign to check that the reads contained what the truth declared
 *before* the BAMs were pruned, which is exactly how #516 survived three campaigns.
 
+> ❌ **And in the very next replicate it failed.** Job 21076622, same array, reports
+> `INS read support: 0 of 1` — a planted insertion whose reads do not contain its middle,
+> which is #516's failure mode occurring *after* the interim cap. Of two insertions planted
+> across four replicates, one is unsupported. **The cap at `read_len - 1` does not guarantee
+> the reads support the truth**; it enforces the *head* visibility condition, which carries no
+> length term, while the middle condition (`anchor_offset <= 84 - L/2`) tightens as the
+> insertion grows. An insertion just under the cap is plantable and still hollow. See #516.
+> Note also that the run reported `0 of 1` and exited 0, archiving the replicate as a result.
+
 Neither caller found it. Manta's only INS call was a false positive on another chromosome
 (`chr11:99348945`, 58 bp, non-PASS); nothing was called within 2 kb of the planted event. Delly
 emitted no INS records at all. So the miss is **verified rather than inferred** — the reads

--- a/eidolon/tests/gate2_realigned_del.rs
+++ b/eidolon/tests/gate2_realigned_del.rs
@@ -1,0 +1,362 @@
+//! **Gate 2 for DEL** — does a real aligner, given eidolon's FASTQ, produce the evidence a
+//! structural-variant caller actually looks for?
+//!
+//! Every other SV test in this repo inspects eidolon's own output: the FASTQ bases, the golden
+//! BAM, the truth VCF. All three are eidolon describing its own work. A caller never sees any of
+//! them — it sees reads that someone else aligned. **Nothing has ever checked that step.** The
+//! whole-genome campaigns jump straight from FASTQ to "did Manta find it", which conflates
+//! "the evidence is correct" with "the evidence was sufficient", and cannot tell you which
+//! failed when the answer is no.
+//!
+//! So this aligns eidolon's reads with **bwa-mem2** and asserts, on the resulting alignment, the
+//! three signatures every read-based DEL caller keys on:
+//!
+//! | signature | why a caller needs it |
+//! |---|---|
+//! | depth collapses over the deleted interval | depth-based callers (CNVnator, GATK gCNV) |
+//! | soft clips pile up at both breakpoints | split-read callers (Manta, Delly, LUMPY) |
+//! | spanning pairs have TLEN inflated by ~SVLEN | discordant-pair callers (all of the above) |
+//!
+//! Each is asserted against a **no-variant control** built from the same reference, seed and
+//! coverage, so "the signature is present" cannot be satisfied by background noise — which is
+//! how a 13% artifact once read as a real DUP defect (see `docs/sv_support_matrix.md`).
+//!
+//! ## Why this test is `#[ignore]`d
+//!
+//! CI has no aligner. Rather than skip silently when `bwa-mem2` is missing — a pass that means
+//! nothing, the exact shape this project keeps re-earning — the test **fails** with instructions
+//! if the binary is absent, and is `#[ignore]`d so CI never reaches it. Run it deliberately:
+//!
+//! ```text
+//! conda activate aln          # or: export BWA_MEM2=/path/to/bwa-mem2
+//! cargo test --test gate2_realigned_del -- --ignored --nocapture
+//! ```
+//!
+//! The analysis is done in Rust over the SAM with `noodles`, not by piping samtools through awk,
+//! so it is debuggable and its arithmetic is visible.
+
+mod common;
+
+use common::{GenReadsConfig, eidolon, fresh_workdir, h1n1_reference};
+use noodles::sam;
+use noodles::sam::alignment::record::cigar::op::Kind;
+use std::io::{BufRead, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The planted deletion. Homozygous so every fragment over the locus carries it — a het event
+/// halves every signal below and would make the control comparison a ratio rather than a
+/// presence/absence question.
+const CONTIG: &str = "H1N1_HA";
+const DEL_POS: usize = 500; // 1-based anchor; deleted bases are POS+1..=END
+const DEL_END: usize = 799;
+const DEL_LEN: usize = DEL_END - DEL_POS; // 299 deleted reference bases
+
+/// Locate bwa-mem2, or fail with something actionable. Never returns a "skip".
+fn bwa_mem2() -> String {
+    if let Ok(p) = std::env::var("BWA_MEM2") {
+        assert!(
+            Path::new(&p).is_file(),
+            "BWA_MEM2={p} does not exist. Gate 2 cannot run without an aligner."
+        );
+        return p;
+    }
+    let found = Command::new("bwa-mem2")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        found,
+        "bwa-mem2 not found on PATH.\n\
+         Gate 2 realigns eidolon's FASTQ with a real aligner; there is nothing to assert \
+         without one.\n\
+         On this workstation it lives in the `aln` conda environment:\n\
+         \n    conda activate aln\n\
+         \nor point at it directly:\n\
+         \n    BWA_MEM2=/path/to/bwa-mem2 cargo test --test gate2_realigned_del -- --ignored\n"
+    );
+    "bwa-mem2".to_string()
+}
+
+fn run(cmd: &mut Command, what: &str) {
+    let out = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("{what}: failed to spawn: {e}"));
+    assert!(
+        out.status.success(),
+        "{what} failed ({}):\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Generate paired reads over H1N1, optionally with a homozygous symbolic DEL.
+/// Same seed and coverage either way, so the control differs only by the variant.
+fn generate_reads(work: &Path, tag: &str, with_del: bool) -> (PathBuf, PathBuf) {
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.to_path_buf(), tag);
+    config.coverage = 60;
+    config.read_len = 100;
+    config.paired_ended = true;
+    config.produce_fastq = true;
+    config.produce_bam = false;
+    config.produce_vcf = true;
+    // No de novo variants: the only difference between the two runs must be the planted DEL.
+    config.mutation_rate = Some(0.0);
+    config.sv_rate_scale = Some(0.0);
+
+    if with_del {
+        let input_vcf = work.join(format!("{tag}.vcf"));
+        let mut f = std::fs::File::create(&input_vcf).unwrap();
+        writeln!(f, "##fileformat=VCFv4.2").unwrap();
+        writeln!(
+            f,
+            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"SV type\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{CONTIG}\t{DEL_POS}\t.\tG\t<DEL>\t60\tPASS\tSVTYPE=DEL;END={DEL_END}\tGT\t1/1"
+        )
+        .unwrap();
+        config.input_vcf = Some(input_vcf);
+    }
+
+    let yaml = config.write_yaml();
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let r1 = work.join(format!("{tag}_r1.fastq.gz"));
+    let r2 = work.join(format!("{tag}_r2.fastq.gz"));
+    assert!(r1.is_file() && r2.is_file(), "expected {r1:?} and {r2:?}");
+    (r1, r2)
+}
+
+/// What a caller can see, extracted from a realigned SAM.
+#[derive(Debug, Default)]
+struct Signatures {
+    /// Mean depth strictly inside the deleted interval.
+    depth_inside: f64,
+    /// Mean depth in a control window well clear of the event.
+    depth_outside: f64,
+    /// Soft-clipped bases whose clip point falls within ±25 bp of either breakpoint.
+    clips_at_breakpoints: usize,
+    /// Soft clips anywhere else — the background this must stand out from.
+    clips_elsewhere: usize,
+    /// Properly-paired reads whose |TLEN| exceeds the no-variant mode by ~DEL_LEN.
+    discordant_pairs: usize,
+    reads: usize,
+}
+
+/// Parse the SAM and accumulate the three signatures. Deliberately in Rust rather than
+/// `samtools | awk`: the arithmetic below is the assertion, and it should be readable.
+fn analyse(sam_path: &Path) -> Signatures {
+    let mut reader = std::fs::File::open(sam_path)
+        .map(std::io::BufReader::new)
+        .map(sam::io::Reader::new)
+        .unwrap();
+    let header = reader.read_header().unwrap();
+
+    // Depth is accumulated over the whole contig, then summarised over two windows.
+    let contig_len = 1_800usize;
+    let mut depth = vec![0usize; contig_len];
+    let mut sig = Signatures::default();
+
+    let _ = &header;
+    for result in reader.records() {
+        let record = result.unwrap();
+        // H1N1 has EIGHT contigs. Without this filter every contig's reads land in one depth
+        // array, the deleted window gets backfilled by unrelated contigs, and the deletion
+        // vanishes into an apparent 1.2x ENRICHMENT. The control comparison is what caught it.
+        let on_target = matches!(
+            record.reference_sequence_name(),
+            Some(n) if n == CONTIG.as_bytes()
+        );
+        if !on_target {
+            continue;
+        }
+        let Some(Ok(start)) = record.alignment_start() else {
+            continue;
+        };
+        sig.reads += 1;
+        let start = usize::from(start); // 1-based
+
+        // Walk the CIGAR: M/=/X/D/N advance the reference, S records a clip point.
+        let mut ref_pos = start;
+        let mut first_op = true;
+        let ops: Vec<_> = record.cigar().iter().map(|o| o.unwrap()).collect();
+        for (i, op) in ops.iter().enumerate() {
+            let len = op.len();
+            match op.kind() {
+                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                    for p in ref_pos..(ref_pos + len).min(contig_len) {
+                        depth[p] += 1;
+                    }
+                    ref_pos += len;
+                }
+                Kind::Deletion | Kind::Skip => ref_pos += len,
+                Kind::SoftClip => {
+                    // A leading clip points at this read's start; a trailing clip at ref_pos.
+                    let clip_at = if first_op && i == 0 { start } else { ref_pos };
+                    let near = |bp: usize| clip_at.abs_diff(bp) <= 25;
+                    if near(DEL_POS) || near(DEL_END) {
+                        sig.clips_at_breakpoints += 1;
+                    } else {
+                        sig.clips_elsewhere += 1;
+                    }
+                }
+                _ => {}
+            }
+            first_op = false;
+        }
+
+        // A fragment spanning the deletion aligns with its mate ~DEL_LEN further away than a
+        // fragment that does not. Count only clearly-inflated pairs, once per pair.
+        let tlen = record
+            .template_length()
+            .map(|t| t.unsigned_abs() as usize)
+            .unwrap_or(0);
+        if record.flags().is_ok_and(|f| f.is_first_segment()) && tlen > 250 + DEL_LEN / 2 {
+            sig.discordant_pairs += 1;
+        }
+    }
+
+    let mean = |lo: usize, hi: usize| -> f64 {
+        let slice = &depth[lo.min(contig_len)..hi.min(contig_len)];
+        if slice.is_empty() {
+            return 0.0;
+        }
+        slice.iter().sum::<usize>() as f64 / slice.len() as f64
+    };
+    // Strictly interior: 20 bp in from each breakpoint, so a read clipped at the junction
+    // cannot contribute and the window measures the deletion rather than its edges.
+    sig.depth_inside = mean(DEL_POS + 20, DEL_END - 20);
+    sig.depth_outside = mean(1_000, 1_400);
+    sig
+}
+
+fn align(bwa: &str, work: &Path, tag: &str, r1: &Path, r2: &Path) -> PathBuf {
+    // Index into the work dir so the repo's test_data is never written to.
+    let local_ref = work.join("ref.fa");
+    std::fs::copy(h1n1_reference(), &local_ref).unwrap();
+    run(
+        Command::new(bwa).arg("index").arg(&local_ref),
+        "bwa-mem2 index",
+    );
+
+    let sam_path = work.join(format!("{tag}.sam"));
+    let out = Command::new(bwa)
+        .args(["mem", "-t", "2"])
+        .arg(&local_ref)
+        .arg(r1)
+        .arg(r2)
+        .output()
+        .expect("bwa-mem2 mem failed to spawn");
+    assert!(
+        out.status.success(),
+        "bwa-mem2 mem failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    std::fs::write(&sam_path, &out.stdout).unwrap();
+
+    // A SAM with a header but no alignments would sail through every assertion below as
+    // "no signal", so establish that reads were actually placed.
+    let mapped = std::io::BufReader::new(std::fs::File::open(&sam_path).unwrap())
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.starts_with('@'))
+        .count();
+    assert!(
+        mapped > 100,
+        "{tag}: bwa-mem2 emitted only {mapped} alignment record(s) — the alignment step \
+         failed, so nothing below would be measuring the deletion"
+    );
+    sam_path
+}
+
+#[test]
+#[ignore = "requires bwa-mem2; run with --ignored (see module docs)"]
+fn gate2_del_produces_the_three_signatures_a_caller_needs() {
+    let bwa = bwa_mem2();
+    let (_dir, work) = fresh_workdir();
+
+    let (dr1, dr2) = generate_reads(&work, "withdel", true);
+    let (cr1, cr2) = generate_reads(&work, "control", false);
+
+    let del = analyse(&align(&bwa, &work, "withdel", &dr1, &dr2));
+    let ctl = analyse(&align(&bwa, &work, "control", &cr1, &cr2));
+
+    println!("  DEL run: {del:?}");
+    println!("  control: {ctl:?}");
+
+    // ── Signature 1: depth collapses over the deletion ────────────────────────────────
+    // Homozygous, so the interior should be ~empty rather than merely reduced. Asserted as a
+    // ratio against the same run's own flanking depth, which cancels any coverage difference
+    // between the two runs.
+    let del_ratio = del.depth_inside / del.depth_outside.max(1e-9);
+    let ctl_ratio = ctl.depth_inside / ctl.depth_outside.max(1e-9);
+    assert!(
+        del_ratio < 0.10,
+        "depth over a HOMOZYGOUS deletion should collapse; interior/flank was {del_ratio:.3} \
+         (inside {:.1}x, outside {:.1}x)",
+        del.depth_inside,
+        del.depth_outside
+    );
+    // MUST-NOT-FIRE: the control has no deletion, so the same window must be normally covered.
+    // Without this, a run that produced no reads over the region for an unrelated reason would
+    // satisfy the assertion above.
+    assert!(
+        ctl_ratio > 0.80,
+        "control has no deletion, yet the same window is depleted (ratio {ctl_ratio:.3}) — \
+         the window itself is unreliable, so signature 1 proves nothing"
+    );
+
+    // ── Signature 2: split reads pile up at the breakpoints ───────────────────────────
+    assert!(
+        del.clips_at_breakpoints >= 5,
+        "a split-read caller needs clipped reads at the junction; found {} within ±25bp of \
+         {DEL_POS}/{DEL_END}",
+        del.clips_at_breakpoints
+    );
+    // MUST-NOT-FIRE: clipping at the breakpoints must be specific to the deletion, not the
+    // aligner's background rate on this fixture.
+    assert!(
+        del.clips_at_breakpoints > ctl.clips_at_breakpoints * 3,
+        "breakpoint clipping ({}) is not clearly above the control's background ({}) — \
+         a caller could not distinguish it either",
+        del.clips_at_breakpoints,
+        ctl.clips_at_breakpoints
+    );
+
+    // ── Signature 3: spanning pairs are discordant by ~SVLEN ──────────────────────────
+    assert!(
+        del.discordant_pairs >= 5,
+        "a paired-end caller needs pairs whose insert size is inflated by the deletion; \
+         found {}",
+        del.discordant_pairs
+    );
+    assert!(
+        del.discordant_pairs > ctl.discordant_pairs * 3,
+        "discordant pairs ({}) are not clearly above the control's background ({})",
+        del.discordant_pairs,
+        ctl.discordant_pairs
+    );
+}


### PR DESCRIPTION
First **Gate 2** evidence in the project (see #538 for what the gates are).

## Why

Every SV test here inspects eidolon's own output — FASTQ bases, golden BAM, truth VCF. All three
are eidolon describing its own work. **A caller never sees any of them.** It sees reads someone
else aligned, and nothing had ever checked that step. The whole-genome campaigns jump from FASTQ
straight to "did Manta find it", which conflates *the evidence is correct* with *the evidence was
sufficient* — and cannot tell you which failed when the answer is no. That ambiguity is exactly
what left the missed DUPs in job 21072620 unexplainable.

## What it asserts

Aligns eidolon's reads with **bwa-mem2**, then asserts the three signatures a read-based DEL
caller keys on, each against a **no-variant control** from the same reference, seed and coverage:

| signature | with DEL | control |
|---|---|---|
| depth inside the deletion | **0.0** | 63.1 |
| depth outside | 66.5 | 65.3 |
| soft clips at breakpoints | **62** | 1 |
| discordant pairs | **46** | 0 |

Homozygous 299 bp DEL at `H1N1_HA:500-799`, 60× paired 100 bp. **Gate 2 for DEL passes.**

## Non-vacuity — mutations of eidolon, not of the test

| mutation | effect | caught by |
|---|---|---|
| hom DEL coverage multiplier `0.0 → 1.0` | depth ratio 0.631 | depth assertion |
| junction reads emit only their left piece | clips 62 → **0**, discordant 46 → **0** | split-read assertion |

The second is the informative one: **depth stayed at 0.0.** A depth-only check would have passed
over reads carrying no junction evidence whatsoever — the same partial-evidence shape as #516.
The three signatures are independent and all three are needed.

## Analysis in Rust, and it caught its own bug immediately

The SAM is parsed with `noodles` rather than `samtools | awk`, on the argument that measurement
logic belongs where it can be read and tested. That paid for itself on the first run: depth was
being accumulated across **all eight H1N1 contigs**, which backfilled the deleted window and
turned a homozygous deletion into an apparent **1.2× enrichment**. The control comparison is what
exposed it — the control's interior was elevated too, which cannot happen for a window with no
variant.

## Running it

CI has no aligner. Rather than skip silently when `bwa-mem2` is absent — a pass that means
nothing — the test **fails with instructions** and is `#[ignore]`d so CI never reaches it:

```bash
conda activate aln    # bwa-mem2 lives here; or set BWA_MEM2=/path/to/bwa-mem2
cargo test --test gate2_realigned_del -- --ignored --nocapture
```

`cargo test --workspace` is unaffected: 34 suites green under `RUSTFLAGS="-D warnings"`.

## What is NOT verified

One event size, one genotype, one aligner, one fixture. Nothing about heterozygous deletions,
events near a read length, or minimap2/STAR clipping conventions. DEL only — DUP, INV, BND, CNV
and INS have no Gate 2 yet.