### PR TITLE
fix(bam)!: golden BAM records were not in reference orientation (Gate 2b) — closes #550, #551

### DIFF
--- a/eidolon-core/src/file_tools/bam_writer.rs
+++ b/eidolon-core/src/file_tools/bam_writer.rs
@@ -5,6 +5,8 @@ use std::num::NonZero;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::file_tools::fastq_tools::reverse_complement;
+use crate::structs::nucleotides::Nucleotide;
 use noodles::bam;
 use noodles::bgzf;
 use noodles::core::Position;
@@ -441,18 +443,62 @@ pub fn build_bam_record(
 ) -> RecordBuf {
     let mut record = RecordBuf::default();
 
-    *record.name_mut() = Some(name.as_bytes().to_vec().into());
+    // SAM v1 §1.4 field 1: segments of one template share a QNAME, and mate identity is carried
+    // by FLAG 0x40/0x80. The `/1` and `/2` suffixes are a FASTQ convention; carried into a BAM
+    // they give mates DIFFERENT names, so nothing can pair them -- MarkDuplicates and fixmate
+    // silently see singletons (#551). The FASTQ writer keeps its suffixes, correctly.
+    let qname = name
+        .strip_suffix("/1")
+        .or_else(|| name.strip_suffix("/2"))
+        .unwrap_or(name);
+
+    // SAM v1 §1.4 fields 10-11: when 0x10 is set, SEQ holds the REVERSE COMPLEMENT of the read as
+    // sequenced and QUAL is reversed, so that POS + CIGAR + SEQ are one consistent statement.
+    //
+    // The `ReadRecord` reaching us is in READ orientation: `fastq_tools` flips R2 via
+    // `reverse_complement_record` because a FASTQ must contain the read as sequenced. Both writers
+    // consume that same record, and only this one needs reference orientation -- so undo the flip
+    // here, keyed off the very flag this function was handed, which is what keeps the two from
+    // disagreeing (#550). Reuses `fastq_tools::reverse_complement` rather than reimplementing the
+    // complement table, so the two paths cannot drift.
+    // The CIGAR needs the same treatment, and this is the part that is easy to miss: it too
+    // arrives in read orientation, so `60M1I39M` on a reverse read describes an insertion 60
+    // bases into the READ. Reference-oriented, that is `39M1I60M`. Measured on 66 reverse records
+    // carrying an indel: identity to the reference is 0.607 with the CIGAR as written and 0.995
+    // with the op order reversed. Fixing SEQ alone leaves SEQ and CIGAR disagreeing with each
+    // other, which is worse than the original bug -- before, the two were at least mutually
+    // consistent in read orientation.
+    let reverse = flags.is_reverse_complemented();
+    let cigar_out: Cigar = if reverse {
+        cigar.as_ref().iter().rev().copied().collect()
+    } else {
+        cigar
+    };
+    let seq_out: String = if reverse {
+        reverse_complement(sequence.chars().map(Nucleotide::from).collect())
+            .into_iter()
+            .map(char::from)
+            .collect()
+    } else {
+        sequence.to_string()
+    };
+
+    *record.name_mut() = Some(qname.as_bytes().to_vec().into());
     *record.flags_mut() = flags;
     *record.reference_sequence_id_mut() = Some(ref_id);
     *record.alignment_start_mut() = Position::new(pos + 1);
     *record.mapping_quality_mut() = MappingQuality::try_from(mapq).ok();
-    *record.cigar_mut() = cigar;
+    *record.cigar_mut() = cigar_out;
     *record.mate_reference_sequence_id_mut() = Some(mate_ref_id);
     *record.mate_alignment_start_mut() = Position::new(mate_pos + 1);
     *record.template_length_mut() = template_length;
-    *record.sequence_mut() = Sequence::from(sequence.as_bytes());
+    *record.sequence_mut() = Sequence::from(seq_out.as_bytes());
 
-    let qual_u8: Vec<u8> = qual_scores.iter().map(|&q| q as u8).collect();
+    let qual_u8: Vec<u8> = if reverse {
+        qual_scores.iter().rev().map(|&q| q as u8).collect()
+    } else {
+        qual_scores.iter().map(|&q| q as u8).collect()
+    };
     *record.quality_scores_mut() = QualityScores::from(qual_u8);
 
     record

--- a/eidolon/tests/gate2b_golden_bam_agrees_with_fastq.rs
+++ b/eidolon/tests/gate2b_golden_bam_agrees_with_fastq.rs
@@ -1,0 +1,389 @@
+//! **Gate 2b** — does the golden BAM agree with the FASTQ it was generated alongside, and with the
+//! reference it claims to be aligned to?
+//!
+//! See `docs/sv_polish_roadmap.md`. Gate 2a asks whether a *realigned* BAM carries the evidence a
+//! caller needs, and requires an aligner. This gate asks a different and cheaper question: are
+//! eidolon's own two outputs mutually consistent? They are produced by one generation pass but
+//! written by different code (`fastq_tools.rs`, `bam_writer.rs`), and nothing asserted they agree
+//! — the shape that let `sv_model.rs` and `runner.rs` disagree about BND geometry for eight
+//! releases.
+//!
+//! **No aligner, no variants, no SVs required, so this runs in CI on every push.** That makes it a
+//! stronger guarantee than Gate 2a, which is `#[ignore]`d and only runs when someone remembers.
+//!
+//! ## What it pins
+//!
+//! | assertion | defect it would have caught |
+//! |---|---|
+//! | `SEQ` matches the reference at `POS` on **both** strands | [#550](https://github.com/ncsa/eidolon/issues/550) |
+//! | reverse-flagged `SEQ`/`QUAL` are the revcomp/reverse of the FASTQ's | #550 |
+//! | no QNAME ends in `/1` or `/2`, and mates share a name | [#551](https://github.com/ncsa/eidolon/issues/551) |
+//!
+//! The reference check is the independent one: it needs neither the FASTQ nor any assumption about
+//! orientation conventions. `SEQ` either matches the sequence it is aligned to or it does not, and
+//! #550 was 0.14 identity against 1.00 after reverse-complementing.
+
+mod common;
+
+use common::{GenReadsConfig, eidolon, fresh_workdir, h1n1_reference, read_gzip_fastq_lines};
+use noodles::bam;
+use noodles::sam::alignment::record::cigar::op::Kind;
+use std::collections::HashMap;
+use std::path::Path;
+
+fn revcomp(seq: &str) -> String {
+    seq.chars()
+        .rev()
+        .map(|c| match c {
+            'A' => 'T',
+            'T' => 'A',
+            'C' => 'G',
+            'G' => 'C',
+            'a' => 't',
+            't' => 'a',
+            'c' => 'g',
+            'g' => 'c',
+            other => other,
+        })
+        .collect()
+}
+
+/// Whole-contig sequences from the H1N1 fixture. The fixture is CRLF, so `\r` is stripped —
+/// a detail that has already cost one debugging session via `samtools faidx`.
+fn reference_contigs() -> HashMap<String, String> {
+    let text = std::fs::read_to_string(h1n1_reference()).unwrap();
+    let mut out: HashMap<String, String> = HashMap::new();
+    let mut current = String::new();
+    for line in text.lines() {
+        let line = line.trim_end_matches('\r');
+        if let Some(header) = line.strip_prefix('>') {
+            current = header.split_whitespace().next().unwrap_or("").to_string();
+            out.insert(current.clone(), String::new());
+        } else if !current.is_empty() {
+            out.get_mut(&current).unwrap().push_str(line);
+        }
+    }
+    out
+}
+
+/// FASTQ name (including its `/1` or `/2`) -> (sequence, quality).
+fn read_fastq(path: &Path) -> HashMap<String, (String, String)> {
+    let lines = read_gzip_fastq_lines(path);
+    let mut out = HashMap::new();
+    for chunk in lines.chunks(4) {
+        if chunk.len() < 4 {
+            break;
+        }
+        let name = chunk[0].trim_start_matches('@').trim().to_string();
+        out.insert(name, (chunk[1].clone(), chunk[3].clone()));
+    }
+    out
+}
+
+struct Run {
+    bam: std::path::PathBuf,
+    r1: HashMap<String, (String, String)>,
+    r2: HashMap<String, (String, String)>,
+}
+
+fn generate(paired: bool) -> (tempfile::TempDir, Run) {
+    let (dir, work) = fresh_workdir();
+    let tag = if paired { "paired" } else { "single" };
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.clone(), tag);
+    config.coverage = 5;
+    config.read_len = 100;
+    config.paired_ended = paired;
+    config.produce_fastq = true;
+    config.produce_bam = true;
+    config.produce_vcf = false;
+    // No variants at all. This gate is about the two writers agreeing, so the reads should be
+    // plain reference sequence plus the sequencing-error model — nothing else to explain a
+    // mismatch away with.
+    config.mutation_rate = Some(0.0);
+    config.sv_rate_scale = Some(0.0);
+    let yaml = config.write_yaml();
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let r1 = read_fastq(&work.join(format!("{tag}_r1.fastq.gz")));
+    let r2 = if paired {
+        read_fastq(&work.join(format!("{tag}_r2.fastq.gz")))
+    } else {
+        HashMap::new()
+    };
+    let bam = work.join(format!("{tag}.bam"));
+    assert!(bam.is_file(), "golden BAM not produced at {bam:?}");
+    (dir, Run { bam, r1, r2 })
+}
+
+/// `SEQ` must match the reference at `POS` — on BOTH strands.
+///
+/// This is the assertion that needs no FASTQ and no convention: a record either agrees with the
+/// sequence it declares itself aligned to, or it does not. #550 failed it at 0.14 identity for
+/// every reverse-strand record while forward records sat at ~0.99.
+#[test]
+fn golden_bam_sequences_match_the_reference_on_both_strands() {
+    let (_dir, run) = generate(true);
+    let contigs = reference_contigs();
+
+    let mut reader = bam::io::reader::Builder::default()
+        .build_from_path(&run.bam)
+        .unwrap();
+    let header = reader.read_header().unwrap();
+
+    let mut checked = (0usize, 0usize); // (forward, reverse)
+    let mut worst = (1.0f64, String::new());
+    for result in reader.records() {
+        let record = result.unwrap();
+        let Some(Ok(start)) = record.alignment_start() else {
+            continue;
+        };
+        let ref_id = record.reference_sequence_id().transpose().unwrap().unwrap();
+        let ref_name = header
+            .reference_sequences()
+            .get_index(ref_id)
+            .map(|(name, _)| String::from_utf8_lossy(name.as_ref()).to_string())
+            .unwrap();
+        let seq: String = record
+            .sequence()
+            .iter()
+            .map(|b| char::from(b).to_ascii_uppercase())
+            .collect();
+        let contig = &contigs[&ref_name];
+
+        // CIGAR-aware comparison. The sequencing-error model emits indels, so a positional
+        // comparison frameshifts on the first `I`/`D` and reports a correct read as ~0.27
+        // identity — which is how the first version of this assertion failed on good data.
+        // Only M/=/X runs are compared; I/S consume read bases, D/N consume reference.
+        let mut read_pos = 0usize;
+        let mut ref_pos = usize::from(start) - 1;
+        let mut matched = 0usize;
+        let mut compared_bases = 0usize;
+        for op in record.cigar().iter() {
+            let op = op.unwrap();
+            let len = op.len();
+            match op.kind() {
+                Kind::Match | Kind::SequenceMatch | Kind::SequenceMismatch => {
+                    for k in 0..len {
+                        if let (Some(r), Some(q)) = (
+                            contig.as_bytes().get(ref_pos + k),
+                            seq.as_bytes().get(read_pos + k),
+                        ) {
+                            compared_bases += 1;
+                            if r.eq_ignore_ascii_case(q) {
+                                matched += 1;
+                            }
+                        }
+                    }
+                    read_pos += len;
+                    ref_pos += len;
+                }
+                Kind::Insertion | Kind::SoftClip => read_pos += len,
+                Kind::Deletion | Kind::Skip => ref_pos += len,
+                _ => {}
+            }
+        }
+        if compared_bases == 0 {
+            continue;
+        }
+        let expected = contig
+            [(usize::from(start) - 1)..(usize::from(start) - 1 + seq.len()).min(contig.len())]
+            .to_uppercase();
+
+        let id = matched as f64 / compared_bases as f64;
+        let reverse = record.flags().is_reverse_complemented();
+        if reverse {
+            checked.1 += 1;
+        } else {
+            checked.0 += 1;
+        }
+        if id < worst.0 {
+            worst = (
+                id,
+                format!(
+                    "{ref_name}:{} reverse={reverse}\n    SEQ {}\n    ref {}\n    rc  {}",
+                    usize::from(start),
+                    &seq[..seq.len().min(50)],
+                    &expected[..expected.len().min(50)],
+                    &revcomp(&seq)[..seq.len().min(50)],
+                ),
+            );
+        }
+    }
+
+    // Both strands must be represented, or the assertion could pass by never testing one.
+    assert!(
+        checked.0 > 20 && checked.1 > 20,
+        "expected both strands to be well represented; got {} forward and {} reverse",
+        checked.0,
+        checked.1
+    );
+    // 0.90 leaves room for the sequencing-error model (~0.99 in practice) while sitting far above
+    // a reverse-complement mismatch, which lands near 0.14 — the two are not close.
+    assert!(
+        worst.0 > 0.90,
+        "a golden BAM record disagrees with the reference it is aligned to (identity {:.2}).\n  \
+         {}\n  If `rc` matches `ref` and `SEQ` does not, SEQ is in READ orientation and SAM 1.4 \
+         requires REFERENCE orientation when 0x10 is set (#550).",
+        worst.0,
+        worst.1
+    );
+}
+
+/// The golden BAM and the FASTQ describe the same reads, so they must agree exactly — modulo the
+/// orientation convention that differs between the two formats.
+#[test]
+fn golden_bam_and_fastq_describe_the_same_reads() {
+    let (_dir, run) = generate(true);
+    let mut reader = bam::io::reader::Builder::default()
+        .build_from_path(&run.bam)
+        .unwrap();
+    let _ = reader.read_header().unwrap();
+
+    let mut compared = 0usize;
+    for result in reader.records() {
+        let record = result.unwrap();
+        let flags = record.flags();
+        let qname = String::from_utf8_lossy(record.name().unwrap().as_ref()).to_string();
+        let mate_suffix = if flags.is_last_segment() { "/2" } else { "/1" };
+        let source = if flags.is_last_segment() {
+            &run.r2
+        } else {
+            &run.r1
+        };
+        let key = format!("{qname}{mate_suffix}");
+        let Some((fq_seq, fq_qual)) = source.get(&key) else {
+            panic!(
+                "golden BAM record {qname:?} (mate {mate_suffix}) has no FASTQ counterpart at \
+                 key {key:?}. Either the two writers disagree about read names, or QNAME still \
+                 carries its own /1 or /2 suffix (#551)."
+            );
+        };
+        let seq: String = record
+            .sequence()
+            .iter()
+            .map(|b| char::from(b).to_ascii_uppercase())
+            .collect();
+        let qual: String = record
+            .quality_scores()
+            .as_ref()
+            .iter()
+            .map(|&q| char::from(q + 33))
+            .collect();
+
+        let (want_seq, want_qual) = if flags.is_reverse_complemented() {
+            (revcomp(fq_seq), fq_qual.chars().rev().collect::<String>())
+        } else {
+            (fq_seq.clone(), fq_qual.clone())
+        };
+        assert_eq!(
+            seq,
+            want_seq,
+            "SEQ mismatch for {qname} (reverse={}): the BAM and FASTQ disagree about the bases \
+             of the same read",
+            flags.is_reverse_complemented()
+        );
+        assert_eq!(
+            qual,
+            want_qual,
+            "QUAL mismatch for {qname} (reverse={}): quality must be reversed exactly when the \
+             sequence is reverse-complemented",
+            flags.is_reverse_complemented()
+        );
+        compared += 1;
+    }
+    assert!(
+        compared > 100,
+        "only {compared} record(s) compared — too few for this to mean anything"
+    );
+}
+
+/// SAM 1.4 field 1: mates share a QNAME. The `/1` and `/2` suffixes are a FASTQ convention and
+/// must not survive into the BAM, or nothing can pair the segments (#551).
+#[test]
+fn golden_bam_qnames_are_shared_between_mates() {
+    let (_dir, run) = generate(true);
+    let mut reader = bam::io::reader::Builder::default()
+        .build_from_path(&run.bam)
+        .unwrap();
+    let _ = reader.read_header().unwrap();
+
+    let mut seen: HashMap<String, (usize, usize)> = HashMap::new(); // name -> (first, last)
+    let mut records = 0usize;
+    for result in reader.records() {
+        let record = result.unwrap();
+        let flags = record.flags();
+        let qname = String::from_utf8_lossy(record.name().unwrap().as_ref()).to_string();
+        assert!(
+            !qname.ends_with("/1") && !qname.ends_with("/2"),
+            "QNAME {qname:?} carries a /1 or /2 suffix. SAM 1.4 field 1: segments with the same \
+             QNAME are one template, and mate identity is carried by FLAG 0x40/0x80. With the \
+             suffix, mates have DIFFERENT names and nothing can pair them (#551)"
+        );
+        let e = seen.entry(qname).or_insert((0, 0));
+        if flags.is_last_segment() {
+            e.1 += 1;
+        } else {
+            e.0 += 1;
+        }
+        records += 1;
+    }
+
+    assert!(records > 100, "only {records} record(s); too few to judge");
+    assert_eq!(
+        seen.len() * 2,
+        records,
+        "a paired run must have exactly half as many distinct QNAMEs as records; got {} names \
+         for {records} records",
+        seen.len()
+    );
+    for (name, (first, last)) in &seen {
+        assert_eq!(
+            (*first, *last),
+            (1, 1),
+            "QNAME {name:?} should appear once as FIRST_SEGMENT and once as LAST_SEGMENT; got \
+             first={first} last={last}"
+        );
+    }
+}
+
+/// MUST-NOT-FIRE: a single-ended run has no mates and no reverse-strand convention to apply, so
+/// its records must be byte-identical to the FASTQ. Establishes that the comparison itself is
+/// sound before any orientation logic is involved.
+#[test]
+fn single_ended_golden_bam_is_identical_to_its_fastq() {
+    let (_dir, run) = generate(false);
+    let mut reader = bam::io::reader::Builder::default()
+        .build_from_path(&run.bam)
+        .unwrap();
+    let _ = reader.read_header().unwrap();
+
+    let mut compared = 0usize;
+    for result in reader.records() {
+        let record = result.unwrap();
+        let qname = String::from_utf8_lossy(record.name().unwrap().as_ref()).to_string();
+        let seq: String = record
+            .sequence()
+            .iter()
+            .map(|b| char::from(b).to_ascii_uppercase())
+            .collect();
+        // Single-ended output names have no mate suffix, so look the name up as-is first.
+        let entry = run
+            .r1
+            .get(&qname)
+            .or_else(|| run.r1.get(&format!("{qname}/1")));
+        let (fq_seq, _) = entry.unwrap_or_else(|| {
+            panic!("single-ended golden BAM record {qname:?} has no FASTQ counterpart")
+        });
+        assert_eq!(
+            &seq, fq_seq,
+            "single-ended records carry no reverse-strand convention and must match the FASTQ \
+             exactly"
+        );
+        compared += 1;
+    }
+    assert!(compared > 50, "only {compared} record(s) compared");
+}

--- a/eidolon/tests/golden_bam_stats.rs
+++ b/eidolon/tests/golden_bam_stats.rs
@@ -1,0 +1,325 @@
+//! Structural health of the golden BAM: generate one at volume, assert its statistics, discard it.
+//!
+//! Gate 2b (`gate2b_golden_bam_agrees_with_fastq.rs`) asks whether the *content* is right — does
+//! `SEQ` match the reference, do the two writers agree. This file asks whether the *file* is right:
+//! is it sorted, do mates point at each other, are the flags internally consistent, is every
+//! record inside its contig. Different failure modes, and cheap to check together once the BAM
+//! exists.
+//!
+//! **This is deliberately a volume run.** The writer has a deferred coordinate-sorted path
+//! (`stage_read_record` → `flush_up_to` → `flush_all`) that only engages once reads are buffered
+//! across block boundaries, and nothing exercised it. A 5× run of the kind Gate 2b uses is too
+//! small to reach it. The BAM is written to a `TempDir` and dropped with it, so nothing is kept.
+//!
+//! No aligner and no variants, so this runs in CI on every push.
+//!
+//! ## What each assertion would catch
+//!
+//! | assertion | failure it detects |
+//! |---|---|
+//! | coordinate-sorted | the deferred sort emitting blocks out of order |
+//! | mates point at each other | `RNEXT`/`PNEXT` computed from the wrong record |
+//! | `TLEN` equal and opposite | template length signed per-record rather than per-pair |
+//! | exactly one R1 and one R2 per QNAME | a mate dropped or duplicated at a flush boundary |
+//! | every record mapped | a golden BAM is truth; an unmapped record is meaningless in one |
+//! | alignment inside its contig | off-by-one or overflow at a contig end |
+//! | `@SQ` matches the reference | header written from something other than the reference |
+
+mod common;
+
+use common::{GenReadsConfig, eidolon, fresh_workdir, h1n1_reference, read_gzip_fastq_lines};
+use noodles::bam;
+use noodles::sam::alignment::record::cigar::op::Kind;
+use std::collections::HashMap;
+
+/// Contig name -> length, parsed from the fixture. CRLF-tolerant.
+fn reference_lengths() -> HashMap<String, usize> {
+    let text = std::fs::read_to_string(h1n1_reference()).unwrap();
+    let mut out: HashMap<String, usize> = HashMap::new();
+    let mut current = String::new();
+    for line in text.lines() {
+        let line = line.trim_end_matches('\r');
+        if let Some(header) = line.strip_prefix('>') {
+            current = header.split_whitespace().next().unwrap_or("").to_string();
+            out.insert(current.clone(), 0);
+        } else if !current.is_empty() {
+            *out.get_mut(&current).unwrap() += line.len();
+        }
+    }
+    out
+}
+
+/// Rightmost mapped base of a pair, 1-based. Taken over BOTH mates rather than assuming the
+/// later-starting one ends later — an indel can make the earlier read span further.
+fn max_end(a: &Observed, b: &Observed) -> usize {
+    (a.pos + a.ref_span - 1).max(b.pos + b.ref_span - 1)
+}
+
+struct Observed {
+    contig: usize,
+    pos: usize,
+    mate_contig: Option<usize>,
+    mate_pos: Option<usize>,
+    tlen: i32,
+    is_first: bool,
+    reverse: bool,
+    ref_span: usize,
+}
+
+#[test]
+fn golden_bam_is_structurally_sound_at_volume() {
+    let (_dir, work) = fresh_workdir();
+
+    // 40x across all eight H1N1 contigs. Enough reads to push the writer through repeated
+    // buffer flushes rather than a single block, which is the path this test exists to stress.
+    let mut config = GenReadsConfig::new(h1n1_reference(), work.clone(), "stats");
+    config.coverage = 40;
+    config.read_len = 100;
+    config.paired_ended = true;
+    config.produce_fastq = true;
+    config.produce_bam = true;
+    config.produce_vcf = false;
+    config.mutation_rate = Some(0.0);
+    config.sv_rate_scale = Some(0.0);
+    let yaml = config.write_yaml();
+    eidolon()
+        .args(["gen-reads", "-c"])
+        .arg(yaml.path())
+        .assert()
+        .success();
+
+    let bam_path = work.join("stats.bam");
+    assert!(
+        bam_path.is_file(),
+        "golden BAM not produced at {bam_path:?}"
+    );
+
+    let lengths = reference_lengths();
+    let mut reader = bam::io::reader::Builder::default()
+        .build_from_path(&bam_path)
+        .unwrap();
+    let header = reader.read_header().unwrap();
+
+    // ── The header must describe the reference we were given ───────────────────────────
+    let sq: HashMap<String, usize> = header
+        .reference_sequences()
+        .iter()
+        .map(|(name, seq)| {
+            (
+                String::from_utf8_lossy(name.as_ref()).to_string(),
+                usize::from(seq.length()),
+            )
+        })
+        .collect();
+    assert_eq!(
+        sq, lengths,
+        "@SQ lines must match the reference's contigs and lengths exactly"
+    );
+
+    let names: Vec<String> = header
+        .reference_sequences()
+        .keys()
+        .map(|n| String::from_utf8_lossy(n.as_ref()).to_string())
+        .collect();
+
+    let mut by_qname: HashMap<String, Vec<Observed>> = HashMap::new();
+    let mut last_key = (0usize, 0usize);
+    let mut records = 0usize;
+    let mut unmapped = 0usize;
+    let mut mapq_other = 0usize;
+
+    for result in reader.records() {
+        let record = result.unwrap();
+        records += 1;
+        let flags = record.flags();
+
+        // A golden BAM is ground truth: every read's origin is known by construction, so an
+        // unmapped or secondary record has no meaning in one.
+        if flags.is_unmapped() {
+            unmapped += 1;
+            continue;
+        }
+        assert!(
+            !flags.is_secondary() && !flags.is_supplementary(),
+            "a golden BAM should contain only primary alignments"
+        );
+        assert!(
+            flags.is_segmented(),
+            "paired run: every record must have the PAIRED flag"
+        );
+
+        if record.mapping_quality().map(u8::from) != Some(60) {
+            mapq_other += 1;
+        }
+
+        let contig = record.reference_sequence_id().transpose().unwrap().unwrap();
+        let pos = usize::from(record.alignment_start().unwrap().unwrap());
+
+        // ── Coordinate-sorted, which the deferred writer is responsible for ────────────
+        let key = (contig, pos);
+        assert!(
+            key >= last_key,
+            "records are not coordinate-sorted: {} : {} follows {} : {}",
+            names[contig],
+            pos,
+            names[last_key.0],
+            last_key.1
+        );
+        last_key = key;
+
+        let ref_span: usize = record
+            .cigar()
+            .iter()
+            .map(|op| {
+                let op = op.unwrap();
+                match op.kind() {
+                    Kind::Match
+                    | Kind::SequenceMatch
+                    | Kind::SequenceMismatch
+                    | Kind::Deletion
+                    | Kind::Skip => op.len(),
+                    _ => 0,
+                }
+            })
+            .sum();
+
+        // ── The alignment must fit inside its contig ───────────────────────────────────
+        let contig_len = lengths[&names[contig]];
+        assert!(
+            pos >= 1 && pos + ref_span - 1 <= contig_len,
+            "{}:{}..{} extends past the contig's {} bp",
+            names[contig],
+            pos,
+            pos + ref_span - 1,
+            contig_len
+        );
+
+        let qname = String::from_utf8_lossy(record.name().unwrap().as_ref()).to_string();
+        by_qname.entry(qname).or_default().push(Observed {
+            contig,
+            pos,
+            mate_contig: record.mate_reference_sequence_id().transpose().unwrap(),
+            mate_pos: record
+                .mate_alignment_start()
+                .transpose()
+                .unwrap()
+                .map(usize::from),
+            tlen: record.template_length(),
+            is_first: flags.is_first_segment(),
+            reverse: flags.is_reverse_complemented(),
+            ref_span,
+        });
+    }
+
+    assert_eq!(unmapped, 0, "{unmapped} unmapped record(s) in a golden BAM");
+    assert_eq!(
+        mapq_other, 0,
+        "{mapq_other} record(s) with a MAPQ other than 60; the writer assigns 60 uniformly, so \
+         anything else means a record was built by a path that does not"
+    );
+    assert!(
+        records > 5_000,
+        "only {records} records at 40x over 8 contigs — too few to have exercised the writer's \
+         buffered path, which is what this test is for"
+    );
+
+    // ── Read count agrees with the FASTQ ──────────────────────────────────────────────
+    let r1 = read_gzip_fastq_lines(&work.join("stats_r1.fastq.gz")).len() / 4;
+    let r2 = read_gzip_fastq_lines(&work.join("stats_r2.fastq.gz")).len() / 4;
+    assert_eq!(r1, r2, "R1 and R2 must contain the same number of reads");
+    assert_eq!(
+        records,
+        r1 + r2,
+        "the BAM must contain exactly one record per FASTQ read"
+    );
+
+    // ── Pairing: mates present, pointing at each other, TLEN equal and opposite ────────
+    let mut checked_pairs = 0usize;
+    for (qname, obs) in &by_qname {
+        assert_eq!(
+            obs.len(),
+            2,
+            "QNAME {qname} appears {} time(s); a paired run must emit exactly two records per \
+             template (a flush boundary dropping or duplicating a mate would show up here)",
+            obs.len()
+        );
+        let firsts = obs.iter().filter(|o| o.is_first).count();
+        assert_eq!(
+            firsts, 1,
+            "QNAME {qname} must have exactly one FIRST_SEGMENT record, found {firsts}"
+        );
+
+        let (a, b) = (&obs[0], &obs[1]);
+        assert_eq!(
+            a.mate_contig,
+            Some(b.contig),
+            "{qname}: mate reference id does not point at the actual mate's contig"
+        );
+        assert_eq!(
+            b.mate_contig,
+            Some(a.contig),
+            "{qname}: mate reference id does not point at the actual mate's contig"
+        );
+        assert_eq!(
+            a.mate_pos,
+            Some(b.pos),
+            "{qname}: mate position does not point at the actual mate's position"
+        );
+        assert_eq!(
+            b.mate_pos,
+            Some(a.pos),
+            "{qname}: mate position does not point at the actual mate's position"
+        );
+
+        assert_eq!(
+            a.tlen, -b.tlen,
+            "{qname}: TLEN must be equal and opposite across a pair, got {} and {}",
+            a.tlen, b.tlen
+        );
+        // The leftmost mate carries the positive sign, per SAM convention.
+        let (left, right) = if a.pos <= b.pos { (a, b) } else { (b, a) };
+        assert!(
+            left.tlen >= 0 && right.tlen <= 0,
+            "{qname}: the leftmost mate must carry the positive TLEN"
+        );
+        // |TLEN| against the OBSERVED span, with a deliberate tolerance.
+        //
+        // SAM v1 §1.4 field 9 defines TLEN as the observed template length: the number of bases
+        // from the leftmost to the rightmost mapped base. eidolon reports the *sampled* fragment
+        // length instead, so the two diverge by the net indel offset whenever the sequencing-error
+        // model puts an `I` or `D` in either mate. Measured over 2894 pairs: 2098 agree exactly,
+        // 493 differ by 1, 34 by 2, one by 4 — and the example that first exposed it has a mate
+        // CIGAR of `62M1D38M`, i.e. a 101 bp reference span for a 100 bp read.
+        //
+        // Tracked separately; not asserted away here, and not blessed either. The tolerance is
+        // wide enough to absorb realistic indel drift and far too narrow to admit the failures
+        // this check exists for — TLEN of zero, TLEN equal to a read length, or a pair whose
+        // mates were matched to the wrong partner, all of which are off by 100 or more.
+        let observed = (max_end(left, right) + 1).saturating_sub(left.pos);
+        let drift = (left.tlen.unsigned_abs() as i64) - observed as i64;
+        assert!(
+            drift.abs() <= 10,
+            "{qname}: |TLEN| {} is {drift} from the observed span {observed} — beyond what \
+             sequencing-error indels can explain, so the pair's template length is wrong rather \
+             than merely imprecise",
+            left.tlen.unsigned_abs()
+        );
+        assert!(
+            left.tlen.unsigned_abs() > 0,
+            "{qname}: TLEN must be non-zero for a mapped pair"
+        );
+        // R1 forward / R2 reverse is the orientation this writer produces; the pair must not be
+        // on the same strand, which would make the fragment un-sequenceable.
+        assert_ne!(
+            a.reverse, b.reverse,
+            "{qname}: mates must be on opposite strands"
+        );
+        checked_pairs += 1;
+    }
+    assert!(
+        checked_pairs > 2_500,
+        "only {checked_pairs} pair(s) checked; expected thousands at 40x"
+    );
+
+    // The BAM is inside the TempDir and goes away with it — nothing is kept.
+}


### PR DESCRIPTION
Gate 2b (#548) is the first thing to compare eidolon's two outputs against each other and against
the reference. **It found three defects in the golden BAM before the test was finished.**

## What was wrong

`build_bam_record` set `REVERSE_COMPLEMENTED` via `read_flags()`, then wrote the sequence, quality
and CIGAR unchanged. The `ReadRecord` reaching it is in **read** orientation — `fastq_tools` flips
R2 via `reverse_complement_record`, correctly, because a FASTQ holds the read as sequenced. Both
writers consume that same record and only the BAM needs reference orientation.

So for every reverse-strand record — **half of a paired run** — `SEQ` did not match the reference
it declared itself aligned to:

```
FORWARD-flagged: SEQ matches ref as-is 102, only after revcomp   0
REVERSE-flagged: SEQ matches ref as-is   0, only after revcomp  98
```

One record in full: **0.14** identity to the reference at its own `POS`, **1.00** after
reverse-complementing.

### The CIGAR is the part that is easy to miss

`60M1I39M` on a reverse read describes an insertion 60 bases into the **read**. Reference-oriented
that is `39M1I60M`. Across 66 reverse records carrying an indel:

| CIGAR | identity to reference |
|---|---|
| as written | 0.607 |
| op order reversed | **0.995** |

**Fixing `SEQ` alone is worse than the original bug** — before, `SEQ` and `CIGAR` were at least
mutually consistent in read orientation. The reference assertion caught exactly that half-fixed
state, which is the best argument for having written the test first.

### And QNAME (#551)

662 records carried 662 distinct names — 331 pairs sharing none, while their flags claimed proper
pairing. SAM v1 §1.4 makes identical QNAME *the definition* of one template. `MarkDuplicates`,
`fixmate`, and any name-grouped pairing saw singletons.

## Why it survived

Nothing consumes the golden BAM's sequence. The Delta pipeline realigns the FASTQ with bwa-mem2 and
never reads it. And `gen_reads/mod.rs:515` asserts R2 **has** the reverse flag and R1 does not — so
the flags were checked while the data they describe never was.

## The fix

All three transformations key off the same `flags` value the function already receives, a few lines
from where `read_flags()` produced it, so flag and data cannot disagree. It reuses
`fastq_tools::reverse_complement` rather than adding a second complement table, so the paths cannot
drift. **The FASTQ path is untouched** — read orientation is correct there.

## Non-vacuity — each part reverted independently

| mutation | caught by |
|---|---|
| `SEQ` not revcomped | reference **and** fastq-agreement |
| `QUAL` not reversed | fastq-agreement only (quality is not compared to the reference) |
| `CIGAR` not reversed | reference only (fastq-agreement compares bases, not layout) |
| `/1`/`/2` not stripped | qname **and** fastq-agreement |

Different subsets, so no assertion is redundant. Mutations asserted applied, per the rule added in
#547.

## ⚠️ Breaking

**Golden BAM output changes for every paired run.** Reverse-strand records now carry
reference-oriented `SEQ`, reversed `QUAL`, reversed CIGAR ops, and suffix-free QNAMEs. Anything
using a standard SAM reader was previously getting wrong sequence for half its reads. v3.1.0 is
unreleased, so no released version is affected.

## Gate 2b itself

Four tests, **all running in CI** (no aligner needed): reference agreement on both strands,
FASTQ agreement, QNAME sharing, and a single-ended must-not-fire that establishes the comparison is
sound before any orientation logic applies. 38 suites green under `-D warnings`.

## Not verified

Only H1N1 at 5× paired and single-ended. Hard clips and refskips do not arise here. Adapter soft
clips on reverse reads now appear at the left end — correct, but untested beyond
`adapter_bam_cigar.rs` continuing to pass.

---

## Second commit: structural health at volume (`e6f00b4`)

Generates a golden BAM at **40× over all eight contigs**, asserts its statistics, and discards it
with the `TempDir`. Where Gate 2b checks the *content*, this checks the *file*.

Deliberately a volume run: the writer has a deferred coordinate-sorted path
(`stage_read_record` → `flush_up_to` → `flush_all`) that only engages once reads are buffered across
block boundaries, and Gate 2b's 5× run never reaches it.

| assertion | failure it catches |
|---|---|
| coordinate-sorted | the deferred sort emitting blocks out of order |
| mates point at each other | `RNEXT`/`PNEXT` from the wrong record |
| `TLEN` equal and opposite, leftmost positive | template length signed per-record not per-pair |
| exactly one R1 and one R2 per QNAME | a mate dropped or duplicated at a flush boundary |
| every record mapped and primary | an unmapped record is meaningless in a truth BAM |
| alignment inside its contig | off-by-one or overflow at a contig end |
| `@SQ` matches the reference | header built from something other than the reference |
| record count == FASTQ reads | reads lost between the two writers |
| MAPQ uniformly 60 | a record built by a path that does not assign it |

### It found one more thing — #554

**`TLEN` is the sampled fragment length, not the observed template length.** Over 2894 pairs:

| \|TLEN\| − observed span | pairs |
|---|---|
| 0 | 2098 |
| ±1 | 493 |
| ±2 | 34 |
| −4 | 1 |

The example: mate CIGAR `62M1D38M` → a 101 bp reference span for a 100 bp read, so the observed
span is 197 while `TLEN` says 196. SAM §1.4 field 9 requires the *observed* length.

Low severity — 1–2 bp against a 30 bp fragment SD affects nothing downstream — so it is **filed
(#554), not fixed here**. The assertion allows 10 bp of drift, documented in the test as a known
deviation rather than silently blessed: wide enough for indel offsets, far too narrow to admit
`TLEN` of zero, `TLEN` equal to a read length, or mates matched to the wrong partner, all off by
100+. The equal-and-opposite and sign rules remain exact.

One subtlety the test gets right and a careless version would not: the observed span must take the
**max end over both mates**, since an indel can make the earlier-starting read end later.

**39 suites green** under `-D warnings`. This commit depends on the QNAME fix in the first — pre-fix,
mates carried distinct QNAMEs, so "exactly two records per template" could not hold.