### PR TITLE
test(sv): Gate 2 for DUP, and a measured mechanism for #499

### DIFF
--- a/eidolon/tests/common/gate2.rs
+++ b/eidolon/tests/common/gate2.rs
@@ -1,0 +1,297 @@
+//! Shared machinery for **Gate 2** — realigning eidolon's FASTQ with a real aligner and asking
+//! whether the result carries the evidence a structural-variant caller keys on.
+//!
+//! See `docs/sv_polish_roadmap.md` for what the gates are. The short version: every other SV
+//! test inspects eidolon describing its own work (its FASTQ, its golden BAM, its truth VCF). A
+//! caller sees none of those — it sees reads somebody else aligned. This module is the seam.
+//!
+//! Analysis is deliberately done in Rust over the SAM with `noodles` rather than by piping
+//! `samtools` through `awk`: the arithmetic *is* the assertion, so it should be readable and
+//! debuggable. That choice caught a bug on its first run — depth was being accumulated across
+//! all eight H1N1 contigs, which backfilled a deleted window and turned a homozygous deletion
+//! into an apparent 1.2x *enrichment*.
+
+#![allow(dead_code)]
+
+use super::{GenReadsConfig, eidolon, fresh_workdir, h1n1_reference};
+use noodles::sam;
+use noodles::sam::alignment::record::cigar::op::Kind;
+use std::io::{BufRead, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Reference window used as the "unaffected" baseline in every gate. Well clear of the event
+/// loci the gates plant, and on the same contig so it shares that contig's coverage.
+pub const FLANK_WINDOW: (usize, usize) = (1_000, 1_400);
+
+/// A symbolic SV to plant via `input_vcf`.
+pub struct SvSpec {
+    pub svtype: &'static str,
+    pub contig: &'static str,
+    pub pos: usize,
+    pub end: usize,
+    /// `"1/1"` for homozygous. Gates use hom so a signature is present or absent rather than
+    /// halved — a het event turns every assertion below into a ratio judgement.
+    pub gt: &'static str,
+}
+
+/// Locate bwa-mem2, or fail with something actionable. **Never returns a "skip"** — a gate that
+/// silently passes when its aligner is missing is worth less than no gate at all.
+pub fn bwa_mem2() -> String {
+    if let Ok(p) = std::env::var("BWA_MEM2") {
+        assert!(
+            Path::new(&p).is_file(),
+            "BWA_MEM2={p} does not exist. Gate 2 cannot run without an aligner."
+        );
+        return p;
+    }
+    let found = Command::new("bwa-mem2")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        found,
+        "bwa-mem2 not found on PATH.\n\
+         Gate 2 realigns eidolon's FASTQ with a real aligner; there is nothing to assert \
+         without one.\n\
+         On this workstation it lives in the `aln` conda environment:\n\
+         \n    conda activate aln\n\
+         \nor point at it directly:\n\
+         \n    BWA_MEM2=/path/to/bwa-mem2 cargo test --test <gate> -- --ignored\n"
+    );
+    "bwa-mem2".to_string()
+}
+
+/// Generate paired reads over H1N1, optionally planting one symbolic SV. The control run uses
+/// the same reference, seed and coverage, so the two differ **only** by the variant.
+pub fn generate_reads(work: &Path, tag: &str, sv: Option<&SvSpec>) -> (PathBuf, PathBuf) {
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.to_path_buf(), tag);
+    config.coverage = 60;
+    config.read_len = 100;
+    config.paired_ended = true;
+    config.produce_fastq = true;
+    config.produce_bam = false;
+    config.produce_vcf = true;
+    // No de novo variants: the only difference between run and control must be the planted SV.
+    config.mutation_rate = Some(0.0);
+    config.sv_rate_scale = Some(0.0);
+
+    if let Some(sv) = sv {
+        let input_vcf = work.join(format!("{tag}.vcf"));
+        let mut f = std::fs::File::create(&input_vcf).unwrap();
+        writeln!(f, "##fileformat=VCFv4.2").unwrap();
+        writeln!(
+            f,
+            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"SV type\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}\t{}\t.\tG\t<{}>\t60\tPASS\tSVTYPE={};END={}\tGT\t{}",
+            sv.contig, sv.pos, sv.svtype, sv.svtype, sv.end, sv.gt
+        )
+        .unwrap();
+        config.input_vcf = Some(input_vcf);
+    }
+
+    let yaml = config.write_yaml();
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let r1 = work.join(format!("{tag}_r1.fastq.gz"));
+    let r2 = work.join(format!("{tag}_r2.fastq.gz"));
+    assert!(r1.is_file() && r2.is_file(), "expected {r1:?} and {r2:?}");
+    (r1, r2)
+}
+
+/// Align a FASTQ pair with bwa-mem2 and return the path to the SAM.
+pub fn align(bwa: &str, work: &Path, tag: &str, r1: &Path, r2: &Path) -> PathBuf {
+    // Index into the work dir so the repo's test_data is never written to.
+    let local_ref = work.join("ref.fa");
+    if !local_ref.exists() {
+        std::fs::copy(h1n1_reference(), &local_ref).unwrap();
+        let out = Command::new(bwa)
+            .arg("index")
+            .arg(&local_ref)
+            .output()
+            .expect("bwa-mem2 index failed to spawn");
+        assert!(
+            out.status.success(),
+            "bwa-mem2 index failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let sam_path = work.join(format!("{tag}.sam"));
+    let out = Command::new(bwa)
+        .args(["mem", "-t", "2"])
+        .arg(&local_ref)
+        .arg(r1)
+        .arg(r2)
+        .output()
+        .expect("bwa-mem2 mem failed to spawn");
+    assert!(
+        out.status.success(),
+        "bwa-mem2 mem failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    std::fs::write(&sam_path, &out.stdout).unwrap();
+
+    // A SAM with a header and no alignments would satisfy every "no signal" branch below, so
+    // establish that reads were actually placed before anything is measured.
+    let mapped = std::io::BufReader::new(std::fs::File::open(&sam_path).unwrap())
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.starts_with('@'))
+        .count();
+    assert!(
+        mapped > 100,
+        "{tag}: bwa-mem2 emitted only {mapped} alignment record(s) — the alignment step failed, \
+         so nothing measured from it would mean anything"
+    );
+    sam_path
+}
+
+/// What a caller can see, extracted from a realigned SAM.
+#[derive(Debug, Default)]
+pub struct Signatures {
+    /// Mean depth strictly inside the event (20 bp in from each breakpoint, so a read clipped
+    /// at a junction cannot contribute and the window measures the event, not its edges).
+    pub depth_inside: f64,
+    /// Mean depth over `FLANK_WINDOW`, well clear of the event.
+    pub depth_outside: f64,
+    /// Soft clips whose clip point is within ±25 bp of either breakpoint.
+    pub clips_at_breakpoints: usize,
+    /// Soft clips anywhere else — the background the above must stand out from.
+    pub clips_elsewhere: usize,
+    /// Leftmost-read-of-pair with |TLEN| inflated well past the fragment mean. The
+    /// **deletion** signature: a pair spanning a deletion aligns further apart than it was.
+    pub long_pairs: usize,
+    /// Leftmost read of the pair is on the reverse strand — "everted" / RF orientation. The
+    /// **tandem-duplication** signature: a pair spanning the duplication junction reads out of
+    /// the second copy into the first, so the mates appear swapped.
+    pub everted_pairs: usize,
+    pub reads: usize,
+}
+
+/// Accumulate the signatures over `contig` for an event spanning `pos..=end`.
+pub fn analyse(sam_path: &Path, contig: &str, pos: usize, end: usize) -> Signatures {
+    let mut reader = std::fs::File::open(sam_path)
+        .map(std::io::BufReader::new)
+        .map(sam::io::Reader::new)
+        .unwrap();
+    let _header = reader.read_header().unwrap();
+
+    let contig_len = 2_000usize;
+    let mut depth = vec![0usize; contig_len];
+    let mut sig = Signatures::default();
+
+    for result in reader.records() {
+        let record = result.unwrap();
+
+        // H1N1 has EIGHT contigs. Without this filter every contig's reads land in one depth
+        // array, the event window gets backfilled by unrelated contigs, and the signal vanishes.
+        let on_target = matches!(
+            record.reference_sequence_name(),
+            Some(n) if n == contig.as_bytes()
+        );
+        if !on_target {
+            continue;
+        }
+        let Some(Ok(start)) = record.alignment_start() else {
+            continue;
+        };
+        sig.reads += 1;
+        let start = usize::from(start); // 1-based
+
+        let mut ref_pos = start;
+        let ops: Vec<_> = record.cigar().iter().map(|o| o.unwrap()).collect();
+        for (i, op) in ops.iter().enumerate() {
+            let len = op.len();
+            match op.kind() {
+                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                    for p in ref_pos..(ref_pos + len).min(contig_len) {
+                        depth[p] += 1;
+                    }
+                    ref_pos += len;
+                }
+                Kind::Deletion | Kind::Skip => ref_pos += len,
+                Kind::SoftClip => {
+                    // A leading clip points at the read's start; a trailing clip at ref_pos.
+                    let clip_at = if i == 0 { start } else { ref_pos };
+                    if clip_at.abs_diff(pos) <= 25 || clip_at.abs_diff(end) <= 25 {
+                        sig.clips_at_breakpoints += 1;
+                    } else {
+                        sig.clips_elsewhere += 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Pair geometry, counted once per pair from the leftmost mate (TLEN > 0).
+        let tlen = record.template_length().map(|t| t as i64).unwrap_or(0);
+        if tlen > 0 {
+            let event_len = end.saturating_sub(pos);
+            if tlen as usize > 250 + event_len / 2 {
+                sig.long_pairs += 1;
+            }
+            if record.flags().is_ok_and(|f| f.is_reverse_complemented()) {
+                sig.everted_pairs += 1;
+            }
+        }
+    }
+
+    let mean = |lo: usize, hi: usize| -> f64 {
+        let slice = &depth[lo.min(contig_len)..hi.min(contig_len)];
+        if slice.is_empty() {
+            return 0.0;
+        }
+        slice.iter().sum::<usize>() as f64 / slice.len() as f64
+    };
+    sig.depth_inside = mean(pos + 20, end.saturating_sub(20));
+    sig.depth_outside = mean(FLANK_WINDOW.0, FLANK_WINDOW.1);
+    sig
+}
+
+/// Run a gate: generate with and without the SV, align both, and return `(with_sv, control)`.
+pub fn run_gate(sv: &SvSpec) -> (Signatures, Signatures, tempfile::TempDir) {
+    let bwa = bwa_mem2();
+    let (dir, work) = fresh_workdir();
+
+    let (vr1, vr2) = generate_reads(&work, "withsv", Some(sv));
+    let (cr1, cr2) = generate_reads(&work, "control", None);
+
+    let with_sv = analyse(
+        &align(&bwa, &work, "withsv", &vr1, &vr2),
+        sv.contig,
+        sv.pos,
+        sv.end,
+    );
+    let control = analyse(
+        &align(&bwa, &work, "control", &cr1, &cr2),
+        sv.contig,
+        sv.pos,
+        sv.end,
+    );
+    (with_sv, control, dir)
+}

--- a/eidolon/tests/common/mod.rs
+++ b/eidolon/tests/common/mod.rs
@@ -7,6 +7,8 @@
 
 #![allow(dead_code)]
 
+pub mod gate2;
+
 use assert_cmd::Command;
 use flate2::Compression;
 use flate2::write::GzEncoder;

--- a/eidolon/tests/gate2_realigned_del.rs
+++ b/eidolon/tests/gate2_realigned_del.rs
@@ -37,280 +37,26 @@
 
 mod common;
 
-use common::{GenReadsConfig, eidolon, fresh_workdir, h1n1_reference};
-use noodles::sam;
-use noodles::sam::alignment::record::cigar::op::Kind;
-use std::io::{BufRead, Write as _};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use common::gate2::{SvSpec, run_gate};
 
-/// The planted deletion. Homozygous so every fragment over the locus carries it — a het event
-/// halves every signal below and would make the control comparison a ratio rather than a
-/// presence/absence question.
-const CONTIG: &str = "H1N1_HA";
-const DEL_POS: usize = 500; // 1-based anchor; deleted bases are POS+1..=END
-const DEL_END: usize = 799;
-const DEL_LEN: usize = DEL_END - DEL_POS; // 299 deleted reference bases
-
-/// Locate bwa-mem2, or fail with something actionable. Never returns a "skip".
-fn bwa_mem2() -> String {
-    if let Ok(p) = std::env::var("BWA_MEM2") {
-        assert!(
-            Path::new(&p).is_file(),
-            "BWA_MEM2={p} does not exist. Gate 2 cannot run without an aligner."
-        );
-        return p;
-    }
-    let found = Command::new("bwa-mem2")
-        .arg("version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    assert!(
-        found,
-        "bwa-mem2 not found on PATH.\n\
-         Gate 2 realigns eidolon's FASTQ with a real aligner; there is nothing to assert \
-         without one.\n\
-         On this workstation it lives in the `aln` conda environment:\n\
-         \n    conda activate aln\n\
-         \nor point at it directly:\n\
-         \n    BWA_MEM2=/path/to/bwa-mem2 cargo test --test gate2_realigned_del -- --ignored\n"
-    );
-    "bwa-mem2".to_string()
-}
-
-fn run(cmd: &mut Command, what: &str) {
-    let out = cmd
-        .output()
-        .unwrap_or_else(|e| panic!("{what}: failed to spawn: {e}"));
-    assert!(
-        out.status.success(),
-        "{what} failed ({}):\n{}",
-        out.status,
-        String::from_utf8_lossy(&out.stderr)
-    );
-}
-
-/// Generate paired reads over H1N1, optionally with a homozygous symbolic DEL.
-/// Same seed and coverage either way, so the control differs only by the variant.
-fn generate_reads(work: &Path, tag: &str, with_del: bool) -> (PathBuf, PathBuf) {
-    let mut config = GenReadsConfig::new(h1n1_reference(), work.to_path_buf(), tag);
-    config.coverage = 60;
-    config.read_len = 100;
-    config.paired_ended = true;
-    config.produce_fastq = true;
-    config.produce_bam = false;
-    config.produce_vcf = true;
-    // No de novo variants: the only difference between the two runs must be the planted DEL.
-    config.mutation_rate = Some(0.0);
-    config.sv_rate_scale = Some(0.0);
-
-    if with_del {
-        let input_vcf = work.join(format!("{tag}.vcf"));
-        let mut f = std::fs::File::create(&input_vcf).unwrap();
-        writeln!(f, "##fileformat=VCFv4.2").unwrap();
-        writeln!(
-            f,
-            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"SV type\">"
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">"
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS"
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{CONTIG}\t{DEL_POS}\t.\tG\t<DEL>\t60\tPASS\tSVTYPE=DEL;END={DEL_END}\tGT\t1/1"
-        )
-        .unwrap();
-        config.input_vcf = Some(input_vcf);
-    }
-
-    let yaml = config.write_yaml();
-    eidolon()
-        .args(["gen-reads", "-c"])
-        .arg(yaml.path())
-        .assert()
-        .success();
-
-    let r1 = work.join(format!("{tag}_r1.fastq.gz"));
-    let r2 = work.join(format!("{tag}_r2.fastq.gz"));
-    assert!(r1.is_file() && r2.is_file(), "expected {r1:?} and {r2:?}");
-    (r1, r2)
-}
-
-/// What a caller can see, extracted from a realigned SAM.
-#[derive(Debug, Default)]
-struct Signatures {
-    /// Mean depth strictly inside the deleted interval.
-    depth_inside: f64,
-    /// Mean depth in a control window well clear of the event.
-    depth_outside: f64,
-    /// Soft-clipped bases whose clip point falls within ±25 bp of either breakpoint.
-    clips_at_breakpoints: usize,
-    /// Soft clips anywhere else — the background this must stand out from.
-    clips_elsewhere: usize,
-    /// Properly-paired reads whose |TLEN| exceeds the no-variant mode by ~DEL_LEN.
-    discordant_pairs: usize,
-    reads: usize,
-}
-
-/// Parse the SAM and accumulate the three signatures. Deliberately in Rust rather than
-/// `samtools | awk`: the arithmetic below is the assertion, and it should be readable.
-fn analyse(sam_path: &Path) -> Signatures {
-    let mut reader = std::fs::File::open(sam_path)
-        .map(std::io::BufReader::new)
-        .map(sam::io::Reader::new)
-        .unwrap();
-    let header = reader.read_header().unwrap();
-
-    // Depth is accumulated over the whole contig, then summarised over two windows.
-    let contig_len = 1_800usize;
-    let mut depth = vec![0usize; contig_len];
-    let mut sig = Signatures::default();
-
-    let _ = &header;
-    for result in reader.records() {
-        let record = result.unwrap();
-        // H1N1 has EIGHT contigs. Without this filter every contig's reads land in one depth
-        // array, the deleted window gets backfilled by unrelated contigs, and the deletion
-        // vanishes into an apparent 1.2x ENRICHMENT. The control comparison is what caught it.
-        let on_target = matches!(
-            record.reference_sequence_name(),
-            Some(n) if n == CONTIG.as_bytes()
-        );
-        if !on_target {
-            continue;
-        }
-        let Some(Ok(start)) = record.alignment_start() else {
-            continue;
-        };
-        sig.reads += 1;
-        let start = usize::from(start); // 1-based
-
-        // Walk the CIGAR: M/=/X/D/N advance the reference, S records a clip point.
-        let mut ref_pos = start;
-        let mut first_op = true;
-        let ops: Vec<_> = record.cigar().iter().map(|o| o.unwrap()).collect();
-        for (i, op) in ops.iter().enumerate() {
-            let len = op.len();
-            match op.kind() {
-                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
-                    for p in ref_pos..(ref_pos + len).min(contig_len) {
-                        depth[p] += 1;
-                    }
-                    ref_pos += len;
-                }
-                Kind::Deletion | Kind::Skip => ref_pos += len,
-                Kind::SoftClip => {
-                    // A leading clip points at this read's start; a trailing clip at ref_pos.
-                    let clip_at = if first_op && i == 0 { start } else { ref_pos };
-                    let near = |bp: usize| clip_at.abs_diff(bp) <= 25;
-                    if near(DEL_POS) || near(DEL_END) {
-                        sig.clips_at_breakpoints += 1;
-                    } else {
-                        sig.clips_elsewhere += 1;
-                    }
-                }
-                _ => {}
-            }
-            first_op = false;
-        }
-
-        // A fragment spanning the deletion aligns with its mate ~DEL_LEN further away than a
-        // fragment that does not. Count only clearly-inflated pairs, once per pair.
-        let tlen = record
-            .template_length()
-            .map(|t| t.unsigned_abs() as usize)
-            .unwrap_or(0);
-        if record.flags().is_ok_and(|f| f.is_first_segment()) && tlen > 250 + DEL_LEN / 2 {
-            sig.discordant_pairs += 1;
-        }
-    }
-
-    let mean = |lo: usize, hi: usize| -> f64 {
-        let slice = &depth[lo.min(contig_len)..hi.min(contig_len)];
-        if slice.is_empty() {
-            return 0.0;
-        }
-        slice.iter().sum::<usize>() as f64 / slice.len() as f64
-    };
-    // Strictly interior: 20 bp in from each breakpoint, so a read clipped at the junction
-    // cannot contribute and the window measures the deletion rather than its edges.
-    sig.depth_inside = mean(DEL_POS + 20, DEL_END - 20);
-    sig.depth_outside = mean(1_000, 1_400);
-    sig
-}
-
-fn align(bwa: &str, work: &Path, tag: &str, r1: &Path, r2: &Path) -> PathBuf {
-    // Index into the work dir so the repo's test_data is never written to.
-    let local_ref = work.join("ref.fa");
-    std::fs::copy(h1n1_reference(), &local_ref).unwrap();
-    run(
-        Command::new(bwa).arg("index").arg(&local_ref),
-        "bwa-mem2 index",
-    );
-
-    let sam_path = work.join(format!("{tag}.sam"));
-    let out = Command::new(bwa)
-        .args(["mem", "-t", "2"])
-        .arg(&local_ref)
-        .arg(r1)
-        .arg(r2)
-        .output()
-        .expect("bwa-mem2 mem failed to spawn");
-    assert!(
-        out.status.success(),
-        "bwa-mem2 mem failed:\n{}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    std::fs::write(&sam_path, &out.stdout).unwrap();
-
-    // A SAM with a header but no alignments would sail through every assertion below as
-    // "no signal", so establish that reads were actually placed.
-    let mapped = std::io::BufReader::new(std::fs::File::open(&sam_path).unwrap())
-        .lines()
-        .map_while(Result::ok)
-        .filter(|l| !l.starts_with('@'))
-        .count();
-    assert!(
-        mapped > 100,
-        "{tag}: bwa-mem2 emitted only {mapped} alignment record(s) — the alignment step \
-         failed, so nothing below would be measuring the deletion"
-    );
-    sam_path
-}
+/// Homozygous 299 bp deletion. Hom so every fragment over the locus carries it — a het event
+/// halves every signal below and turns each assertion into a ratio judgement.
+const DEL: SvSpec = SvSpec {
+    svtype: "DEL",
+    contig: "H1N1_HA",
+    pos: 500,
+    end: 799,
+    gt: "1/1",
+};
 
 #[test]
 #[ignore = "requires bwa-mem2; run with --ignored (see module docs)"]
 fn gate2_del_produces_the_three_signatures_a_caller_needs() {
-    let bwa = bwa_mem2();
-    let (_dir, work) = fresh_workdir();
-
-    let (dr1, dr2) = generate_reads(&work, "withdel", true);
-    let (cr1, cr2) = generate_reads(&work, "control", false);
-
-    let del = analyse(&align(&bwa, &work, "withdel", &dr1, &dr2));
-    let ctl = analyse(&align(&bwa, &work, "control", &cr1, &cr2));
-
+    let (del, ctl, _dir) = run_gate(&DEL);
     println!("  DEL run: {del:?}");
     println!("  control: {ctl:?}");
 
     // ── Signature 1: depth collapses over the deletion ────────────────────────────────
-    // Homozygous, so the interior should be ~empty rather than merely reduced. Asserted as a
-    // ratio against the same run's own flanking depth, which cancels any coverage difference
-    // between the two runs.
     let del_ratio = del.depth_inside / del.depth_outside.max(1e-9);
     let ctl_ratio = ctl.depth_inside / ctl.depth_outside.max(1e-9);
     assert!(
@@ -321,8 +67,8 @@ fn gate2_del_produces_the_three_signatures_a_caller_needs() {
         del.depth_outside
     );
     // MUST-NOT-FIRE: the control has no deletion, so the same window must be normally covered.
-    // Without this, a run that produced no reads over the region for an unrelated reason would
-    // satisfy the assertion above.
+    // Without this, a run producing no reads there for an unrelated reason would satisfy the
+    // assertion above — which is exactly how the first version of this harness fooled itself.
     assert!(
         ctl_ratio > 0.80,
         "control has no deletion, yet the same window is depleted (ratio {ctl_ratio:.3}) — \
@@ -332,31 +78,27 @@ fn gate2_del_produces_the_three_signatures_a_caller_needs() {
     // ── Signature 2: split reads pile up at the breakpoints ───────────────────────────
     assert!(
         del.clips_at_breakpoints >= 5,
-        "a split-read caller needs clipped reads at the junction; found {} within ±25bp of \
-         {DEL_POS}/{DEL_END}",
+        "a split-read caller needs clipped reads at the junction; found {}",
         del.clips_at_breakpoints
     );
-    // MUST-NOT-FIRE: clipping at the breakpoints must be specific to the deletion, not the
-    // aligner's background rate on this fixture.
     assert!(
         del.clips_at_breakpoints > ctl.clips_at_breakpoints * 3,
-        "breakpoint clipping ({}) is not clearly above the control's background ({}) — \
-         a caller could not distinguish it either",
+        "breakpoint clipping ({}) is not clearly above the control background ({}) — a caller \
+         could not distinguish it either",
         del.clips_at_breakpoints,
         ctl.clips_at_breakpoints
     );
 
     // ── Signature 3: spanning pairs are discordant by ~SVLEN ──────────────────────────
     assert!(
-        del.discordant_pairs >= 5,
-        "a paired-end caller needs pairs whose insert size is inflated by the deletion; \
-         found {}",
-        del.discordant_pairs
+        del.long_pairs >= 5,
+        "a paired-end caller needs pairs whose insert size is inflated by the deletion; found {}",
+        del.long_pairs
     );
     assert!(
-        del.discordant_pairs > ctl.discordant_pairs * 3,
-        "discordant pairs ({}) are not clearly above the control's background ({})",
-        del.discordant_pairs,
-        ctl.discordant_pairs
+        del.long_pairs > ctl.long_pairs * 3,
+        "long pairs ({}) are not clearly above the control background ({})",
+        del.long_pairs,
+        ctl.long_pairs
     );
 }

--- a/eidolon/tests/gate2_realigned_dup.rs
+++ b/eidolon/tests/gate2_realigned_dup.rs
@@ -1,0 +1,129 @@
+//! **Gate 2 for DUP** — does a real aligner produce the evidence a duplication caller needs?
+//!
+//! Motivated by a concrete failure. In SV validation array 21072620, Manta and Delly missed the
+//! **identical** set of duplications (pooled TP=91, FN=14 for both). That is not caller
+//! behaviour — two independent tools agreeing to the record points at a property of the events.
+//! Investigation ruled out a size floor (one miss was 1.7 Mb) and assembly gaps (three of four
+//! were 0.0% N), and one of the four turned out to be a `--passonly` artifact (#541). The rest
+//! are unexplained, and the question Gate 2 answers is the one nobody had asked: *is the
+//! evidence a duplication caller looks for actually present in the reads?*
+//!
+//! A tandem duplication has a signature a deletion does not:
+//!
+//! | signature | why a caller needs it |
+//! |---|---|
+//! | depth **rises** over the duplicated span | depth/CNV callers |
+//! | soft clips at the junction | split-read callers |
+//! | **everted (RF) pairs** — mates appear swapped | the discriminating tandem-DUP signal |
+//!
+//! The everted pair is the discriminating one: a fragment spanning the junction reads out of the
+//! *second* copy back into the *first*, so its mates align in reverse order. A duplication that
+//! raised depth without producing everted pairs would look like a copy-number gain with no
+//! breakpoint — detectable by a depth caller and invisible to Manta or Delly, which is
+//! consistent with what array 21072620 reported.
+//!
+//! ## Measured excess over the declared dosage — evidence for #499
+//!
+//! A homozygous DUP without `CN` gets `coverage_multiplier_for` = **2.0**, but the realigned
+//! depth over this 300 bp event reads **2.55x** its flank. Mutating the multiplier gives a clean
+//! dose-response:
+//!
+//! | multiplier | depth inside | flank | ratio |
+//! |---|---|---|---|
+//! | 2.0 (shipped) | 168.60 | 66.05 | 2.553 |
+//! | 1.0 | 99.14 | 65.25 | 1.519 |
+//! | 0.5 | 69.08 | 65.55 | 1.054 |
+//!
+//! That is `ratio ~= multiplier + 0.53` — a constant offset independent of the multiplier, and
+//! ~44 everted pairs plus 64 clipped reads is about the right number of extra reads to account
+//! for it. The junction reads appear to be emitted *in addition to* the coverage-multiplied
+//! regular reads, rather than being part of them. Being a fixed number of reads, the excess
+//! scales inversely with event length, which predicts the ~8% seen on #499's 1200 bp event
+//! against the 27% seen here on 300 bp.
+//!
+//! **This gate deliberately does not assert the excess away.** It asserts the signature is
+//! present; the dosage question belongs to #499 and to the Phase 1 size sweep, which this
+//! measurement now gives a mechanism to test.
+//!
+//! Requires bwa-mem2; `#[ignore]`d so CI never reaches it. See `common/gate2.rs`.
+//!
+//! ```text
+//! conda activate aln
+//! cargo test --test gate2_realigned_dup -- --ignored --nocapture
+//! ```
+
+mod common;
+
+use common::gate2::{SvSpec, run_gate};
+
+/// Homozygous 300 bp tandem duplication. Hom so the depth change is a doubling rather than a
+/// 1.5x, which keeps every assertion a presence/absence question.
+const DUP: SvSpec = SvSpec {
+    svtype: "DUP",
+    contig: "H1N1_HA",
+    pos: 500,
+    end: 799,
+    gt: "1/1",
+};
+
+#[test]
+#[ignore = "requires bwa-mem2; run with --ignored (see module docs)"]
+fn gate2_dup_produces_the_three_signatures_a_caller_needs() {
+    let (dup, ctl, _dir) = run_gate(&DUP);
+    println!("  DUP run: {dup:?}");
+    println!("  control: {ctl:?}");
+
+    // ── Signature 1: depth rises over the duplicated span ─────────────────────────────
+    // Homozygous DUP without CN means one extra copy per haplotype, so the multiplier is 2.0.
+    // Asserted as a ratio against the same run's own flank, which cancels any coverage
+    // difference between the two runs.
+    let dup_ratio = dup.depth_inside / dup.depth_outside.max(1e-9);
+    let ctl_ratio = ctl.depth_inside / ctl.depth_outside.max(1e-9);
+    // Threshold is 1.9, just under the physically expected 2.0, NOT under the observed 2.55.
+    // The first version used 1.5 and a mutation setting the multiplier to 1.0 landed at 1.519 --
+    // surviving by 0.019. Anchor a threshold to what the value SHOULD be, never to a margin
+    // below what it happens to be.
+    assert!(
+        dup_ratio > 1.9,
+        "depth over a homozygous duplication should roughly double; interior/flank was \
+         {dup_ratio:.3} (inside {:.1}x, outside {:.1}x)",
+        dup.depth_inside,
+        dup.depth_outside
+    );
+    // MUST-NOT-FIRE: the control has no duplication, so the same window must be flat. Without
+    // this, a window that happens to be over-covered would satisfy the assertion above.
+    assert!(
+        (0.8..1.2).contains(&ctl_ratio),
+        "control has no duplication, yet the same window reads {ctl_ratio:.3} — the window is \
+         unreliable, so signature 1 proves nothing"
+    );
+
+    // ── Signature 2: split reads at the junction ──────────────────────────────────────
+    assert!(
+        dup.clips_at_breakpoints >= 5,
+        "a split-read caller needs clipped reads at the duplication junction; found {}",
+        dup.clips_at_breakpoints
+    );
+    assert!(
+        dup.clips_at_breakpoints > ctl.clips_at_breakpoints * 3,
+        "breakpoint clipping ({}) is not clearly above the control background ({})",
+        dup.clips_at_breakpoints,
+        ctl.clips_at_breakpoints
+    );
+
+    // ── Signature 3: everted pairs — the tandem-duplication discriminator ─────────────
+    // This is the one that separates "a duplication" from "a region with more coverage".
+    assert!(
+        dup.everted_pairs >= 5,
+        "a tandem duplication must produce everted (RF) read pairs at its junction; found {}. \
+         Without them the event is a copy-number gain with no breakpoint — visible to a depth \
+         caller and invisible to Manta/Delly",
+        dup.everted_pairs
+    );
+    assert!(
+        dup.everted_pairs > ctl.everted_pairs * 3,
+        "everted pairs ({}) are not clearly above the control background ({})",
+        dup.everted_pairs,
+        ctl.everted_pairs
+    );
+}


### PR DESCRIPTION
Second Gate 2 (see #538). Factors the machinery into `tests/common/gate2.rs` and moves the DEL
gate onto it, so each new gate is a test rather than a copy. Both gates pass.

## Why DUP next

In array 21072620 Manta and Delly missed the **identical** set of duplications — pooled TP=91,
FN=14 for both. Two independent tools agreeing to the record points at the events, not the
callers. Nobody had asked whether the evidence a duplication caller needs is present at all.

**It is.** Homozygous 300 bp tandem DUP at `H1N1_HA:500-799`, realigned with bwa-mem2:

| signature | with DUP | control |
|---|---|---|
| depth inside | 168.6 | 63.1 |
| depth outside | 66.0 | 65.3 |
| clips at breakpoints | **64** | 1 |
| **everted (RF) pairs** | **44** | 0 |

The everted pair is the discriminating one: a fragment spanning the junction reads out of the
*second* copy back into the *first*, so its mates align in reverse order. A duplication that
raised depth without producing them would be a copy-number gain with no breakpoint — visible to
a depth caller, invisible to Manta or Delly. They are present, so **those campaign misses are
not explained by missing breakpoint evidence at this scale.**

## The finding: a measured mechanism for #499

A hom DUP gets `coverage_multiplier_for` = **2.0**, but realigned depth reads **2.55×** its
flank. Mutating the multiplier gives a clean dose–response:

| multiplier | depth inside | flank | ratio |
|---|---|---|---|
| 2.0 (shipped) | 168.60 | 66.05 | **2.553** |
| 1.0 | 99.14 | 65.25 | 1.519 |
| 0.5 | 69.08 | 65.55 | 1.054 |

`ratio ≈ multiplier + 0.53` — a **constant offset independent of the multiplier**, and ~44
everted pairs plus 64 clipped reads is about the right number of extra reads to account for it.
The junction reads appear to be emitted *in addition to* the coverage-multiplied regular reads
rather than being part of them.

Being a fixed count, the excess scales **inversely with event length** — which predicts #499's
~8% on a 1200 bp event against the 27% here on 300 bp. That is exactly the fork Phase 1's size
sweep was designed to resolve, now with a mechanism to test instead of a symptom.

**This gate deliberately does not assert the excess away.** It asserts the signature is present;
dosage belongs to #499.

## Non-vacuity

| mutation | effect | caught by |
|---|---|---|
| hom DUP multiplier `2.0 → 1.0` | ratio 1.519 | depth assertion |
| junction reads emit left piece only | clips 64 → 2, everted 44 → **0** | split-read assertion |

The second kept depth at 149.6 — a depth-only check would have passed over a duplication with no
junction evidence, which is precisely what would make a caller miss it.

**A threshold bug worth flagging in review:** the first version asserted `> 1.5`, and the
`multiplier = 1.0` mutant scored **1.519** — surviving by 0.019. It is now 1.9, anchored to what
the value *should* be rather than to a margin below what it happens to be. Same error as testing
`count > 0`, one step subtler.

## Not verified

One event size, one genotype, one aligner. A 300 bp event with 200 bp fragments is dominated by
junction effects, so **2.55 is not a dosage measurement** — noted in the module docs. INV, BND,
CNV and INS still have no Gate 2.