### PR TITLE
docs: refresh GitNexus index metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Hand-written guidance below; the GitNexus block that follows is auto-generated
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **eidolon** (2845 symbols, 7093 relationships, 241 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **eidolon** (3759 symbols, 9214 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,7 @@ contig lengths).
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **eidolon** (2845 symbols, 7093 relationships, 241 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **eidolon** (3759 symbols, 9214 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 


### PR DESCRIPTION
Refresh the generated GitNexus metadata in `AGENTS.md` and `CLAUDE.md` after reindexing the repository.

Updated counts: 3,759 symbols, 9,214 relationships, and 300 execution flows. No product code or tests are changed.

GitNexus change detection reports low risk and no affected execution flows.