### PR TITLE
test(sv): Gate 2 for INV — and the reads are cleared of the precision artifact

### DIFF
--- a/docs/sv_support_matrix.md
+++ b/docs/sv_support_matrix.md
@@ -316,13 +316,20 @@ All four bracket forms present, every record parsed, **0 unpaired and 0 mispaire
 #451-era failure (truth emitted unmatchable by construction) is gone, and Manta independently
 recovers 46 of the 50 records from the reads alone.
 
-### INV precision 0.500 is ours, not the callers'
+### INV precision 0.500 is ours, not the callers' — and Gate 2 now shows the reads are clean
 
 Both callers report TP=9, FP=9 — *identically*. The pipeline predicts this in its own pre-flight:
 16 of the truth's junctions are inversion-oriented (`t]p]` or `[p[t`), and a caller's breakends
 for those convert to `<INV>` via Manta's `convertInversion.py`, landing as INV false positives.
 Two independent callers arriving at the same number is the evidence that it is a representation
 artifact. **INV recall 1.000 is real; INV precision from this tier is not quotable.**
+
+Gate 2 (`eidolon/tests/gate2_realigned_inv.rs`) closes the remaining inference. Realigning a
+homozygous 1.2 kb inversion with bwa-mem2 gives **123 breakpoint-clipped reads against 0 in the
+control**, **98 same-orientation (FF/RR) pairs against 0**, **0 everted (RF) pairs** — so nothing
+suggests a duplication — and interior depth of 1.026x the flank, i.e. balanced. The reads carry
+an unambiguous inversion signature, so the false positives are not attributable to them. That was
+previously an argument from two callers agreeing; it is now a measurement.
 
 ### INS: one planted, one verified present, zero found
 

--- a/eidolon/tests/common/gate2.rs
+++ b/eidolon/tests/common/gate2.rs
@@ -20,11 +20,12 @@ use std::io::{BufRead, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Reference window used as the "unaffected" baseline in every gate. Well clear of the event
-/// loci the gates plant, and on the same contig so it shares that contig's coverage.
-pub const FLANK_WINDOW: (usize, usize) = (1_000, 1_400);
-
-/// A symbolic SV to plant via `input_vcf`.
+/// A symbolic SV to plant via `input_vcf`, with the windows its depth is measured over.
+///
+/// The windows are per-event on purpose. A 1.2 kb inversion cannot share a 300 bp deletion's
+/// interior window, and it cannot share its flank either — `H1N1_HA:1000-1400` sits *inside* an
+/// `H1N1_PB2:500-1700` inversion. Getting this wrong measures the wrong thing quietly, which is
+/// how the first version of this harness turned a homozygous deletion into a 1.2x enrichment.
 pub struct SvSpec {
     pub svtype: &'static str,
     pub contig: &'static str,
@@ -33,6 +34,13 @@ pub struct SvSpec {
     /// `"1/1"` for homozygous. Gates use hom so a signature is present or absent rather than
     /// halved — a het event turns every assertion below into a ratio judgement.
     pub gt: &'static str,
+    /// Depth window strictly inside the event. Must clear each breakpoint by more than a
+    /// fragment length where the event is large enough to allow it: coverage within ~one
+    /// fragment of a junction is depressed by junction effects, not by the event's dosage
+    /// (`docs/sv_support_matrix.md` measures 0.74–0.82 there for an inversion).
+    pub interior: (usize, usize),
+    /// Unaffected baseline on the same contig, so it shares that contig's coverage.
+    pub flank: (usize, usize),
 }
 
 /// Locate bwa-mem2, or fail with something actionable. **Never returns a "skip"** — a gate that
@@ -183,25 +191,36 @@ pub struct Signatures {
     pub clips_at_breakpoints: usize,
     /// Soft clips anywhere else — the background the above must stand out from.
     pub clips_elsewhere: usize,
-    /// Leftmost-read-of-pair with |TLEN| inflated well past the fragment mean. The
-    /// **deletion** signature: a pair spanning a deletion aligns further apart than it was.
+    /// Leftmost-read-of-pair with |TLEN| inflated well past the fragment mean. Necessary for a
+    /// deletion but **not sufficient to identify one**: measured, a 1.2 kb inversion produces
+    /// ~99 of these too, because a mate landing inside the inverted block maps to a mirrored
+    /// position. Orientation is what discriminates — DEL shows long pairs with none of the
+    /// others, DUP shows everted, INV shows same-orientation. Which is exactly why callers use
+    /// insert size and orientation together rather than either alone.
     pub long_pairs: usize,
-    /// Leftmost read of the pair is on the reverse strand — "everted" / RF orientation. The
+    /// Leftmost read reverse, mate forward — "everted" / RF orientation. The
     /// **tandem-duplication** signature: a pair spanning the duplication junction reads out of
     /// the second copy into the first, so the mates appear swapped.
     pub everted_pairs: usize,
+    /// Both mates on the SAME strand (FF or RR). The **inversion** signature: one mate falls
+    /// inside the inverted block and is therefore read from the opposite strand to its partner.
+    /// Distinct from everted — an RF pair has mates on opposite strands, an inversion pair does
+    /// not, and conflating them would let a DUP satisfy an INV assertion.
+    pub same_orientation_pairs: usize,
     pub reads: usize,
 }
 
 /// Accumulate the signatures over `contig` for an event spanning `pos..=end`.
-pub fn analyse(sam_path: &Path, contig: &str, pos: usize, end: usize) -> Signatures {
+pub fn analyse(sam_path: &Path, sv: &SvSpec) -> Signatures {
+    let (contig, pos, end) = (sv.contig, sv.pos, sv.end);
     let mut reader = std::fs::File::open(sam_path)
         .map(std::io::BufReader::new)
         .map(sam::io::Reader::new)
         .unwrap();
     let _header = reader.read_header().unwrap();
 
-    let contig_len = 2_000usize;
+    // Longest H1N1 contig is 2280 bp (PB2). Sized past it so no contig is silently truncated.
+    let contig_len = 3_000usize;
     let mut depth = vec![0usize; contig_len];
     let mut sig = Signatures::default();
 
@@ -255,8 +274,15 @@ pub fn analyse(sam_path: &Path, contig: &str, pos: usize, end: usize) -> Signatu
             if tlen as usize > 250 + event_len / 2 {
                 sig.long_pairs += 1;
             }
-            if record.flags().is_ok_and(|f| f.is_reverse_complemented()) {
-                sig.everted_pairs += 1;
+            if let Ok(flags) = record.flags() {
+                let rev = flags.is_reverse_complemented();
+                let mate_rev = flags.is_mate_reverse_complemented();
+                if rev && !mate_rev {
+                    sig.everted_pairs += 1;
+                }
+                if rev == mate_rev {
+                    sig.same_orientation_pairs += 1;
+                }
             }
         }
     }
@@ -268,8 +294,8 @@ pub fn analyse(sam_path: &Path, contig: &str, pos: usize, end: usize) -> Signatu
         }
         slice.iter().sum::<usize>() as f64 / slice.len() as f64
     };
-    sig.depth_inside = mean(pos + 20, end.saturating_sub(20));
-    sig.depth_outside = mean(FLANK_WINDOW.0, FLANK_WINDOW.1);
+    sig.depth_inside = mean(sv.interior.0, sv.interior.1);
+    sig.depth_outside = mean(sv.flank.0, sv.flank.1);
     sig
 }
 
@@ -281,17 +307,7 @@ pub fn run_gate(sv: &SvSpec) -> (Signatures, Signatures, tempfile::TempDir) {
     let (vr1, vr2) = generate_reads(&work, "withsv", Some(sv));
     let (cr1, cr2) = generate_reads(&work, "control", None);
 
-    let with_sv = analyse(
-        &align(&bwa, &work, "withsv", &vr1, &vr2),
-        sv.contig,
-        sv.pos,
-        sv.end,
-    );
-    let control = analyse(
-        &align(&bwa, &work, "control", &cr1, &cr2),
-        sv.contig,
-        sv.pos,
-        sv.end,
-    );
+    let with_sv = analyse(&align(&bwa, &work, "withsv", &vr1, &vr2), sv);
+    let control = analyse(&align(&bwa, &work, "control", &cr1, &cr2), sv);
     (with_sv, control, dir)
 }

--- a/eidolon/tests/common/gate2.rs
+++ b/eidolon/tests/common/gate2.rs
@@ -1,0 +1,297 @@
+//! Shared machinery for **Gate 2** — realigning eidolon's FASTQ with a real aligner and asking
+//! whether the result carries the evidence a structural-variant caller keys on.
+//!
+//! See `docs/sv_polish_roadmap.md` for what the gates are. The short version: every other SV
+//! test inspects eidolon describing its own work (its FASTQ, its golden BAM, its truth VCF). A
+//! caller sees none of those — it sees reads somebody else aligned. This module is the seam.
+//!
+//! Analysis is deliberately done in Rust over the SAM with `noodles` rather than by piping
+//! `samtools` through `awk`: the arithmetic *is* the assertion, so it should be readable and
+//! debuggable. That choice caught a bug on its first run — depth was being accumulated across
+//! all eight H1N1 contigs, which backfilled a deleted window and turned a homozygous deletion
+//! into an apparent 1.2x *enrichment*.
+
+#![allow(dead_code)]
+
+use super::{GenReadsConfig, eidolon, fresh_workdir, h1n1_reference};
+use noodles::sam;
+use noodles::sam::alignment::record::cigar::op::Kind;
+use std::io::{BufRead, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Reference window used as the "unaffected" baseline in every gate. Well clear of the event
+/// loci the gates plant, and on the same contig so it shares that contig's coverage.
+pub const FLANK_WINDOW: (usize, usize) = (1_000, 1_400);
+
+/// A symbolic SV to plant via `input_vcf`.
+pub struct SvSpec {
+    pub svtype: &'static str,
+    pub contig: &'static str,
+    pub pos: usize,
+    pub end: usize,
+    /// `"1/1"` for homozygous. Gates use hom so a signature is present or absent rather than
+    /// halved — a het event turns every assertion below into a ratio judgement.
+    pub gt: &'static str,
+}
+
+/// Locate bwa-mem2, or fail with something actionable. **Never returns a "skip"** — a gate that
+/// silently passes when its aligner is missing is worth less than no gate at all.
+pub fn bwa_mem2() -> String {
+    if let Ok(p) = std::env::var("BWA_MEM2") {
+        assert!(
+            Path::new(&p).is_file(),
+            "BWA_MEM2={p} does not exist. Gate 2 cannot run without an aligner."
+        );
+        return p;
+    }
+    let found = Command::new("bwa-mem2")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        found,
+        "bwa-mem2 not found on PATH.\n\
+         Gate 2 realigns eidolon's FASTQ with a real aligner; there is nothing to assert \
+         without one.\n\
+         On this workstation it lives in the `aln` conda environment:\n\
+         \n    conda activate aln\n\
+         \nor point at it directly:\n\
+         \n    BWA_MEM2=/path/to/bwa-mem2 cargo test --test <gate> -- --ignored\n"
+    );
+    "bwa-mem2".to_string()
+}
+
+/// Generate paired reads over H1N1, optionally planting one symbolic SV. The control run uses
+/// the same reference, seed and coverage, so the two differ **only** by the variant.
+pub fn generate_reads(work: &Path, tag: &str, sv: Option<&SvSpec>) -> (PathBuf, PathBuf) {
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.to_path_buf(), tag);
+    config.coverage = 60;
+    config.read_len = 100;
+    config.paired_ended = true;
+    config.produce_fastq = true;
+    config.produce_bam = false;
+    config.produce_vcf = true;
+    // No de novo variants: the only difference between run and control must be the planted SV.
+    config.mutation_rate = Some(0.0);
+    config.sv_rate_scale = Some(0.0);
+
+    if let Some(sv) = sv {
+        let input_vcf = work.join(format!("{tag}.vcf"));
+        let mut f = std::fs::File::create(&input_vcf).unwrap();
+        writeln!(f, "##fileformat=VCFv4.2").unwrap();
+        writeln!(
+            f,
+            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"SV type\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS"
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}\t{}\t.\tG\t<{}>\t60\tPASS\tSVTYPE={};END={}\tGT\t{}",
+            sv.contig, sv.pos, sv.svtype, sv.svtype, sv.end, sv.gt
+        )
+        .unwrap();
+        config.input_vcf = Some(input_vcf);
+    }
+
+    let yaml = config.write_yaml();
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let r1 = work.join(format!("{tag}_r1.fastq.gz"));
+    let r2 = work.join(format!("{tag}_r2.fastq.gz"));
+    assert!(r1.is_file() && r2.is_file(), "expected {r1:?} and {r2:?}");
+    (r1, r2)
+}
+
+/// Align a FASTQ pair with bwa-mem2 and return the path to the SAM.
+pub fn align(bwa: &str, work: &Path, tag: &str, r1: &Path, r2: &Path) -> PathBuf {
+    // Index into the work dir so the repo's test_data is never written to.
+    let local_ref = work.join("ref.fa");
+    if !local_ref.exists() {
+        std::fs::copy(h1n1_reference(), &local_ref).unwrap();
+        let out = Command::new(bwa)
+            .arg("index")
+            .arg(&local_ref)
+            .output()
+            .expect("bwa-mem2 index failed to spawn");
+        assert!(
+            out.status.success(),
+            "bwa-mem2 index failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let sam_path = work.join(format!("{tag}.sam"));
+    let out = Command::new(bwa)
+        .args(["mem", "-t", "2"])
+        .arg(&local_ref)
+        .arg(r1)
+        .arg(r2)
+        .output()
+        .expect("bwa-mem2 mem failed to spawn");
+    assert!(
+        out.status.success(),
+        "bwa-mem2 mem failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    std::fs::write(&sam_path, &out.stdout).unwrap();
+
+    // A SAM with a header and no alignments would satisfy every "no signal" branch below, so
+    // establish that reads were actually placed before anything is measured.
+    let mapped = std::io::BufReader::new(std::fs::File::open(&sam_path).unwrap())
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.starts_with('@'))
+        .count();
+    assert!(
+        mapped > 100,
+        "{tag}: bwa-mem2 emitted only {mapped} alignment record(s) — the alignment step failed, \
+         so nothing measured from it would mean anything"
+    );
+    sam_path
+}
+
+/// What a caller can see, extracted from a realigned SAM.
+#[derive(Debug, Default)]
+pub struct Signatures {
+    /// Mean depth strictly inside the event (20 bp in from each breakpoint, so a read clipped
+    /// at a junction cannot contribute and the window measures the event, not its edges).
+    pub depth_inside: f64,
+    /// Mean depth over `FLANK_WINDOW`, well clear of the event.
+    pub depth_outside: f64,
+    /// Soft clips whose clip point is within ±25 bp of either breakpoint.
+    pub clips_at_breakpoints: usize,
+    /// Soft clips anywhere else — the background the above must stand out from.
+    pub clips_elsewhere: usize,
+    /// Leftmost-read-of-pair with |TLEN| inflated well past the fragment mean. The
+    /// **deletion** signature: a pair spanning a deletion aligns further apart than it was.
+    pub long_pairs: usize,
+    /// Leftmost read of the pair is on the reverse strand — "everted" / RF orientation. The
+    /// **tandem-duplication** signature: a pair spanning the duplication junction reads out of
+    /// the second copy into the first, so the mates appear swapped.
+    pub everted_pairs: usize,
+    pub reads: usize,
+}
+
+/// Accumulate the signatures over `contig` for an event spanning `pos..=end`.
+pub fn analyse(sam_path: &Path, contig: &str, pos: usize, end: usize) -> Signatures {
+    let mut reader = std::fs::File::open(sam_path)
+        .map(std::io::BufReader::new)
+        .map(sam::io::Reader::new)
+        .unwrap();
+    let _header = reader.read_header().unwrap();
+
+    let contig_len = 2_000usize;
+    let mut depth = vec![0usize; contig_len];
+    let mut sig = Signatures::default();
+
+    for result in reader.records() {
+        let record = result.unwrap();
+
+        // H1N1 has EIGHT contigs. Without this filter every contig's reads land in one depth
+        // array, the event window gets backfilled by unrelated contigs, and the signal vanishes.
+        let on_target = matches!(
+            record.reference_sequence_name(),
+            Some(n) if n == contig.as_bytes()
+        );
+        if !on_target {
+            continue;
+        }
+        let Some(Ok(start)) = record.alignment_start() else {
+            continue;
+        };
+        sig.reads += 1;
+        let start = usize::from(start); // 1-based
+
+        let mut ref_pos = start;
+        let ops: Vec<_> = record.cigar().iter().map(|o| o.unwrap()).collect();
+        for (i, op) in ops.iter().enumerate() {
+            let len = op.len();
+            match op.kind() {
+                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                    for p in ref_pos..(ref_pos + len).min(contig_len) {
+                        depth[p] += 1;
+                    }
+                    ref_pos += len;
+                }
+                Kind::Deletion | Kind::Skip => ref_pos += len,
+                Kind::SoftClip => {
+                    // A leading clip points at the read's start; a trailing clip at ref_pos.
+                    let clip_at = if i == 0 { start } else { ref_pos };
+                    if clip_at.abs_diff(pos) <= 25 || clip_at.abs_diff(end) <= 25 {
+                        sig.clips_at_breakpoints += 1;
+                    } else {
+                        sig.clips_elsewhere += 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Pair geometry, counted once per pair from the leftmost mate (TLEN > 0).
+        let tlen = record.template_length().map(|t| t as i64).unwrap_or(0);
+        if tlen > 0 {
+            let event_len = end.saturating_sub(pos);
+            if tlen as usize > 250 + event_len / 2 {
+                sig.long_pairs += 1;
+            }
+            if record.flags().is_ok_and(|f| f.is_reverse_complemented()) {
+                sig.everted_pairs += 1;
+            }
+        }
+    }
+
+    let mean = |lo: usize, hi: usize| -> f64 {
+        let slice = &depth[lo.min(contig_len)..hi.min(contig_len)];
+        if slice.is_empty() {
+            return 0.0;
+        }
+        slice.iter().sum::<usize>() as f64 / slice.len() as f64
+    };
+    sig.depth_inside = mean(pos + 20, end.saturating_sub(20));
+    sig.depth_outside = mean(FLANK_WINDOW.0, FLANK_WINDOW.1);
+    sig
+}
+
+/// Run a gate: generate with and without the SV, align both, and return `(with_sv, control)`.
+pub fn run_gate(sv: &SvSpec) -> (Signatures, Signatures, tempfile::TempDir) {
+    let bwa = bwa_mem2();
+    let (dir, work) = fresh_workdir();
+
+    let (vr1, vr2) = generate_reads(&work, "withsv", Some(sv));
+    let (cr1, cr2) = generate_reads(&work, "control", None);
+
+    let with_sv = analyse(
+        &align(&bwa, &work, "withsv", &vr1, &vr2),
+        sv.contig,
+        sv.pos,
+        sv.end,
+    );
+    let control = analyse(
+        &align(&bwa, &work, "control", &cr1, &cr2),
+        sv.contig,
+        sv.pos,
+        sv.end,
+    );
+    (with_sv, control, dir)
+}

--- a/eidolon/tests/common/mod.rs
+++ b/eidolon/tests/common/mod.rs
@@ -7,6 +7,8 @@
 
 #![allow(dead_code)]
 
+pub mod gate2;
+
 use assert_cmd::Command;
 use flate2::Compression;
 use flate2::write::GzEncoder;

--- a/eidolon/tests/gate2_realigned_del.rs
+++ b/eidolon/tests/gate2_realigned_del.rs
@@ -37,280 +37,26 @@
 
 mod common;
 
-use common::{GenReadsConfig, eidolon, fresh_workdir, h1n1_reference};
-use noodles::sam;
-use noodles::sam::alignment::record::cigar::op::Kind;
-use std::io::{BufRead, Write as _};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use common::gate2::{SvSpec, run_gate};
 
-/// The planted deletion. Homozygous so every fragment over the locus carries it — a het event
-/// halves every signal below and would make the control comparison a ratio rather than a
-/// presence/absence question.
-const CONTIG: &str = "H1N1_HA";
-const DEL_POS: usize = 500; // 1-based anchor; deleted bases are POS+1..=END
-const DEL_END: usize = 799;
-const DEL_LEN: usize = DEL_END - DEL_POS; // 299 deleted reference bases
-
-/// Locate bwa-mem2, or fail with something actionable. Never returns a "skip".
-fn bwa_mem2() -> String {
-    if let Ok(p) = std::env::var("BWA_MEM2") {
-        assert!(
-            Path::new(&p).is_file(),
-            "BWA_MEM2={p} does not exist. Gate 2 cannot run without an aligner."
-        );
-        return p;
-    }
-    let found = Command::new("bwa-mem2")
-        .arg("version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    assert!(
-        found,
-        "bwa-mem2 not found on PATH.\n\
-         Gate 2 realigns eidolon's FASTQ with a real aligner; there is nothing to assert \
-         without one.\n\
-         On this workstation it lives in the `aln` conda environment:\n\
-         \n    conda activate aln\n\
-         \nor point at it directly:\n\
-         \n    BWA_MEM2=/path/to/bwa-mem2 cargo test --test gate2_realigned_del -- --ignored\n"
-    );
-    "bwa-mem2".to_string()
-}
-
-fn run(cmd: &mut Command, what: &str) {
-    let out = cmd
-        .output()
-        .unwrap_or_else(|e| panic!("{what}: failed to spawn: {e}"));
-    assert!(
-        out.status.success(),
-        "{what} failed ({}):\n{}",
-        out.status,
-        String::from_utf8_lossy(&out.stderr)
-    );
-}
-
-/// Generate paired reads over H1N1, optionally with a homozygous symbolic DEL.
-/// Same seed and coverage either way, so the control differs only by the variant.
-fn generate_reads(work: &Path, tag: &str, with_del: bool) -> (PathBuf, PathBuf) {
-    let mut config = GenReadsConfig::new(h1n1_reference(), work.to_path_buf(), tag);
-    config.coverage = 60;
-    config.read_len = 100;
-    config.paired_ended = true;
-    config.produce_fastq = true;
-    config.produce_bam = false;
-    config.produce_vcf = true;
-    // No de novo variants: the only difference between the two runs must be the planted DEL.
-    config.mutation_rate = Some(0.0);
-    config.sv_rate_scale = Some(0.0);
-
-    if with_del {
-        let input_vcf = work.join(format!("{tag}.vcf"));
-        let mut f = std::fs::File::create(&input_vcf).unwrap();
-        writeln!(f, "##fileformat=VCFv4.2").unwrap();
-        writeln!(
-            f,
-            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"SV type\">"
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "##INFO=<ID=END,Number=1,Type=Integer,Description=\"End\">"
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS"
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{CONTIG}\t{DEL_POS}\t.\tG\t<DEL>\t60\tPASS\tSVTYPE=DEL;END={DEL_END}\tGT\t1/1"
-        )
-        .unwrap();
-        config.input_vcf = Some(input_vcf);
-    }
-
-    let yaml = config.write_yaml();
-    eidolon()
-        .args(["gen-reads", "-c"])
-        .arg(yaml.path())
-        .assert()
-        .success();
-
-    let r1 = work.join(format!("{tag}_r1.fastq.gz"));
-    let r2 = work.join(format!("{tag}_r2.fastq.gz"));
-    assert!(r1.is_file() && r2.is_file(), "expected {r1:?} and {r2:?}");
-    (r1, r2)
-}
-
-/// What a caller can see, extracted from a realigned SAM.
-#[derive(Debug, Default)]
-struct Signatures {
-    /// Mean depth strictly inside the deleted interval.
-    depth_inside: f64,
-    /// Mean depth in a control window well clear of the event.
-    depth_outside: f64,
-    /// Soft-clipped bases whose clip point falls within ±25 bp of either breakpoint.
-    clips_at_breakpoints: usize,
-    /// Soft clips anywhere else — the background this must stand out from.
-    clips_elsewhere: usize,
-    /// Properly-paired reads whose |TLEN| exceeds the no-variant mode by ~DEL_LEN.
-    discordant_pairs: usize,
-    reads: usize,
-}
-
-/// Parse the SAM and accumulate the three signatures. Deliberately in Rust rather than
-/// `samtools | awk`: the arithmetic below is the assertion, and it should be readable.
-fn analyse(sam_path: &Path) -> Signatures {
-    let mut reader = std::fs::File::open(sam_path)
-        .map(std::io::BufReader::new)
-        .map(sam::io::Reader::new)
-        .unwrap();
-    let header = reader.read_header().unwrap();
-
-    // Depth is accumulated over the whole contig, then summarised over two windows.
-    let contig_len = 1_800usize;
-    let mut depth = vec![0usize; contig_len];
-    let mut sig = Signatures::default();
-
-    let _ = &header;
-    for result in reader.records() {
-        let record = result.unwrap();
-        // H1N1 has EIGHT contigs. Without this filter every contig's reads land in one depth
-        // array, the deleted window gets backfilled by unrelated contigs, and the deletion
-        // vanishes into an apparent 1.2x ENRICHMENT. The control comparison is what caught it.
-        let on_target = matches!(
-            record.reference_sequence_name(),
-            Some(n) if n == CONTIG.as_bytes()
-        );
-        if !on_target {
-            continue;
-        }
-        let Some(Ok(start)) = record.alignment_start() else {
-            continue;
-        };
-        sig.reads += 1;
-        let start = usize::from(start); // 1-based
-
-        // Walk the CIGAR: M/=/X/D/N advance the reference, S records a clip point.
-        let mut ref_pos = start;
-        let mut first_op = true;
-        let ops: Vec<_> = record.cigar().iter().map(|o| o.unwrap()).collect();
-        for (i, op) in ops.iter().enumerate() {
-            let len = op.len();
-            match op.kind() {
-                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
-                    for p in ref_pos..(ref_pos + len).min(contig_len) {
-                        depth[p] += 1;
-                    }
-                    ref_pos += len;
-                }
-                Kind::Deletion | Kind::Skip => ref_pos += len,
-                Kind::SoftClip => {
-                    // A leading clip points at this read's start; a trailing clip at ref_pos.
-                    let clip_at = if first_op && i == 0 { start } else { ref_pos };
-                    let near = |bp: usize| clip_at.abs_diff(bp) <= 25;
-                    if near(DEL_POS) || near(DEL_END) {
-                        sig.clips_at_breakpoints += 1;
-                    } else {
-                        sig.clips_elsewhere += 1;
-                    }
-                }
-                _ => {}
-            }
-            first_op = false;
-        }
-
-        // A fragment spanning the deletion aligns with its mate ~DEL_LEN further away than a
-        // fragment that does not. Count only clearly-inflated pairs, once per pair.
-        let tlen = record
-            .template_length()
-            .map(|t| t.unsigned_abs() as usize)
-            .unwrap_or(0);
-        if record.flags().is_ok_and(|f| f.is_first_segment()) && tlen > 250 + DEL_LEN / 2 {
-            sig.discordant_pairs += 1;
-        }
-    }
-
-    let mean = |lo: usize, hi: usize| -> f64 {
-        let slice = &depth[lo.min(contig_len)..hi.min(contig_len)];
-        if slice.is_empty() {
-            return 0.0;
-        }
-        slice.iter().sum::<usize>() as f64 / slice.len() as f64
-    };
-    // Strictly interior: 20 bp in from each breakpoint, so a read clipped at the junction
-    // cannot contribute and the window measures the deletion rather than its edges.
-    sig.depth_inside = mean(DEL_POS + 20, DEL_END - 20);
-    sig.depth_outside = mean(1_000, 1_400);
-    sig
-}
-
-fn align(bwa: &str, work: &Path, tag: &str, r1: &Path, r2: &Path) -> PathBuf {
-    // Index into the work dir so the repo's test_data is never written to.
-    let local_ref = work.join("ref.fa");
-    std::fs::copy(h1n1_reference(), &local_ref).unwrap();
-    run(
-        Command::new(bwa).arg("index").arg(&local_ref),
-        "bwa-mem2 index",
-    );
-
-    let sam_path = work.join(format!("{tag}.sam"));
-    let out = Command::new(bwa)
-        .args(["mem", "-t", "2"])
-        .arg(&local_ref)
-        .arg(r1)
-        .arg(r2)
-        .output()
-        .expect("bwa-mem2 mem failed to spawn");
-    assert!(
-        out.status.success(),
-        "bwa-mem2 mem failed:\n{}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    std::fs::write(&sam_path, &out.stdout).unwrap();
-
-    // A SAM with a header but no alignments would sail through every assertion below as
-    // "no signal", so establish that reads were actually placed.
-    let mapped = std::io::BufReader::new(std::fs::File::open(&sam_path).unwrap())
-        .lines()
-        .map_while(Result::ok)
-        .filter(|l| !l.starts_with('@'))
-        .count();
-    assert!(
-        mapped > 100,
-        "{tag}: bwa-mem2 emitted only {mapped} alignment record(s) — the alignment step \
-         failed, so nothing below would be measuring the deletion"
-    );
-    sam_path
-}
+/// Homozygous 299 bp deletion. Hom so every fragment over the locus carries it — a het event
+/// halves every signal below and turns each assertion into a ratio judgement.
+const DEL: SvSpec = SvSpec {
+    svtype: "DEL",
+    contig: "H1N1_HA",
+    pos: 500,
+    end: 799,
+    gt: "1/1",
+};
 
 #[test]
 #[ignore = "requires bwa-mem2; run with --ignored (see module docs)"]
 fn gate2_del_produces_the_three_signatures_a_caller_needs() {
-    let bwa = bwa_mem2();
-    let (_dir, work) = fresh_workdir();
-
-    let (dr1, dr2) = generate_reads(&work, "withdel", true);
-    let (cr1, cr2) = generate_reads(&work, "control", false);
-
-    let del = analyse(&align(&bwa, &work, "withdel", &dr1, &dr2));
-    let ctl = analyse(&align(&bwa, &work, "control", &cr1, &cr2));
-
+    let (del, ctl, _dir) = run_gate(&DEL);
     println!("  DEL run: {del:?}");
     println!("  control: {ctl:?}");
 
     // ── Signature 1: depth collapses over the deletion ────────────────────────────────
-    // Homozygous, so the interior should be ~empty rather than merely reduced. Asserted as a
-    // ratio against the same run's own flanking depth, which cancels any coverage difference
-    // between the two runs.
     let del_ratio = del.depth_inside / del.depth_outside.max(1e-9);
     let ctl_ratio = ctl.depth_inside / ctl.depth_outside.max(1e-9);
     assert!(
@@ -321,8 +67,8 @@ fn gate2_del_produces_the_three_signatures_a_caller_needs() {
         del.depth_outside
     );
     // MUST-NOT-FIRE: the control has no deletion, so the same window must be normally covered.
-    // Without this, a run that produced no reads over the region for an unrelated reason would
-    // satisfy the assertion above.
+    // Without this, a run producing no reads there for an unrelated reason would satisfy the
+    // assertion above — which is exactly how the first version of this harness fooled itself.
     assert!(
         ctl_ratio > 0.80,
         "control has no deletion, yet the same window is depleted (ratio {ctl_ratio:.3}) — \
@@ -332,31 +78,27 @@ fn gate2_del_produces_the_three_signatures_a_caller_needs() {
     // ── Signature 2: split reads pile up at the breakpoints ───────────────────────────
     assert!(
         del.clips_at_breakpoints >= 5,
-        "a split-read caller needs clipped reads at the junction; found {} within ±25bp of \
-         {DEL_POS}/{DEL_END}",
+        "a split-read caller needs clipped reads at the junction; found {}",
         del.clips_at_breakpoints
     );
-    // MUST-NOT-FIRE: clipping at the breakpoints must be specific to the deletion, not the
-    // aligner's background rate on this fixture.
     assert!(
         del.clips_at_breakpoints > ctl.clips_at_breakpoints * 3,
-        "breakpoint clipping ({}) is not clearly above the control's background ({}) — \
-         a caller could not distinguish it either",
+        "breakpoint clipping ({}) is not clearly above the control background ({}) — a caller \
+         could not distinguish it either",
         del.clips_at_breakpoints,
         ctl.clips_at_breakpoints
     );
 
     // ── Signature 3: spanning pairs are discordant by ~SVLEN ──────────────────────────
     assert!(
-        del.discordant_pairs >= 5,
-        "a paired-end caller needs pairs whose insert size is inflated by the deletion; \
-         found {}",
-        del.discordant_pairs
+        del.long_pairs >= 5,
+        "a paired-end caller needs pairs whose insert size is inflated by the deletion; found {}",
+        del.long_pairs
     );
     assert!(
-        del.discordant_pairs > ctl.discordant_pairs * 3,
-        "discordant pairs ({}) are not clearly above the control's background ({})",
-        del.discordant_pairs,
-        ctl.discordant_pairs
+        del.long_pairs > ctl.long_pairs * 3,
+        "long pairs ({}) are not clearly above the control background ({})",
+        del.long_pairs,
+        ctl.long_pairs
     );
 }

--- a/eidolon/tests/gate2_realigned_del.rs
+++ b/eidolon/tests/gate2_realigned_del.rs
@@ -47,6 +47,10 @@ const DEL: SvSpec = SvSpec {
     pos: 500,
     end: 799,
     gt: "1/1",
+    // 20 bp in from each breakpoint: enough that a read clipped at a junction cannot contribute,
+    // and this event is too short (300 bp vs 200 bp fragments) for a fragment-length margin.
+    interior: (520, 779),
+    flank: (1_000, 1_400),
 };
 
 #[test]

--- a/eidolon/tests/gate2_realigned_dup.rs
+++ b/eidolon/tests/gate2_realigned_dup.rs
@@ -1,0 +1,129 @@
+//! **Gate 2 for DUP** — does a real aligner produce the evidence a duplication caller needs?
+//!
+//! Motivated by a concrete failure. In SV validation array 21072620, Manta and Delly missed the
+//! **identical** set of duplications (pooled TP=91, FN=14 for both). That is not caller
+//! behaviour — two independent tools agreeing to the record points at a property of the events.
+//! Investigation ruled out a size floor (one miss was 1.7 Mb) and assembly gaps (three of four
+//! were 0.0% N), and one of the four turned out to be a `--passonly` artifact (#541). The rest
+//! are unexplained, and the question Gate 2 answers is the one nobody had asked: *is the
+//! evidence a duplication caller looks for actually present in the reads?*
+//!
+//! A tandem duplication has a signature a deletion does not:
+//!
+//! | signature | why a caller needs it |
+//! |---|---|
+//! | depth **rises** over the duplicated span | depth/CNV callers |
+//! | soft clips at the junction | split-read callers |
+//! | **everted (RF) pairs** — mates appear swapped | the discriminating tandem-DUP signal |
+//!
+//! The everted pair is the discriminating one: a fragment spanning the junction reads out of the
+//! *second* copy back into the *first*, so its mates align in reverse order. A duplication that
+//! raised depth without producing everted pairs would look like a copy-number gain with no
+//! breakpoint — detectable by a depth caller and invisible to Manta or Delly, which is
+//! consistent with what array 21072620 reported.
+//!
+//! ## Measured excess over the declared dosage — evidence for #499
+//!
+//! A homozygous DUP without `CN` gets `coverage_multiplier_for` = **2.0**, but the realigned
+//! depth over this 300 bp event reads **2.55x** its flank. Mutating the multiplier gives a clean
+//! dose-response:
+//!
+//! | multiplier | depth inside | flank | ratio |
+//! |---|---|---|---|
+//! | 2.0 (shipped) | 168.60 | 66.05 | 2.553 |
+//! | 1.0 | 99.14 | 65.25 | 1.519 |
+//! | 0.5 | 69.08 | 65.55 | 1.054 |
+//!
+//! That is `ratio ~= multiplier + 0.53` — a constant offset independent of the multiplier, and
+//! ~44 everted pairs plus 64 clipped reads is about the right number of extra reads to account
+//! for it. The junction reads appear to be emitted *in addition to* the coverage-multiplied
+//! regular reads, rather than being part of them. Being a fixed number of reads, the excess
+//! scales inversely with event length, which predicts the ~8% seen on #499's 1200 bp event
+//! against the 27% seen here on 300 bp.
+//!
+//! **This gate deliberately does not assert the excess away.** It asserts the signature is
+//! present; the dosage question belongs to #499 and to the Phase 1 size sweep, which this
+//! measurement now gives a mechanism to test.
+//!
+//! Requires bwa-mem2; `#[ignore]`d so CI never reaches it. See `common/gate2.rs`.
+//!
+//! ```text
+//! conda activate aln
+//! cargo test --test gate2_realigned_dup -- --ignored --nocapture
+//! ```
+
+mod common;
+
+use common::gate2::{SvSpec, run_gate};
+
+/// Homozygous 300 bp tandem duplication. Hom so the depth change is a doubling rather than a
+/// 1.5x, which keeps every assertion a presence/absence question.
+const DUP: SvSpec = SvSpec {
+    svtype: "DUP",
+    contig: "H1N1_HA",
+    pos: 500,
+    end: 799,
+    gt: "1/1",
+};
+
+#[test]
+#[ignore = "requires bwa-mem2; run with --ignored (see module docs)"]
+fn gate2_dup_produces_the_three_signatures_a_caller_needs() {
+    let (dup, ctl, _dir) = run_gate(&DUP);
+    println!("  DUP run: {dup:?}");
+    println!("  control: {ctl:?}");
+
+    // ── Signature 1: depth rises over the duplicated span ─────────────────────────────
+    // Homozygous DUP without CN means one extra copy per haplotype, so the multiplier is 2.0.
+    // Asserted as a ratio against the same run's own flank, which cancels any coverage
+    // difference between the two runs.
+    let dup_ratio = dup.depth_inside / dup.depth_outside.max(1e-9);
+    let ctl_ratio = ctl.depth_inside / ctl.depth_outside.max(1e-9);
+    // Threshold is 1.9, just under the physically expected 2.0, NOT under the observed 2.55.
+    // The first version used 1.5 and a mutation setting the multiplier to 1.0 landed at 1.519 --
+    // surviving by 0.019. Anchor a threshold to what the value SHOULD be, never to a margin
+    // below what it happens to be.
+    assert!(
+        dup_ratio > 1.9,
+        "depth over a homozygous duplication should roughly double; interior/flank was \
+         {dup_ratio:.3} (inside {:.1}x, outside {:.1}x)",
+        dup.depth_inside,
+        dup.depth_outside
+    );
+    // MUST-NOT-FIRE: the control has no duplication, so the same window must be flat. Without
+    // this, a window that happens to be over-covered would satisfy the assertion above.
+    assert!(
+        (0.8..1.2).contains(&ctl_ratio),
+        "control has no duplication, yet the same window reads {ctl_ratio:.3} — the window is \
+         unreliable, so signature 1 proves nothing"
+    );
+
+    // ── Signature 2: split reads at the junction ──────────────────────────────────────
+    assert!(
+        dup.clips_at_breakpoints >= 5,
+        "a split-read caller needs clipped reads at the duplication junction; found {}",
+        dup.clips_at_breakpoints
+    );
+    assert!(
+        dup.clips_at_breakpoints > ctl.clips_at_breakpoints * 3,
+        "breakpoint clipping ({}) is not clearly above the control background ({})",
+        dup.clips_at_breakpoints,
+        ctl.clips_at_breakpoints
+    );
+
+    // ── Signature 3: everted pairs — the tandem-duplication discriminator ─────────────
+    // This is the one that separates "a duplication" from "a region with more coverage".
+    assert!(
+        dup.everted_pairs >= 5,
+        "a tandem duplication must produce everted (RF) read pairs at its junction; found {}. \
+         Without them the event is a copy-number gain with no breakpoint — visible to a depth \
+         caller and invisible to Manta/Delly",
+        dup.everted_pairs
+    );
+    assert!(
+        dup.everted_pairs > ctl.everted_pairs * 3,
+        "everted pairs ({}) are not clearly above the control background ({})",
+        dup.everted_pairs,
+        ctl.everted_pairs
+    );
+}

--- a/eidolon/tests/gate2_realigned_dup.rs
+++ b/eidolon/tests/gate2_realigned_dup.rs
@@ -64,6 +64,10 @@ const DUP: SvSpec = SvSpec {
     pos: 500,
     end: 799,
     gt: "1/1",
+    // 20 bp in from each breakpoint: enough that a read clipped at a junction cannot contribute,
+    // and this event is too short (300 bp vs 200 bp fragments) for a fragment-length margin.
+    interior: (520, 779),
+    flank: (1_000, 1_400),
 };
 
 #[test]

--- a/eidolon/tests/gate2_realigned_inv.rs
+++ b/eidolon/tests/gate2_realigned_inv.rs
@@ -1,0 +1,129 @@
+//! **Gate 2 for INV** — does a real aligner produce the evidence an inversion caller needs?
+//!
+//! Two questions here, one of them load-bearing for how we report results.
+//!
+//! **1. Are the signatures present?** An inversion is *balanced* — no sequence is gained or lost —
+//! so depth is not the signal. What a caller sees is:
+//!
+//! | signature | why a caller needs it |
+//! |---|---|
+//! | depth **unchanged** over the interior | distinguishes INV from DEL/DUP |
+//! | soft clips at both breakpoints | split-read callers |
+//! | **same-orientation (FF/RR) pairs** | the discriminating inversion signal |
+//!
+//! The same-orientation pair is the discriminator: one mate falls inside the inverted block and
+//! is therefore read from the opposite strand to its partner, so both align to the same strand.
+//! That is distinct from a duplication's everted (RF) pair, whose mates remain on *opposite*
+//! strands — and the two are counted separately here so a DUP cannot satisfy an INV assertion.
+//!
+//! **2. Is the INV precision artifact really ours?** Array 21072620 pooled `manta_INV` at
+//! precision 0.513 and `delly_INV` at 0.527 — both about half, with FP=56 and FP=52. We have
+//! been attributing that to our own representation: inversion-oriented junctions convert to
+//! `<INV>` via Manta's `convertInversion.py` and land as INV false positives. Two independent
+//! callers agreeing that closely is good evidence, but it is still inference. If eidolon's
+//! inversions produce clean FF/RR pairs and clean breakpoint clips, then the reads are not the
+//! problem and the representational explanation survives a real test rather than a plausible one.
+//!
+//! ## Fixture choice matters here
+//!
+//! `docs/sv_support_matrix.md` records that coverage within ~one fragment of an inversion
+//! junction sits at 0.74–0.82, and warns explicitly: *an inversion shorter than the fragment
+//! length is not a clean fixture* — a 300 bp inversion with 200 bp fragments is entirely inside
+//! its own junction-dip zone, which is what once made a correct implementation read as 0.63. So
+//! this uses the 1.2 kb inversion on `H1N1_PB2` and measures 300 bp in from each breakpoint.
+//!
+//! Requires bwa-mem2; `#[ignore]`d so CI never reaches it. See `common/gate2.rs`.
+//!
+//! ```text
+//! conda activate aln
+//! cargo test --test gate2_realigned_inv -- --ignored --nocapture
+//! ```
+
+mod common;
+
+use common::gate2::{SvSpec, run_gate};
+
+/// Homozygous 1200 bp inversion — the fixture `docs/sv_support_matrix.md` used to establish that
+/// the inverted sequence is covered at full depth and the loss is junction-proximal only.
+const INV: SvSpec = SvSpec {
+    svtype: "INV",
+    contig: "H1N1_PB2",
+    pos: 500,
+    end: 1_700,
+    gt: "1/1",
+    // 300 bp in from each breakpoint: more than one fragment (mean 200), so the window measures
+    // the inverted sequence rather than the junction dip.
+    interior: (800, 1_400),
+    flank: (1_750, 2_050),
+};
+
+#[test]
+#[ignore = "requires bwa-mem2; run with --ignored (see module docs)"]
+fn gate2_inv_produces_the_signatures_a_caller_needs() {
+    let (inv, ctl, _dir) = run_gate(&INV);
+    println!("  INV run: {inv:?}");
+    println!("  control: {ctl:?}");
+
+    // ── Signature 1: depth is UNCHANGED — an inversion is balanced ─────────────────────
+    // This is the assertion that separates INV from DEL and DUP. Note it is a must-NOT-fire in
+    // the depth channel: a depth change here would mean the inversion is losing or duplicating
+    // sequence, which is a different (and worse) defect than failing to be detectable.
+    let inv_ratio = inv.depth_inside / inv.depth_outside.max(1e-9);
+    let ctl_ratio = ctl.depth_inside / ctl.depth_outside.max(1e-9);
+    assert!(
+        (0.85..1.15).contains(&inv_ratio),
+        "an inversion is balanced, so interior depth must match the flank; got {inv_ratio:.3} \
+         (inside {:.1}x, outside {:.1}x). Below 1.0 means sequence is being lost, above means \
+         it is being duplicated",
+        inv.depth_inside,
+        inv.depth_outside
+    );
+    // The control establishes the windows themselves are comparable. Without it, an interior and
+    // flank that happen to differ would make the assertion above either vacuous or unpassable.
+    assert!(
+        (0.85..1.15).contains(&ctl_ratio),
+        "control interior/flank is {ctl_ratio:.3} — the two windows are not comparable, so \
+         signature 1 measures the windows rather than the inversion"
+    );
+
+    // ── Signature 2: split reads at BOTH breakpoints ───────────────────────────────────
+    assert!(
+        inv.clips_at_breakpoints >= 5,
+        "a split-read caller needs clipped reads at the inversion junctions; found {}",
+        inv.clips_at_breakpoints
+    );
+    assert!(
+        inv.clips_at_breakpoints > ctl.clips_at_breakpoints * 3,
+        "breakpoint clipping ({}) is not clearly above the control background ({})",
+        inv.clips_at_breakpoints,
+        ctl.clips_at_breakpoints
+    );
+
+    // ── Signature 3: same-orientation pairs — the inversion discriminator ──────────────
+    assert!(
+        inv.same_orientation_pairs >= 5,
+        "an inversion must produce same-orientation (FF/RR) read pairs at its junctions; found \
+         {}. Without them a caller sees clipped reads with no orientation evidence and cannot \
+         classify the event as an inversion",
+        inv.same_orientation_pairs
+    );
+    assert!(
+        inv.same_orientation_pairs > ctl.same_orientation_pairs * 3,
+        "same-orientation pairs ({}) are not clearly above the control background ({})",
+        inv.same_orientation_pairs,
+        ctl.same_orientation_pairs
+    );
+
+    // ── Must-not-fire across signatures: an inversion is not a duplication ─────────────
+    // Everted (RF) pairs are the tandem-DUP signature. If an inversion produced them, a caller
+    // would have grounds to call DUP here, and our INV false-positive story would be about the
+    // reads rather than about representation.
+    assert!(
+        inv.everted_pairs <= ctl.everted_pairs + 2,
+        "inversion produced {} everted (RF) pairs against the control's {} — that is a \
+         DUPLICATION signature, and its presence would explain caller confusion by the reads \
+         rather than by our representation",
+        inv.everted_pairs,
+        ctl.everted_pairs
+    );
+}


### PR DESCRIPTION
Third Gate 2 (see #538). An inversion is *balanced*, so depth is not the signal — what a caller
sees is breakpoint clips plus **same-orientation (FF/RR) pairs**, where one mate falls inside the
inverted block and is read from the opposite strand to its partner.

Homozygous 1.2 kb inversion at `H1N1_PB2:500-1700`, realigned with bwa-mem2:

| signature | with INV | control |
|---|---|---|
| depth interior/flank | **1.026** (balanced) | 1.014 |
| clips at breakpoints | **123** | 0 |
| same-orientation pairs | **98** | 0 |
| everted (RF) pairs | 0 | 0 |

## Why this matters beyond the gate

Array 21072620 pooled `manta_INV` precision at **0.513** and `delly_INV` at **0.527**. We have
been attributing that to our own representation — inversion-oriented junctions convert to `<INV>`
via Manta's `convertInversion.py` and land as INV false positives. Two independent callers
agreeing that closely is good evidence, but it was still inference.

The reads are now **measured clean**: unambiguous FF/RR orientation, clips at both breakpoints,
zero everted pairs suggesting a duplication, balanced depth. The false positives are not
attributable to the reads. `docs/sv_support_matrix.md` is updated to say so from measurement
rather than from agreement.

## Fixture choice is load-bearing

Following the matrix's own warning: *an inversion shorter than the fragment length is not a clean
fixture*. A 300 bp inversion with 200 bp fragments sits entirely inside its own junction-dip zone,
which once made a correct implementation read as 0.63. This uses the 1.2 kb fixture and measures
300 bp in from each breakpoint — more than one fragment.

## Non-vacuity

| mutation | clips at bp | same-orientation | caught by |
|---|---|---|---|
| both revcomp flags ignored (`if false && rev1`) | 123 → 60 | **98 → 0** | **signature 3 only** |
| junction reads emit left piece only | 123 → 1 | 98 → 0 | depth + clips |

**Read that first row carefully.** With the reverse-complement disabled — the exact blind spot
`chimeric_sequence_content.rs` was written for — clips at breakpoints stayed at 60, well above
background, so the **clip assertion still passed**. Only the orientation signature caught it.
Without that channel this gate would have blessed reads no caller could classify as an inversion.

## A nuance worth reviewing

Separating the pair geometries turned up that **inflated-TLEN pairs are not deletion-specific**: a
1.2 kb inversion produces ~99 of them, because a mate landing inside the inverted block maps to a
mirrored position. Orientation is the discriminator:

| | long pairs | everted | same-orientation |
|---|---|---|---|
| DEL | 46 | 0 | 0 |
| DUP | 0 | 44 | 0 |
| INV | 98 | 0 | 98 |

Which is exactly why callers use insert size and orientation together. The three counters are now
separate so a DUP cannot satisfy an INV assertion, and `everted` requires a *forward* mate rather
than merely a reverse leftmost read.

## Not verified

One event size, one genotype, one aligner. Nothing about inversions shorter than a fragment
(known-bad fixture), or minimap2/STAR orientation conventions. All three gates pass; 36 suites
green under `-D warnings`; `eidolon/src` untouched.